### PR TITLE
Make ajaxEditable display a configurable ...loading... message instead o...

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -472,7 +472,7 @@ trait SHtml {
    *              () => { println("submitted"); Noop })
    * </pre>
    */
-  def myAjaxEditable (displayContents : => NodeSeq, editForm : => NodeSeq, onSubmit : () => JsCmd, 
+  def ajaxEditable (displayContents : => NodeSeq, editForm : => NodeSeq, onSubmit : () => JsCmd, 
                       loadingContents: => NodeSeq = Text("...loading...")) : NodeSeq = {
     import net.liftweb.http.js
     import js.{jquery,JsCmd,JsCmds,JE}


### PR DESCRIPTION
...f soon-to-be-replaced content and forms.

ajaxEditable is currently estranging users with wacky connections: They see a form, can start editing, only to see their work vanish and the form apparently resetting when the setAndSwap command comes through the slow connection.

I found references #259 to touch this and wondered if I was talking about the same issue?

Cheers Lift!
