### PR TITLE
Add Req.ajax_? function to identify ajax requests.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/Req.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Req.scala
@@ -855,7 +855,7 @@ class Req(val path: ParsePath,
   def ajax_? =
     request.headers.toList.exists { header =>
       (header.name equalsIgnoreCase "x-requested-with") &&
-      (header.value equalsIgnoreCase "xmlhttprequest")
+      (header.values.exists(_ equalsIgnoreCase "xmlhttprequest"))
     }
 
   /**


### PR DESCRIPTION
Ajax requests are identified by looking for the X-Requested-With header to be set to “XMLHttpRequest”. This can be used for the purposes of, for example, deciding whether to render a layout based on the nature of the incoming request.
