### PR TITLE
Deprecate net.liftweb.builtin.snippet.A

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/A.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/A.scala
@@ -23,12 +23,24 @@ import net.liftweb.http._
 import net.liftweb.http.js._
 import net.liftweb.util._
 
+@deprecated("Use any of the ajax methods in SHtml instead.")
 object A extends DispatchSnippet {
 
   def dispatch : DispatchIt = {
     case _ => render _
   }
 
+  /**
+   * Usage:
+   *
+   *   <pre name="code" class="xml"
+   *   def a(func: () => JsCmd, body: NodeSeq, attrs: ElemAttr*): Elem = {
+   *     val key = formFuncName
+   *     addFunctionMap(key, ((a: List[String]) => func()))
+   *     attrs.foldLeft(&lt;lift:a key={key}>{body}&lt;/lift:a>)(_ % _)
+   *   }
+   *   </pre>
+   */
   def render(kids: NodeSeq) : NodeSeq = Elem(null, "a", addAjaxHREF(), TopScope, kids :_*)
 
   private def addAjaxHREF(): MetaData = {

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1685,7 +1685,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
       Map("CSS" -> CSS, "Msgs" -> Msgs, "Msg" -> Msg,
         "Menu" -> Menu, "css" -> CSS, "msgs" -> Msgs, "msg" -> Msg,
         "menu" -> Menu,
-        "a" -> A, "children" -> Children,
+        "children" -> Children,
         "comet" -> Comet, "form" -> Form, "ignore" -> Ignore, "loc" -> Loc,
         "surround" -> Surround,
         "test_cond" -> TestCond,

--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -523,9 +523,8 @@ trait SHtml {
    * @param attrs - the anchor node attributes
    */
   def a(func: () => JsCmd, body: NodeSeq, attrs: ElemAttr*): Elem = {
-    val key = formFuncName
-    addFunctionMap(key, ((a: List[String]) => func()))
-    attrs.foldLeft(<lift:a key={key}>{body}</lift:a>)(_ % _)
+    attrs.foldLeft(fmapFunc((func))(name =>
+      <a href="javascript://" onclick={makeAjaxCall(Str(name + "=true")).toJsCmd + "; return false;"}>{body}</a>))(_ % _)
   }
 
   /**


### PR DESCRIPTION
As discussed here https://groups.google.com/d/topic/liftweb/cM8gXrHK3f0/discussion
- Deprecate builtin.snippet.A
  *\* (As Jeppe suggested: "remove the definition from
  LiftRules.snippetDispatch and deprecate the class)
- Replace any internal use of it for S.fmapFunc
