### PR TITLE
Unify resource lookup using S.?? and S:.?

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -580,7 +580,6 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
     }
 
     // We need to determine the full set of IDs that need messages rendered.
-    // TODO: Change to use "distinct" when 2.7.7 support is dropped
     val idSet = (S.idMessages((S.errors)) ++
                  S.idMessages((S.warnings)) ++
                  S.idMessages((S.notices))).map(_._1).distinct

--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -925,11 +925,13 @@ trait S extends HasParams with Loggable {
   /**
    * Get a List of the resource bundles for the current locale. The resource bundles are defined by
    * the LiftRules.resourceNames and LiftRules.resourceBundleFactories variables.
+   * If you do not define an entry for a particular key, we fall back to using
+   * Lift's core entries.
    *
    * @see LiftRules.resourceNames
    * @see LiftRules.resourceBundleFactories
    */
-  def resourceBundles: List[ResourceBundle] = resourceBundles(locale)
+  def resourceBundles: List[ResourceBundle] = resourceBundles(locale) ++ liftCoreResourceBundle.toList
 
   def resourceBundles(loc: Locale): List[ResourceBundle] = {
     _resBundle.box match {
@@ -972,6 +974,8 @@ trait S extends HasParams with Loggable {
 
   /**
    * Get a localized string or return the original string.
+   * We first try your own bundle resources, if that fails, we try
+   * Lift's core bundle.
    *
    * @param str the string to localize
    *
@@ -983,6 +987,8 @@ trait S extends HasParams with Loggable {
 
   /**
    * Get a localized string or return the original string.
+   * We first try your own bundle resources, if that fails, we try
+   * Lift's core bundle.
    *
    * @param str the string to localize
    *
@@ -996,6 +1002,8 @@ trait S extends HasParams with Loggable {
   /**
    * Attempt to localize and then format the given string. This uses the String.format method
    * to format the localized string.
+   * We first try your own bundle resources, if that fails, we try
+   * Lift's core bundle.
    *
    * @param str the string to localize
    * @param params the var-arg parameters applied for string formatting
@@ -1018,7 +1026,8 @@ trait S extends HasParams with Loggable {
    *
    * @return the localized version of the string
    */
-  def ??(str: String): String = ?!(str, liftCoreResourceBundle.toList)
+  @deprecated("Use S.?() instead. S.?? will be removed in 2.6")
+  def ??(str: String): String = ?(str)
 
   /**
    * Get a core lift localized and formatted string or return the original string.
@@ -1028,7 +1037,8 @@ trait S extends HasParams with Loggable {
    *
    * @return the localized version of the string
    */
-  def ??(str: String, params: AnyRef*): String = String.format(locale, ??(str), params: _*)
+  @deprecated("Use S.?() instead. S.?? will be removed in 2.6")
+  def ??(str: String, params: AnyRef*): String = String.format(locale, ?(str), params: _*)
 
   private def ?!(str: String, resBundle: List[ResourceBundle]): String = resBundle.flatMap(r => tryo(r.getObject(str) match {
     case s: String => Full(s)


### PR DESCRIPTION
Deprecate the use of S.?? and have all resources go through S.?

Core resources should be searched last to give users opportunity to override
