### PR TITLE
MetaLDAPProtoUser add field focus on username and password

### DIFF
--- a/persistence/ldap/src/main/scala/net/liftweb/ldap/LDAPProtoUser.scala
+++ b/persistence/ldap/src/main/scala/net/liftweb/ldap/LDAPProtoUser.scala
@@ -114,7 +114,7 @@ trait MetaLDAPProtoUser[ModelType <: LDAPProtoUser[ModelType]] extends MetaMegaP
 
         Helpers.bind("user", loginXhtml,
                     "name" -> (JsCmds.FocusOnLoad(<input type="text" name="username"/>)),
-                    "password" -> (JsCmds.FocusOnLoad(<input type="password" name="password"/>)),
+                    "password" -> (<input type="password" name="password"/>),
                     "submit" -> (<input type="submit" value={S.??("log.in")}/>))
     }
 


### PR DESCRIPTION
The LDAPProtoUser.scala file has a method 

override def login

which binds the user, password fields and submit button.
It has a problem because it adds a JsCmds.FocusOnLoad to both, the username and password fields. This results in having the cursor focus on the password, instead of the username.

Simple fix:

```
    Helpers.bind("user", loginXhtml,
                "name" -> (JsCmds.FocusOnLoad(<input type="text" name="username"/>)),
```
- ```
                "password" -> (JsCmds.FocusOnLoad(<input type="password" name="password"/>)),
              "submit" -> (<input type="submit" value={S.??("log.in")}/>))
  
  
  Helpers.bind("user", loginXhtml,
              "name" -> (JsCmds.FocusOnLoad(<input type="text" name="username"/>)),
  ```
-                   "password" -> (<input type="password" name="password"/>),
                  "submit" -> (<input type="submit" value={S.??("log.in")}/>))
