### PR TITLE
Transaction S.addAround is broken in some cases

### DIFF
--- a/persistence/db/src/main/scala/net/liftweb/db/DB.scala
+++ b/persistence/db/src/main/scala/net/liftweb/db/DB.scala
@@ -21,6 +21,8 @@ import common._
 import util._
 import Helpers._
 
+import net.liftweb.http.S
+
 import javax.sql.{DataSource}
 import java.sql.ResultSetMetaData
 import java.sql.{Statement, ResultSet, Types, PreparedStatement, Connection, DriverManager}
@@ -240,13 +242,13 @@ trait DB extends Loggable {
               try {
                 try {
                   val ret = f
-                  success = true
+                  success = !S.exceptionThrown_?
                   ret
                 } catch {
                   // this is the case when we want to commit the transaction
                   // but continue to throw the exception
                   case e: LiftFlowOfControlException => {
-                    success = true
+                    success = !S.exceptionThrown_?
                     throw e
                   }
                 }
@@ -263,13 +265,13 @@ trait DB extends Loggable {
             try {
               try {
                 val ret = f
-                success = true
+                success = !S.exceptionThrown_?
                 ret
               } catch {
                 // this is the case when we want to commit the transaction
                 // but continue to throw the exception
                 case e: LiftFlowOfControlException => {
-                  success = true
+                  success = !S.exceptionThrown_?
                   throw e
                 }
               }
@@ -676,13 +678,13 @@ trait DB extends Loggable {
       var rollback = true
       try {
         val ret = f(conn)
-        rollback = false
+        rollback = S.exceptionThrown_?
         ret
       } catch {
         // this is the case when we want to commit the transaction
         // but continue to throw the exception
         case e: LiftFlowOfControlException => {
-          rollback = false
+          rollback = S.exceptionThrown_?
           throw e
         }
       } finally {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -109,7 +109,7 @@ object BuildDef extends Build {
 
   lazy val db =
     persistenceProject("db")
-        .dependsOn(util)
+        .dependsOn(util, webkit)
         .settings(libraryDependencies += mockito_all)
 
   lazy val proto =

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1299,7 +1299,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * a default implementation is already appended.
    *
    */
-  @volatile var exceptionHandler = RulesSeq[ExceptionHandlerPF].append {
+  val exceptionHandler = RulesSeq[ExceptionHandlerPF].append {
     case (Props.RunModes.Development, r, e) =>
       logger.error("Exception being returned to browser when processing " + r.uri.toString + ": " + showException(e))
       XhtmlResponse((<html> <body>Exception occured while processing {r.uri}<pre>{showException(e)}</pre> </body> </html>), S.htmlProperties.docType, List("Content-Type" -> "text/html; charset=utf-8"), Nil, 500, S.ieMode)

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -1145,7 +1145,7 @@ class LiftSession(private[http] val _contextPath: String, val uniqueId: String,
 
       case e: LiftFlowOfControlException => throw e
 
-      case e => NamedPF.applyBox((Props.mode, request, e), LiftRules.exceptionHandler.toList);
+      case e => S.assertExceptionThrown() ; NamedPF.applyBox((Props.mode, request, e), LiftRules.exceptionHandler.toList);
 
     }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -338,6 +338,8 @@ trait S extends HasParams with Loggable {
   private val _oneShot = new ThreadGlobal[Boolean]
   private val _disableTestFuncNames = new ThreadGlobal[Boolean]
 
+  private object _exceptionThrown extends TransientRequestVar(false)
+
   private object postFuncs extends TransientRequestVar(new ListBuffer[() => Unit])
 
   /**
@@ -385,6 +387,18 @@ trait S extends HasParams with Loggable {
   private[http] object CurrentLocation extends RequestVar[Box[sitemap.Loc[_]]](request.flatMap(_.location))
 
   def location: Box[sitemap.Loc[_]] = CurrentLocation.is
+
+
+  /**
+   * An exception was thrown during the processing of this request.
+   * This is tested to see if the transaction should be rolled back
+   */
+  def assertExceptionThrown() {_exceptionThrown.set(true)}
+
+  /**
+   * Was an exception thrown during the processing of the current request?
+   */
+  def exceptionThrown_? : Boolean = _exceptionThrown.get
 
   /**
    * @return a List of any Cookies that have been set for this Response. If you want


### PR DESCRIPTION
Stateful REST support for transactions via S.addAround was broken (the exception was swallowed).

Pulling on the thread leads to failures in LiftRules.allAround as well.

See https://github.com/dpp/Lift-Mapper-Transaction-Test
