### PR TITLE
use dynamic "safe_#" instead of random long

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/Safe.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Safe.scala
@@ -17,30 +17,22 @@
 package net.liftweb
 package util
 
-import java.security.{SecureRandom, MessageDigest}
-import org.apache.commons.codec.binary.Base64
-
 /**
  * Manage the current "safety" state of the stack
  */
 object Safe {
-  private val rand = new SecureRandom
-  /**
-   * Get the next "safe" number
-   */
-  def next = rand.synchronized{rand.nextLong}
-  private val threadLocal = new ThreadGlobal[Long]
+  private val threadLocal = new ThreadGlobal[Int]
 
   /**
    * Is the current context "safe" for the object with the
    * given safety code?
    */
-  def safe_?(test : Long) : Boolean = test == threadLocal.value
+  def safe_?(test : Int) : Boolean = test == threadLocal.value
 
   /**
    * Marks access to a given object as safe for the duration of the function
    */
-  def runSafe[T](x : Long)(f : => T) : T = {
+  def runSafe[T](x : Int)(f : => T) : T = {
      threadLocal.doWith(x)(f)
   }
 

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/Mapper.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/Mapper.scala
@@ -37,7 +37,6 @@ trait Mapper[A<:Mapper[A]] extends BaseMapper {
   self: A =>
   type MapperType = A
 
-  private val secure_# = Safe.next
   private var was_deleted_? = false
   private var dbConnectionIdentifier: Box[ConnectionIdentifier] = Empty
   private[mapper] var addedPostCommit = false
@@ -45,7 +44,7 @@ trait Mapper[A<:Mapper[A]] extends BaseMapper {
 
   def getSingleton : MetaMapper[A];
   final def safe_? : Boolean = {
-    Safe.safe_?(secure_#)
+    Safe.safe_?(System.identityHashCode(this))
   }
 
   def dbName:String = getSingleton.dbName
@@ -53,7 +52,7 @@ trait Mapper[A<:Mapper[A]] extends BaseMapper {
   implicit def thisToMappee(in: Mapper[A]): A = this.asInstanceOf[A]
 
   def runSafe[T](f : => T) : T = {
-    Safe.runSafe(secure_#)(f)
+    Safe.runSafe(System.identityHashCode(this))(f)
   }
 
   def connectionIdentifier(id: ConnectionIdentifier): A = {

--- a/persistence/record/src/main/scala/net/liftweb/record/Record.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/Record.scala
@@ -31,11 +31,6 @@ trait Record[MyType <: Record[MyType]] extends FieldContainer {
   self: MyType =>
 
   /**
-   * A unique identifier for this record... used for access control
-   */
-  private val secure_# = Safe.next
-
-  /**
    * Get the fields defined on the meta object for this record instance
    */
   def fields() = meta.fields(this)
@@ -51,11 +46,11 @@ trait Record[MyType <: Record[MyType]] extends FieldContainer {
    * Is it safe to make changes to the record (or should we check access control?)
    */
   final def safe_? : Boolean = {
-    Safe.safe_?(secure_#)
+    Safe.safe_?(System.identityHashCode(this))
   }
 
   def runSafe[T](f : => T) : T = {
-    Safe.runSafe(secure_#)(f)
+    Safe.runSafe(System.identityHashCode(this))(f)
   }
 
   /**


### PR DESCRIPTION
Closes #1196

Remove instance field  which stored random long in Mapper and Record
in favor of pseudo unique System.identityHashCode at call time for
purpose of runSafe{} blocks
