### PR TITLE
Add configurable ObjectId tester in JObjectParser

### DIFF
--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoRecordSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoRecordSpec.scala
@@ -658,17 +658,34 @@ object MongoRecordSpec extends Specification("MongoRecord Specification") with M
         .optionalStringField("optional string")
         .save
 
-      fttr.mandatoryBooleanField(false)
-      fttr.mandatoryDecimalField(BigDecimal("3.14"))
-      fttr.mandatoryDoubleField(1999)
-      fttr.mandatoryEnumField(MyTestEnum.ONE)
-      fttr.mandatoryIntField(99)
-      fttr.mandatoryLongField(100L)
-      fttr.mandatoryStringField("string")
-      fttr.optionalStringField(Empty)
-      fttr.legacyOptionalStringField(Empty)
+      fttr.mandatoryBooleanField(true)
+      fttr.mandatoryBooleanField.dirty_? must_== true
 
-      fttr.dirtyFields.length must_== 9
+      fttr.mandatoryDecimalField(BigDecimal("3.14"))
+      fttr.mandatoryDecimalField.dirty_? must_== true
+
+      fttr.mandatoryDoubleField(1999)
+      fttr.mandatoryDoubleField.dirty_? must_== true
+
+      fttr.mandatoryEnumField(MyTestEnum.TWO)
+      fttr.mandatoryEnumField.dirty_? must_== true
+
+      fttr.mandatoryIntField(99)
+      fttr.mandatoryIntField.dirty_? must_== true
+
+      fttr.mandatoryLongField(100L)
+      fttr.mandatoryLongField.dirty_? must_== true
+
+      fttr.mandatoryStringField("string")
+      fttr.mandatoryStringField.dirty_? must_== true
+
+      fttr.optionalStringField(Empty)
+      fttr.optionalStringField.dirty_? must_== true
+
+      fttr.legacyOptionalStringField(Empty)
+      fttr.legacyOptionalStringField.dirty_? must_== true
+
+      fttr.dirtyFields.length must_== 7
       fttr.update
       fttr.dirtyFields.length must_== 0
 
@@ -682,7 +699,10 @@ object MongoRecordSpec extends Specification("MongoRecord Specification") with M
       val fttr2 = FieldTypeTestRecord.createRecord.save
 
       fttr2.legacyOptionalStringField("legacy optional string")
+      fttr2.legacyOptionalStringField.dirty_? must_== true
+
       fttr2.optionalStringField("optional string")
+      fttr2.optionalStringField.dirty_? must_== true
 
       fttr2.dirtyFields.length must_== 2
       fttr2.update
@@ -704,13 +724,28 @@ object MongoRecordSpec extends Specification("MongoRecord Specification") with M
         .legacyOptionalObjectIdField(ObjectId.get)
         .save
 
+      Thread.sleep(100) // sleep so dates will be different
+
       mfttr.mandatoryDateField(new Date)
+      mfttr.mandatoryDateField.dirty_? must_== true
+
       mfttr.mandatoryJsonObjectField(TypeTestJsonObject(1, "jsonobj1", Map("x" -> "1")))
+      mfttr.mandatoryJsonObjectField.dirty_? must_== true
+
       mfttr.mandatoryObjectIdField(ObjectId.get)
+      mfttr.mandatoryObjectIdField.dirty_? must_== true
+
       mfttr.mandatoryPatternField(Pattern.compile("^Mon", Pattern.CASE_INSENSITIVE))
+      mfttr.mandatoryPatternField.dirty_? must_== true
+
       mfttr.mandatoryUUIDField(UUID.randomUUID)
+      mfttr.mandatoryUUIDField.dirty_? must_== true
+
       mfttr.legacyOptionalDateField(Empty)
+      mfttr.legacyOptionalDateField.dirty_? must_== true
+
       mfttr.legacyOptionalObjectIdField(Empty)
+      mfttr.legacyOptionalObjectIdField.dirty_? must_== true
 
       mfttr.dirtyFields.length must_== 7
       mfttr.update
@@ -726,7 +761,10 @@ object MongoRecordSpec extends Specification("MongoRecord Specification") with M
       val mfttr2 = MongoFieldTypeTestRecord.createRecord.save
 
       mfttr2.legacyOptionalDateField(new Date)
+      mfttr2.legacyOptionalDateField.dirty_? must_== true
+
       mfttr2.legacyOptionalObjectIdField(ObjectId.get)
+      mfttr2.legacyOptionalObjectIdField.dirty_? must_== true
 
       mfttr2.dirtyFields.length must_== 2
       mfttr2.update
@@ -746,9 +784,16 @@ object MongoRecordSpec extends Specification("MongoRecord Specification") with M
       val ltr = ListTestRecord.createRecord.save
 
       ltr.mandatoryStringListField(List("abc", "def", "ghi"))
+      ltr.mandatoryStringListField.dirty_? must_== true
+
       ltr.mandatoryIntListField(List(4, 5, 6))
+      ltr.mandatoryIntListField.dirty_? must_== true
+
       ltr.mandatoryMongoJsonObjectListField(List(TypeTestJsonObject(1, "jsonobj1", Map("x" -> "1")), TypeTestJsonObject(2, "jsonobj2", Map("x" -> "2"))))
+      ltr.mandatoryMongoJsonObjectListField.dirty_? must_== true
+
       ltr.mongoCaseClassListField(List(MongoCaseClassTestObject(1,"str")))
+      ltr.mongoCaseClassListField.dirty_? must_== true
 
       ltr.dirtyFields.length must_== 4
       ltr.update
@@ -768,7 +813,10 @@ object MongoRecordSpec extends Specification("MongoRecord Specification") with M
       val mtr = MapTestRecord.save
 
       mtr.mandatoryStringMapField(Map("a" -> "abc", "b" -> "def", "c" -> "ghi"))
+      mtr.mandatoryStringMapField.dirty_? must_== true
+
       mtr.mandatoryIntMapField(Map("a" -> 4, "b" -> 5, "c" -> 6))
+      mtr.mandatoryIntMapField.dirty_? must_== true
 
       mtr.dirtyFields.length must_== 2
       mtr.update
@@ -801,7 +849,10 @@ object MongoRecordSpec extends Specification("MongoRecord Specification") with M
       val sr2 = SubRecord.createRecord.name("SubRecord2")
 
       srtr.mandatoryBsonRecordField(sr1)
+      srtr.mandatoryBsonRecordField.dirty_? must_== true
+
       srtr.mandatoryBsonRecordListField(List(sr1,sr2))
+      srtr.mandatoryBsonRecordListField.dirty_? must_== true
 
       srtr.dirtyFields.length must_== 2
       srtr.update

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JObjectParser.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JObjectParser.scala
@@ -24,11 +24,22 @@ import java.util.regex.Pattern
 
 import net.liftweb.json._
 import net.liftweb.common.Box
+import net.liftweb.util.SimpleInjector
 
 import com.mongodb.{BasicDBObject, BasicDBList, DBObject}
 import org.bson.types.ObjectId
 
-object JObjectParser {
+object JObjectParser extends SimpleInjector {
+  /**
+    * Set this to override JObjectParser turning strings that are valid
+    * ObjectIds into actual ObjectIds. For example, place the following in Boot.boot:
+    *
+    * <code>JObjectParser.stringProcessor.default.set((s: String) => s)</code>
+    */
+  val stringProcessor = new Inject(() => (s: String) => {
+    if (ObjectId.isValid(s)) new ObjectId(s)
+    else s
+  }) {}
 
   /*
   * Parse a JObject into a DBObject
@@ -113,8 +124,7 @@ object JObjectParser {
       case JNull => null
       case JNothing => error("can't render 'nothing'")
       case JString(null) => "null"
-      case JString(s) if (ObjectId.isValid(s)) => new ObjectId(s)
-      case JString(s) => s
+      case JString(s) => stringProcessor.vend(s)
       case _ =>  ""
     }
 

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/JObjectParserSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/JObjectParserSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+
+import json._
+import JsonDSL._
+import util.Helpers._
+
+import org.bson.types.ObjectId
+import org.specs.Specification
+
+import com.mongodb.DBObject
+
+object JObjectParserSpec extends Specification("JObjectParser Specification") {
+
+  def buildTestData: (ObjectId, DBObject) = {
+    val oid = ObjectId.get
+    val dbo = JObjectParser.parse(("x" -> oid.toString))(DefaultFormats)
+    (oid, dbo)
+  }
+
+  "JObjectParser" should {
+    "convert strings to ObjectId by default" in {
+      val (oid, dbo) = buildTestData
+      val xval = tryo(dbo.get("x").asInstanceOf[ObjectId])
+
+      xval must notBeEmpty
+      xval.foreach { x =>
+        x must_== oid
+      }
+    }
+    "not convert strings to ObjectId when configured not to" in {
+      JObjectParser.stringProcessor.default.set((s: String) => s)
+
+      val (oid, dbo) = buildTestData
+      val xval = tryo(dbo.get("x").asInstanceOf[String])
+
+      xval must notBeEmpty
+      xval.foreach { x =>
+        x must_== oid.toString
+      }
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -147,7 +147,7 @@ object BuildDef extends Build {
 
   lazy val mongodb =
     persistenceProject("mongodb")
-        .dependsOn(json_ext)
+        .dependsOn(json_ext, util)
         .settings(parallelExecution in Test := false,
                   libraryDependencies += mongo_driver,
                   initialize in Test <<= (resourceDirectory in Test) { rd =>


### PR DESCRIPTION
https://groups.google.com/d/topic/liftweb/fXDixRS1H4M/discussion

Currently, all Strings are tested to see if they are valid ObjectIds. This can cause problems if that's not what's needed. Allow configuration via a FactoryMaker.

```
object MongoDB extends Factory {

  val jobjectParserObjectIdTester = new FactoryMaker[String => Boolean](s => ObjectId.isValid(s)) {}

}
```
