### PR TITLE
Fixes JSON deserialization for "read[AnyRef](...)"

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -167,7 +167,7 @@ object Extraction {
 
   private def extract0[A](json: JValue, mf: Manifest[A])(implicit formats: Formats): A = {
     val mapping = 
-      if (mf.erasure == classOf[List[_]] || mf.erasure == classOf[Set[_]] || mf.erasure == classOf[Array[_]]) 
+      if (mf.erasure == classOf[List[_]] || mf.erasure == classOf[Set[_]] || mf.erasure.isArray)
         Col(mf.erasure, mappingOf(mf.typeArguments(0).erasure))
       else if (mf.erasure == classOf[Map[_, _]]) 
         Dict(mappingOf(mf.typeArguments(1).erasure))

--- a/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
@@ -24,7 +24,7 @@ import org.specs.Specification
  * System under specification for Extraction bugs.
  */
 object ExtractionBugs extends Specification("Extraction bugs Specification") {
-  implicit val formats = DefaultFormats
+  implicit val formats = DefaultFormats.withHints(FullTypeHints(classOf[ExtractWithAnyRef] :: Nil))
   
   "ClassCastException (BigInt) regression 2 must pass" in {
     val opt = OptionOfInt(Some(39))    
@@ -41,6 +41,12 @@ object ExtractionBugs extends Specification("Extraction bugs Specification") {
     args.size mustEqual 4
   }
 
+  "Extraction should handle AnyRef" in {
+    val extracted = Extraction.extract[AnyRef](JObject(JField("jsonClass", JString(classOf[ExtractWithAnyRef].getName)) :: Nil))
+
+    extracted mustEqual ExtractWithAnyRef()
+  }
+
   case class OptionOfInt(opt: Option[Int])
 
   case class PMap(m: Map[String, List[String]])
@@ -50,4 +56,6 @@ object ExtractionBugs extends Specification("Extraction bugs Specification") {
     def this(name: String) = this(0, name, "Doe", "")
     def this(name: String, email: String) = this(0, name, "Doe", email)
   }
+
+  case class ExtractWithAnyRef()
 }


### PR DESCRIPTION
In Scala, classOf[Array[_]] == classOf[AnyRef], which triggers a bug in the JSON extraction. Now uses Class.isArray() to check if an array is being deserialized.
