### PR TITLE
Early access to S.location breaks snippet resolution

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -386,7 +386,10 @@ trait S extends HasParams with Loggable {
 
   private[http] object CurrentLocation extends RequestVar[Box[sitemap.Loc[_]]](request.flatMap(_.location))
 
-  def location: Box[sitemap.Loc[_]] = CurrentLocation.is
+  def location: Box[sitemap.Loc[_]] = CurrentLocation.is or {
+    //try again in case CurrentLocation was accessed before the request was available
+    request flatMap { r => CurrentLocation(r.location) }
+  }
 
 
   /**


### PR DESCRIPTION
S.location is stored in a RequestVar and will resolve to Empty if it is accessed before the lift request is initialized.  The best solution seems to be to repeatedly attempt resolution when the RequestVar is Empty

https://groups.google.com/d/topic/liftweb/1mEpk4UtDZM/discussion
