### PR TITLE
Levenshtein distance in net.liftweb.util.LD - exception if first parameter is empty.

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/LD.scala
+++ b/core/util/src/main/scala/net/liftweb/util/LD.scala
@@ -92,7 +92,7 @@ object LD {
       }
 
     matrix(y1, 0, (1 to x.length).toList) match {
-      case Nil => 10000
+      case Nil => 100000
       case xs => xs.last
     }
   }


### PR DESCRIPTION
[info] Starting scala interpreter...
[info] 
Welcome to Scala version 2.9.1.final (Java HotSpot(TM) 64-Bit Server VM, Java 1.6.0_26).

scala> import net.liftweb.util.LD
import net.liftweb.util.LD

scala> LD("aa", "bb")
res3: Int = 2

scala> LD("aa", "")
res4: Int = 2

scala> LD("", "bb")
java.util.NoSuchElementException
    at scala.collection.LinearSeqOptimized$class.last(LinearSeqOptimized.scala:135)
    at scala.collection.immutable.List.last(List.scala:45)
    at net.liftweb.util.LD$.apply(LD.scala:94)
    at .<init>(<console>:11)
    at .<clinit>(<console>)
    at .<init>(<console>:11)
    at .<clinit>(<console>)
    at $print(<console>)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.call(IMain.scala:704)
    at scala.tools.nsc.interpreter.IMain$Request.loadAndRun(IMain.scala:914)
    at scala.tools.nsc.interpreter.IMain.loadAndRunReq$1(IMain.scala:546)
    at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:577)
    at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:543)
    at scala.tools.nsc.interpreter.ILoop.reallyInterpret$1(ILoop.scala:694)
    at scala.tools.nsc.interpreter.ILoop.interpretStartingWith(ILoop.scala:745)
    at scala.tools.nsc.interpreter.ILoop.command(ILoop.scala:651)
    at scala.tools.nsc.interpreter.ILoop.processLine$1(ILoop.scala:542)
    at scala.tools.nsc.interpreter.ILoop.loop(ILoop.scala:550)
    at scala.tools.nsc.interpreter.ILoop.process(ILoop.scala:822)
    at scala.tools.nsc.interpreter.ILoop.main(ILoop.scala:851)
    at xsbt.ConsoleInterface.run(ConsoleInterface.scala:57)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at sbt.compiler.AnalyzingCompiler.call(AnalyzingCompiler.scala:57)
    at sbt.compiler.AnalyzingCompiler.console(AnalyzingCompiler.scala:48)
    at sbt.Console.console0$1(Console.scala:23)
    at sbt.Console$$anonfun$apply$2$$anonfun$apply$1.apply$mcV$sp(Console.scala:24)
    at sbt.TrapExit$.executeMain$1(TrapExit.scala:33)
    at sbt.TrapExit$$anon$1.run(TrapExit.scala:42)
