### PR TITLE
Squeryl-Record integration should be Record "dirty_?" field aware

### DIFF
--- a/persistence/squeryl-record/src/main/scala/net/liftweb/squerylrecord/RecordMetaDataFactory.scala
+++ b/persistence/squeryl-record/src/main/scala/net/liftweb/squerylrecord/RecordMetaDataFactory.scala
@@ -141,15 +141,30 @@ class RecordMetaDataFactory extends FieldMetaDataFactory {
         fieldScale getOrElse super.scale
       }
 
-      private def fieldFor(o: AnyRef) = getter.get.invoke(o).asInstanceOf[TypedField[_ <: AnyRef]]
+      private def fieldFor(o: AnyRef) = getter.get.invoke(o) match {
+        case tf: TypedField[_] => tf
+        case other => org.squeryl.internals.Utils.throwError("Field's used with Squeryl must inherit from net.liftweb.record.TypedField : " + other )
+      }
 
-      override def set(target: AnyRef, value: AnyRef) = {
-        val typedField: TypedField[_] = fieldFor(target)
-        typedField.setFromAny(Box !! value)
+      /**
+       * Sets the value which was retrieved from the DB into the appropriate Record field
+       */
+      override def set(target: AnyRef, value: AnyRef) = target match {
+          case record: Record[_] =>
+            record.runSafe {
+            	val typedField: TypedField[_] = fieldFor(target)
+            	typedField.setFromAny(Box !! value)
+            	typedField.resetDirty
+            }
+          case other =>
+            org.squeryl.internals.Utils.throwError("RecordMetaDataFactory can not set fields on non Record objects : " + other)
       }
 
       override def setFromResultSet(target: AnyRef, rs: ResultSet, index: Int) = set(target, resultSetHandler(rs, index))
 
+      /**
+       * Extracts the value from the field referenced by o that will be stored in the DB
+       */
       override def get(o: AnyRef) = fieldFor(o) match {
         case enumField: EnumTypedField[_] => enumField.valueBox match {
           case Full(enum: Enumeration#Value) => enum.id: java.lang.Integer
@@ -161,7 +176,7 @@ class RecordMetaDataFactory extends FieldMetaDataFactory {
         }
         case other => other.valueBox match {
           case Full(c: Calendar) => new Timestamp(c.getTime.getTime)
-          case Full(other) => other
+          case Full(other: AnyRef) => other
           case _ => null
         }
       }

--- a/persistence/squeryl-record/src/test/scala/net/liftweb/squerylrecord/SquerylRecordSpec.scala
+++ b/persistence/squeryl-record/src/test/scala/net/liftweb/squerylrecord/SquerylRecordSpec.scala
@@ -352,6 +352,12 @@ object SquerylRecordSpec extends Specification("SquerylRecord Specification") {
       val columnDefinition = new PostgreSqlAdapter().writeColumnDeclaration(fieldMetaData, false, MySchema)
       columnDefinition.endsWith("numeric(" + Company.employeeSatisfaction.context.getPrecision() +"," + Company.employeeSatisfaction.scale + ")") must_== true
     }
+    
+    forExample("Properly reset the dirty_? flag after loading entities") >> inTransaction {
+      val company = from(companies)(company =>
+        select(company)).page(0, 1).single
+      company.allFields map { f => f.dirty_? must_== false }
+    }
 
   }
 


### PR DESCRIPTION
Many persistence frameworks (including Lift's Mapper, Lift's Mongodb-Record, ActiveRecord) track which fields have changed their values over record's lifetime since it was populated with data. This allows to reduce overhead when updating rows in database.
This also means that first value assignment should not set the "dirty_?" flag to true (so setFromAny shouldn't be called when the record is being populated for the first time ? or just use Empty value as blank one ?)
This also leaves a question what should be the policy of populating Optional*Fields from Record framework, since there's no information if a field was assigned before (not the case with non optional fields where Empty could mean that first assignment takes place)

As a note: Lift's Mapper fields also keep orgData (original data to track the changes, "protected def i_was_! = orgData")
