### PR TITLE
Record's BooleanField has broken tabindex

### DIFF
--- a/persistence/record/src/main/scala/net/liftweb/record/field/BooleanField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/BooleanField.scala
@@ -40,7 +40,7 @@ trait BooleanTypedField extends TypedField[Boolean] {
   def setFromString(s: String): Box[Boolean] = setBox(tryo(toBoolean(s)))
 
   private def elem(attrs: SHtml.ElemAttr*) =
-      SHtml.checkbox(valueBox openOr false, (b: Boolean) => this.setBox(Full(b)), (("tabIndex" -> tabIndex.toString): SHtml.ElemAttr) :: attrs.toList: _*)
+      SHtml.checkbox(valueBox openOr false, (b: Boolean) => this.setBox(Full(b)), (("tabindex" -> tabIndex.toString): SHtml.ElemAttr) :: attrs.toList: _*)
 
   def toForm: Box[NodeSeq] =
     // FIXME? no support for optional_?

--- a/persistence/record/src/test/scala/net/liftweb/record/FieldSpec.scala
+++ b/persistence/record/src/test/scala/net/liftweb/record/FieldSpec.scala
@@ -189,7 +189,6 @@ object FieldSpec extends Specification("Record Field Specification") {
               case _ => false
             }) andThen "* [value]" #> ".*"))(fprime)
             val ret: Boolean = Helpers.compareXml(f, fp)
-
             ret must_== true
           }
         }
@@ -217,7 +216,7 @@ object FieldSpec extends Specification("Record Field Specification") {
       rec.mandatoryBooleanField,
       JsTrue,
       JBool(bool),
-      Full(<input checked="checked" tabIndex="1" value="true" type="checkbox" name=".*" id="mandatoryBooleanField_id"></input><input value="false" type="hidden" name=".*"></input>)
+      Full(<input checked="checked" tabindex="1" value="true" type="checkbox" name=".*" id="mandatoryBooleanField_id"></input><input value="false" type="hidden" name=".*"></input>)
     )
     "support java.lang.Boolean" in {
       rec.mandatoryBooleanField.setFromAny(java.lang.Boolean.TRUE)


### PR DESCRIPTION
Reference discussion:
https://groups.google.com/forum/?fromgroups#!topic/liftweb/zaf3RUtAIWs

net.liftweb.record.field.BooleanField renders tabindex as tabIndex (camel case) - should be lowercase according to XHTML specification. 
