### PR TITLE
snippet Msgs.ShowAll should not be a session var

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msgs.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msgs.scala
@@ -18,12 +18,15 @@ package net.liftweb
 package builtin
 package snippet
 
-import net.liftweb.http.{DispatchSnippet,LiftRules,NoticeType,S,SessionVar}
+import http._
 import scala.xml._
 import net.liftweb.util.Helpers._
 import net.liftweb.http.js._
 import JsCmds._
 import net.liftweb.common.{Box, Full, Empty}
+import common.Full
+import xml.Text
+import snippet.AjaxMessageMeta
 
 
 /**
@@ -219,8 +222,8 @@ object MsgsErrorMeta extends SessionVar[Box[AjaxMessageMeta]](Empty) {
  * This SessionVar records whether to show id-based messages in
  * addition to non-id messages.
  */
-object ShowAll extends SessionVar[Boolean](false) {
-    override private[liftweb] def magicSessionVar_? = true
+object ShowAll extends RequestVar[Boolean](false) {
+    //override private[liftweb] def magicSessionVar_? = true
 }
 
 /**


### PR DESCRIPTION
More of the global nastiness around Msgs.  I think I need to totally re-write the messages mechanism... perhaps to use wiring.
