### PR TITLE
Wrap db access in inTrasaction{} blocks.

### DIFF
--- a/persistence/squeryl-record/src/main/scala/net/liftweb/squerylrecord/CRUDify.scala
+++ b/persistence/squeryl-record/src/main/scala/net/liftweb/squerylrecord/CRUDify.scala
@@ -42,11 +42,15 @@ trait CRUDify[K, T <: Record[T] with KeyedEntity[K]] extends Crudify {
 
   override def computeFieldFromPointer(instance: TheCrudType, pointer: FieldPointerType): Box[FieldPointerType] = instance.fieldByName(pointer.name)
 
-  override def findForParam(in: String): Box[TheCrudType] = {
-    table.lookup(idFromString(in))
-  }
+  override def findForParam(in: String): Box[TheCrudType] =
+    inTransaction{
+	  table.lookup(idFromString(in))
+  	}
 
-  override def findForList(start: Long, count: Int) = from(table)(t => select(t)).page(start.toInt, count).toList
+  override def findForList(start: Long, count: Int) = 
+    inTransaction{
+	  from(table)(t => select(t)).page(start.toInt, count).toList
+  	}
 
   override def create = createRecord
 
@@ -58,10 +62,14 @@ trait CRUDify[K, T <: Record[T] with KeyedEntity[K]] extends Crudify {
 
     def save = {
       if (in.isPersisted) {
-        table.update(in)
+        inTransaction{
+        	table.update(in)
+        }
       }
       else {
-        table.insert(in)
+        inTransaction {
+        	table.insert(in)
+        }
       }
       true
     }


### PR DESCRIPTION
Ensures that a new transaction is started if one doesn't already exist.  In the case of rewrites the code seems to execute outside of S.addAround scope.  Addresses http://www.assembla.com/spaces/liftweb/tickets/1168.
