### PR TITLE
Deprecate bundled jQuery

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/js/jquery/JQueryArtifacts.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/jquery/JQueryArtifacts.scala
@@ -133,6 +133,7 @@ trait JQueryArtifacts extends JSArtifacts {
             info.failFunc.map("error : " + _).toList mkString ("{ ", ", ", " }")
 }
 
+@deprecated("Either include your own jQuery or use https://github.com/karma4u101/lift-jquery-module")
 case object JQuery13Artifacts extends JQueryArtifacts {
   override def pathRewriter: PartialFunction[List[String], List[String]] = {
     case "jquery.js" :: Nil if Props.devMode => List("jquery-1.3.2.js")
@@ -140,7 +141,7 @@ case object JQuery13Artifacts extends JQueryArtifacts {
   }
 }
 
-
+@deprecated("Either include your own jQuery or use https://github.com/karma4u101/lift-jquery-module")
 case object JQuery14Artifacts extends JQueryArtifacts {
   override def pathRewriter: PartialFunction[List[String], List[String]] = {
     case "jquery.js" :: Nil if Props.devMode => List("jquery-1.4.4.js")


### PR DESCRIPTION
Based on this thread
https://groups.google.com/d/topic/liftweb/l3M8yNaAVX8/discussion
we will deprecate the "very old" bundled jQuery and offer out users a couple of alternatives.

1- Let them include jQuery in their own projects (like in webapp/js/ )
2- Let them use one of the CDN hosted urls (like Google, etc)
3- Use the lightweight module Peter Petersson wrote.
