### PR TITLE
Fix for Issue #1083

### DIFF
--- a/liftsh.cmd
+++ b/liftsh.cmd
@@ -1,13 +1,13 @@
 @echo off
 
 @REM Internal options, always specified
-set INTERNAL_OPTS="-Dfile.encoding=UTF-8 -Xss8M -Xmx1G -noverify -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=512M"
+set INTERNAL_OPTS=-Dfile.encoding=UTF-8 -Xss8M -Xmx1G -noverify -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=512M
 
 @REM Default options, if nothing is specified
-set DEFAULT_OPTS="-Dsbt.intransitive=true"
+set DEFAULT_OPTS=-Dsbt.intransitive=true
 
 if "%LIFTSH_OPTS%"=="" (
-  set LIFTSH_OPTS=DEFAULT_OPTS
+  set LIFTSH_OPTS=%DEFAULT_OPTS%
 )
 
 @REM Call with INTERNAL_OPTS followed by LIFTSH_OPTS (or DEFAULT_OPTS). java aways takes the last option when duplicate.


### PR DESCRIPTION
Applies the patch provided in Issue [#1083](https://www.assembla.com/spaces/liftweb/tickets/1083-windows-illegalcharsetnameexception-using-liftsh) via github
