### PR TITLE
PasswordField fails to change the current password and it throws validation errors when no password was changed

### DIFF
--- a/persistence/record/src/test/scala/net/liftweb/record/FieldSpec.scala
+++ b/persistence/record/src/test/scala/net/liftweb/record/FieldSpec.scala
@@ -408,11 +408,13 @@ object FieldSpec extends Specification("Record Field Specification") {
       )
     }
 
-    "validate the unencrypted value" in {
+    "correctly validate the unencrypted value" in {
       val rec = PasswordTestRecord.createRecord.password("testvalue")
-
+      rec.validate must_== Nil
+      
+      rec.password("1234")
       rec.validate must_== (
-        FieldError(rec.password, Text("no way!")) ::
+        FieldError(rec.password, Text(S.??("password.too.short"))) ::
         Nil
       )
     }


### PR DESCRIPTION
Torstens message:

when I want to change the current password, I see that the apply() method is called and I see the "Password changed" message, but the password is still the old one.

Then, when I try to change the user data (that do not contain the password), I get the error message with that key: "password.must.be.set"
That's not a problem of apply() I think. Rather I would guess that the password field does not validate if it had not been filled with a new password.
And since changing the user data validates the user object and thus also the password field, that problem appears…

---

setFromAny() is completely wrong, I forgot to rewrite it when doing the change.

group discussion: https://groups.google.com/forum/?fromgroups#!topic/liftweb/OErzpfpyBjk

some of these issues probably cause this problem as well, though set_! shoud stay as is, as far as I'm aware of, so proposed solution should not work: https://github.com/lift/framework/issues/1256
