### PR TITLE
Implement !== Operator

### DIFF
--- a/core/common/src/main/scala/net/liftweb/common/Box.scala
+++ b/core/common/src/main/scala/net/liftweb/common/Box.scala
@@ -429,6 +429,12 @@ sealed abstract class Box[+A] extends Product {
   def ===[B >: A](to: B): Boolean = false
 
   /**
+   * Returns true if the value contained in this box is NOT equal to the
+   * specified value, or if this Box is Empty.
+   */
+  def !==[B >: A](to: B): Boolean = ! (this === to)
+
+  /**
    * Equivalent to map(f).openOr(Full(dflt))
    */
   def dmap[B](dflt: => B)(f: A => B): B = dflt

--- a/core/common/src/test/scala/net/liftweb/common/BoxSpec.scala
+++ b/core/common/src/test/scala/net/liftweb/common/BoxSpec.scala
@@ -86,6 +86,18 @@ object BoxSpec extends Specification("Box Specification") with ScalaCheck with B
       Full(1).choice(gotIt)(Full("nothing")) must_== Full("got it: 1")
       Empty.choice(gotIt)(Full("nothing")) must_== Full("nothing")
     }
+    "define an '===' method, returning true only if this box is Full and its value matches" in {
+      Full(1).===(1) must beTrue
+      Full(2).===(1) must beFalse
+      Empty.===(1) must beFalse
+      (Empty ?~ "failure").===(1) must beFalse
+    }
+    "define a '!==' method, returning true only if this box is Empty or its value does not match" in {
+      Full(1).!==(1) must beFalse
+      Full(2).!==(1) must beTrue
+      Empty.!==(1) must beTrue
+      (Empty ?~ "failure").!==(1) must beTrue
+    }
   }
 
   "A Full Box" should {


### PR DESCRIPTION
Presently, we have the === operator that works on Boxes, like so:

``` scala
val awesomeBox : Box[Boolean] = ...

if (awesomeBox === true) {
  //do something
}
```

I'm proposing the implementation of a !== operator that negates the current === operator. Such that you could write....

``` scala
if (awesomeBox !== true) {
```

... and have the following code run so long as `awesomeBox` isn't a Full box containing true.
