### PR TITLE
Please add an additional SHtml.number method to support floating point number.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -1373,6 +1373,49 @@ trait SHtml {
     ("max" -> max.toString)
   }
 
+
+  /**
+   * Generate an input field with type number. It allows for Double if your step is
+   * for example: 0.1
+   * At some point,
+   * there will be graceful fallback for non-HTML5 browsers.  FIXME
+   */
+  def number(value: Double, func: Double => Any,
+             min: Double, max: Double,  step: Double ,
+             attrs: ElemAttr*): Elem =
+    number_double_*(value,
+      min, max, step,
+      SFuncHolder(s => Helpers.asDouble(s).map(func)), attrs: _*)
+
+  /**
+   * Generate a number input element for the Settable. It allows for Double if your step is
+   * for example: 0.1
+   * At some point
+   * there will be graceful fallback for non-HTML5 browsers. FIXME
+   */
+  def number(settable: Settable{type ValueType = Double},
+             min: Double, max: Double, step: Double,
+             attrs: ElemAttr*): Elem =
+    number_double_*(settable.get, min, max, step: Double,
+      SFuncHolder(s => Helpers.asDouble(s).map(s => settable.set(s))),
+      attrs: _*)
+
+  private def number_double_*(value: Double,
+                       min: Double, max: Double, step: Double,
+                       func: AFuncHolder, attrs: ElemAttr*): Elem = {
+    import Helpers._
+    import common.Full
+
+
+    makeFormElement("number",
+                    func,
+                    attrs: _*) %
+    ("value" -> value.toString) %
+    ("min" -> min.toString) %
+    ("min" -> min.toString) %
+    ("step" -> step.toString)
+  }
+
   /**
    * Generate an input field with type range.  At some point,
    * there will be graceful fallback for non-HTML5 browsers.  FIXME

--- a/web/webkit/src/test/scala/net/liftweb/http/SHtmlSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/SHtmlSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2012 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package http
+
+import org.specs.Specification
+import util._
+import Helpers._
+import net.liftweb.mockweb.MockWeb._
+
+object SHtmlSpec extends Specification("NamedCometPerTabSpec Specification") {
+
+  val html1= <span><input id="number"></input></span>
+  val inputField1= testS("/")( ("#number" #> SHtml.number(0, println(_), 0, 100))(html1)  )
+  val inputField2= testS("/")( ("#number" #> SHtml.number(0, println(_), 0, 100, 0.1))(html1)  )
+  val inputField3= testS("/")( ("#number" #> SHtml.number(0, println(_), 0, 100, 1))(html1)  )
+
+  "SHtml" should {
+    "create a number input field" in {
+      inputField1 must \("input", "type" -> "number")
+    }
+    "create a number input field with min='0'" in {
+      inputField1 must \("input", "min" -> "0")
+    }
+    "create a number input field with max='100'" in {
+      inputField1 must \("input", "max" -> "100")
+    }
+    "create a number input field with step='0.1'" in {
+      inputField2 must \("input", "step" -> "0.1")
+    }
+    "create a number input field with step='1.0'" in {
+      inputField3 must \("input", "step" -> "1.0")
+    }
+
+  }
+}


### PR DESCRIPTION
From the method signature, it does not look like SHtml.number method 
supports floating point number. But Html5 input type "number" does 
support floating point numbers when you set the "step" attribute (of 
input) to a floating point (for example 0.1).

Please add an additional SHtml.number method to support floating point number.
