### PR TITLE
Use S.? instead of S.?? all around Lift

### DIFF
--- a/persistence/ldap/src/main/scala/net/liftweb/ldap/LDAPProtoUser.scala
+++ b/persistence/ldap/src/main/scala/net/liftweb/ldap/LDAPProtoUser.scala
@@ -88,7 +88,7 @@ trait MetaLDAPProtoUser[ModelType <: LDAPProtoUser[ModelType]] extends MetaMegaP
         <form method="post" action={S.uri}>
             <table>
                 <tr>
-                    <td colspan="2">{S.??("log.in")}</td>
+                    <td colspan="2">{S.?("log.in")}</td>
                 </tr>
                 <tr>
                     <td>Username</td><td><user:name /></td>
@@ -115,7 +115,7 @@ trait MetaLDAPProtoUser[ModelType <: LDAPProtoUser[ModelType]] extends MetaMegaP
         Helpers.bind("user", loginXhtml,
                     "name" -> (JsCmds.FocusOnLoad(<input type="text" name="username"/>)),
                     "password" -> (<input type="password" name="password"/>),
-                    "submit" -> (<input type="submit" value={S.??("log.in")}/>))
+                    "submit" -> (<input type="submit" value={S.?("log.in")}/>))
     }
 
     def ldapLogin(username: String, password: String): Boolean = {

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedEmail.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedEmail.scala
@@ -34,7 +34,7 @@ abstract class MappedEmail[T<:Mapper[T]](owner: T, maxLen: Int) extends MappedSt
   override def setFilter = notNull _ :: toLower _ :: trim _ :: super.setFilter
 
   override def validate =
-    (if (MappedEmail.emailPattern.matcher(i_is_!).matches) Nil else List(FieldError(this, Text(S.??("invalid.email.address"))))) :::
+    (if (MappedEmail.emailPattern.matcher(i_is_!).matches) Nil else List(FieldError(this, Text(S.?("invalid.email.address"))))) :::
     super.validate
 
 }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedPassword.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedPassword.scala
@@ -57,10 +57,10 @@ extends MappedField[String, T] {
 
   protected def real_i_set_!(value : String) : String = {
     password() = value match {
-      case "*" | null | MappedPassword.blankPw if (value.length < 3) => {invalidPw = true ; invalidMsg = S.??("password.must.be.set") ; "*"}
+      case "*" | null | MappedPassword.blankPw if (value.length < 3) => {invalidPw = true ; invalidMsg = S.?("password.must.be.set") ; "*"}
       case MappedPassword.blankPw => {return "*"}
       case _ if (value.length > 4) => {invalidPw = false; hash("{"+value+"} salt={"+salt_i.get+"}")}
-      case _ => {invalidPw = true ; invalidMsg = S.??("password.too.short"); "*"}
+      case _ => {invalidPw = true ; invalidMsg = S.?("password.too.short"); "*"}
     }
     this.dirty_?( true)
     "*"
@@ -69,7 +69,7 @@ extends MappedField[String, T] {
   def setList(in: List[String]): Boolean =
   in match {
     case x1 :: x2 :: Nil if x1 == x2 => this.set(x1) ; true
-    case _ => invalidPw = true; invalidMsg = S.??("passwords.do.not.match"); false
+    case _ => invalidPw = true; invalidMsg = S.?("passwords.do.not.match"); false
   }
 
 
@@ -77,7 +77,7 @@ extends MappedField[String, T] {
     f match {
       case a : Array[String] if (a.length == 2 && a(0) == a(1)) => {this.set(a(0))}
       case l : List[String] if (l.length == 2 && l.head == l(1)) => {this.set(l.head)}
-      case _ => {invalidPw = true; invalidMsg = S.??("passwords.do.not.match")}
+      case _ => {invalidPw = true; invalidMsg = S.?("passwords.do.not.match")}
     }
     is
   }
@@ -93,7 +93,7 @@ extends MappedField[String, T] {
   override def validate : List[FieldError] = {
     if (!invalidPw && password.get != "*") Nil
     else if (invalidPw) List(FieldError(this, Text(invalidMsg)))
-    else List(FieldError(this, Text(S.??("password.must.be.set"))))
+    else List(FieldError(this, Text(S.?("password.must.be.set"))))
   }
 
   def real_convertToJDBCFriendly(value: String): Object = hash("{"+value+"} salt={"+salt_i.get+"}")
@@ -124,7 +124,7 @@ extends MappedField[String, T] {
   override def _toForm: Box[NodeSeq] = {
     S.fmapFunc({s: List[String] => this.setFromAny(s)}){funcName =>
       Full(<span>{appendFieldId(<input type={formInputType} name={funcName}
-            value={is.toString}/>)}&nbsp;{S.??("repeat")}&nbsp;<input
+            value={is.toString}/>)}&nbsp;{S.?("repeat")}&nbsp;<input
             type={formInputType} name={funcName}
             value={is.toString}/></span>)
     }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedPostalCode.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedPostalCode.scala
@@ -69,7 +69,7 @@ object Countries extends Enumeration(1) {
 
   class I18NCountry extends Val {
     override def toString() =
-    S.??("country_" + id)
+    S.?("country_" + id)
   }
 }
 
@@ -125,8 +125,8 @@ abstract class MappedPostalCode[T <: Mapper[T]](owner: T, country: MappedCountry
 
   private def genericCheck(zip: String): List[FieldError] = {
     zip match {
-      case null => List(FieldError(this, Text(S.??("invalid.postal.code"))))
-      case s if s.length < 3 => List(FieldError(this, Text(S.??("invalid.postal.code"))))
+      case null => List(FieldError(this, Text(S.?("invalid.postal.code"))))
+      case s if s.length < 3 => List(FieldError(this, Text(S.?("invalid.postal.code"))))
       case _ => Nil
     }
   }
@@ -135,22 +135,22 @@ abstract class MappedPostalCode[T <: Mapper[T]](owner: T, country: MappedCountry
 
   override def validations = country.is match {
     case Countries.USA =>  valRegex(REPat.compile("[0-9]{5}(\\-[0-9]{4})?"),
-                                    S.??("invalid.zip.code")) _ :: super.validations
+                                    S.?("invalid.zip.code")) _ :: super.validations
 
     case Countries.Sweden => valRegex(REPat.compile("[0-9]{3}[ ]?[0-9]{2}"),
-                                      S.??("invalid.postal.code")) _ :: super.validations
+                                      S.?("invalid.postal.code")) _ :: super.validations
 
     case Countries.Australia => valRegex(REPat.compile("(0?|[1-9])[0-9]{3}"),
-                                         S.??("invalid.postal.code")) _ :: super.validations
+                                         S.?("invalid.postal.code")) _ :: super.validations
 
     case Countries.Canada => valRegex(REPat.compile("[A-Z][0-9][A-Z][ ][0-9][A-Z][0-9]"),
-                                      S.??("invalid.postal.code")) _ :: super.validations
+                                      S.?("invalid.postal.code")) _ :: super.validations
 
     case Countries.Germany => valRegex(REPat.compile("[0-9]{5}"),
-                                       S.??("invalid.postal.code")) _ :: super.validations
+                                       S.?("invalid.postal.code")) _ :: super.validations
 
     case Countries.UK =>  valRegex(REPat.compile("[A-Z]{1,2}[0-9R][0-9A-Z]?[0-9][ABD-HJLNP-UW-Z]{2}"),
-                                     S.??("invalid.postal.code")) _ :: super.validations
+                                     S.?("invalid.postal.code")) _ :: super.validations
 
     case _ => genericCheck _ :: super.validations
   }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedUniqueId.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedUniqueId.scala
@@ -59,7 +59,7 @@ object Genders extends Enumeration {
 
   class I18NGender(id : Int, name: String) extends Val(id, name) {
     override def toString = {
-      S.??(name)
+      S.?(name)
     }
   }
 }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoUser.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoUser.scala
@@ -114,7 +114,7 @@ trait ProtoUser[T <: ProtoUser[T]] extends KeyedMapper[Long, T] with UserIdAsStr
 
   protected class MyEmail(obj: T, size: Int) extends MappedEmail(obj, size) {
     override def dbIndexed_? = true
-    override def validations = valUnique(S.??("unique.email.address")) _ :: super.validations
+    override def validations = valUnique(S.?("unique.email.address")) _ :: super.validations
     override def displayName = fieldOwner.emailDisplayName
     override val fieldId = Some(Text("txtEmail"))
   }

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoPasswordField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoPasswordField.scala
@@ -80,9 +80,9 @@ class MongoPasswordField[OwnerType <: BsonRecord[OwnerType]](rec: OwnerType, min
 
   private def validatePassword(pwd: Password): List[FieldError] = pwd match {
     case null | Password("", _) | Password("*", _) | Password(MongoPasswordField.blankPw, _) =>
-      Text(S.??("password.must.be.set"))
+      Text(S.?("password.must.be.set"))
     case Password(pwd, _) if pwd.length < minLen =>
-      Text(S.??("password.too.short"))
+      Text(S.?("password.too.short"))
     case _ => Nil
   }
 

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
@@ -259,7 +259,7 @@ object MongoFieldSpec extends Specification("MongoField Specification") with Mon
       val rec = PasswordTestRecord.createRecord
       rec.password.setPassword("")
       rec.validate must_== (
-        FieldError(rec.password, Text(S.??("password.must.be.set"))) ::
+        FieldError(rec.password, Text(S.?("password.must.be.set"))) ::
         Nil
       )
     }
@@ -268,7 +268,7 @@ object MongoFieldSpec extends Specification("MongoField Specification") with Mon
       val rec = PasswordTestRecord.createRecord
       rec.password.setPassword("ab")
       rec.validate must_== (
-        FieldError(rec.password, Text(S.??("password.too.short"))) ::
+        FieldError(rec.password, Text(S.?("password.too.short"))) ::
         Nil
       )
     }

--- a/persistence/proto/src/main/scala/net/liftweb/proto/Crudify.scala
+++ b/persistence/proto/src/main/scala/net/liftweb/proto/Crudify.scala
@@ -229,7 +229,7 @@ trait Crudify {
          */
         val text = new Loc.LinkText(calcLinkText _)
 
-        def calcLinkText(in: TheCrudType): NodeSeq = Text(S.??("crudify.menu.view.displayName", displayName))
+        def calcLinkText(in: TheCrudType): NodeSeq = Text(S.?("crudify.menu.view.displayName", displayName))
 
         /**
          * Rewrite the request and emit the type-safe parameter
@@ -264,7 +264,7 @@ trait Crudify {
           def name = "Edit "+Prefix
 
           override val snippets: SnippetTest = {
-            case ("crud.edit", Full(wp: TheCrudType)) => crudDoForm(wp, S.??("Save"))
+            case ("crud.edit", Full(wp: TheCrudType)) => crudDoForm(wp, S.?("Save"))
           }
 
           def defaultValue = Empty
@@ -276,7 +276,7 @@ trait Crudify {
            */
           val text = new Loc.LinkText(calcLinkText _)
 
-          def calcLinkText(in: TheCrudType): NodeSeq = Text(S.??("crudify.menu.edit.displayName", displayName))
+          def calcLinkText(in: TheCrudType): NodeSeq = Text(S.?("crudify.menu.edit.displayName", displayName))
 
           /**
            * Rewrite the request and emit the type-safe parameter
@@ -307,7 +307,7 @@ trait Crudify {
   /**
    * The String displayed for menu editing
    */
-  def editMenuName = S.??("Edit")+" "+displayName
+  def editMenuName = S.?("Edit")+" "+displayName
 
   /**
    * This is the template that's used to render the page after the
@@ -345,7 +345,7 @@ trait Crudify {
   </lift:crud.edit>
   }
 
-  def editButton = S.??("Save")
+  def editButton = S.?("Save")
 
   /**
    * Override this method to change how fields are displayed for delete
@@ -406,7 +406,7 @@ trait Crudify {
            */
           val text = new Loc.LinkText(calcLinkText _)
 
-          def calcLinkText(in: TheCrudType): NodeSeq = Text(S.??("crudify.menu.delete.displayName", displayName))
+          def calcLinkText(in: TheCrudType): NodeSeq = Text(S.?("crudify.menu.delete.displayName", displayName))
 
           /**
            * Rewrite the request and emit the type-safe parameter
@@ -440,7 +440,7 @@ trait Crudify {
   def deleteMenuLocParams: List[Loc.LocParam[TheCrudType]] = Nil
 
 
-  def deleteMenuName = S.??("Delete")+" "+displayName
+  def deleteMenuName = S.?("Delete")+" "+displayName
 
   /**
    * This is the template that's used to render the page after the
@@ -476,10 +476,10 @@ trait Crudify {
     </table>
   </lift:crud.delete>
 
-  def deleteButton = S.??("Delete")
+  def deleteButton = S.?("Delete")
 
 
-  def createMenuName = S.??("Create")+" "+displayName
+  def createMenuName = S.?("Create")+" "+displayName
 
   /**
    * This is the template that's used to render the page after the
@@ -515,9 +515,9 @@ trait Crudify {
     </table>
   </lift:crud.create>
 
-  def createButton = S.??("Create")
+  def createButton = S.?("Create")
 
-  def viewMenuName = S.??("View")+" "+displayName
+  def viewMenuName = S.?("View")+" "+displayName
 
   /**
    * This is the template that's used to render the page after the
@@ -544,7 +544,7 @@ trait Crudify {
     </table>
   </lift:crud.view>
 
-  def showAllMenuName = S.??("List")+" "+displayName
+  def showAllMenuName = S.?("List")+" "+displayName
 
   /**
    * This is the template that's used to render the page after the
@@ -574,9 +574,9 @@ trait Crudify {
         <crud:row>
           <tr>
             <crud:row_item><td><crud:value/></td></crud:row_item>
-            <td><a crud:view_href="">{S.??("View")}</a></td>
-            <td><a crud:edit_href="">{S.??("Edit")}</a></td>
-            <td><a crud:delete_href="">{S.??("Delete")}</a></td>
+            <td><a crud:view_href="">{S.?("View")}</a></td>
+            <td><a crud:edit_href="">{S.?("Edit")}</a></td>
+            <td><a crud:delete_href="">{S.?("Delete")}</a></td>
           </tr>
         </crud:row>
       </tbody>
@@ -589,8 +589,8 @@ trait Crudify {
     </table>
   </lift:crud.all>
 
-  def nextWord = S.??("Next")
-  def previousWord = S.??("Previous")
+  def nextWord = S.?("Next")
+  def previousWord = S.?("Previous")
 
   lazy val listPath = Prefix ::: List(ListItems)
 
@@ -721,7 +721,7 @@ trait Crudify {
   lazy val locSnippets = new DispatchLocSnippets {
     val dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
       case "crud.all" => doCrudAll
-      case "crud.create" => crudDoForm(create, S.??("Created"))
+      case "crud.create" => crudDoForm(create, S.?("Created"))
     }
 
   }

--- a/persistence/proto/src/main/scala/net/liftweb/proto/ProtoUser.scala
+++ b/persistence/proto/src/main/scala/net/liftweb/proto/ProtoUser.scala
@@ -326,12 +326,12 @@ trait ProtoUser {
   /**
    * A Menu.LocParam to test if the user is logged in
    */
-  lazy val testLogginIn = If(loggedIn_? _, S.??("must.be.logged.in")) ;
+  lazy val testLogginIn = If(loggedIn_? _, S.?("must.be.logged.in")) ;
 
   /**
    * A Menu.LocParam to test if the user is a super user
    */
-  lazy val testSuperUser = If(superUser_? _, S.??("must.be.super.user"))
+  lazy val testSuperUser = If(superUser_? _, S.?("must.be.super.user"))
 
   /**
    * A Menu.LocParam for testing if the user is logged in and if they're not,
@@ -358,7 +358,7 @@ trait ProtoUser {
    * The menu item for login (make this "Empty" to disable)
    */
   def loginMenuLoc: Box[Menu] =
-    Full(Menu(Loc("Login" + menuNameSuffix, loginPath, S.??("login"), loginMenuLocParams ::: globalUserLocParams)))
+    Full(Menu(Loc("Login" + menuNameSuffix, loginPath, S.?("login"), loginMenuLocParams ::: globalUserLocParams)))
 
 
   /**
@@ -372,7 +372,7 @@ trait ProtoUser {
    * Overwrite in order to add custom LocParams. Attention: Not calling super will change the default behavior!
    */
   protected def loginMenuLocParams: List[LocParam[Unit]] =
-    If(notLoggedIn_? _, S.??("already.logged.in")) ::
+    If(notLoggedIn_? _, S.?("already.logged.in")) ::
     Template(() => wrapIt(login)) ::
     Nil
 
@@ -386,7 +386,7 @@ trait ProtoUser {
    * The menu item for logout (make this "Empty" to disable)
    */
   def logoutMenuLoc: Box[Menu] =
-    Full(Menu(Loc("Logout" + menuNameSuffix, logoutPath, S.??("logout"), logoutMenuLocParams ::: globalUserLocParams)))
+    Full(Menu(Loc("Logout" + menuNameSuffix, logoutPath, S.?("logout"), logoutMenuLocParams ::: globalUserLocParams)))
 
   /**
    * The LocParams for the menu item for logout.
@@ -401,7 +401,7 @@ trait ProtoUser {
    * The menu item for creating the user/sign up (make this "Empty" to disable)
    */
   def createUserMenuLoc: Box[Menu] =
-    Full(Menu(Loc("CreateUser" + menuNameSuffix, signUpPath, S.??("sign.up"), createUserMenuLocParams ::: globalUserLocParams)))
+    Full(Menu(Loc("CreateUser" + menuNameSuffix, signUpPath, S.?("sign.up"), createUserMenuLocParams ::: globalUserLocParams)))
 
   /**
    * The LocParams for the menu item for creating the user/sign up.
@@ -409,14 +409,14 @@ trait ProtoUser {
    */
   protected def createUserMenuLocParams: List[LocParam[Unit]] =
     Template(() => wrapIt(signupFunc.map(_()) openOr signup)) ::
-    If(notLoggedIn_? _, S.??("logout.first")) ::
+    If(notLoggedIn_? _, S.?("logout.first")) ::
     Nil
 
   /**
    * The menu item for lost password (make this "Empty" to disable)
    */
   def lostPasswordMenuLoc: Box[Menu] =
-    Full(Menu(Loc("LostPassword" + menuNameSuffix, lostPasswordPath, S.??("lost.password"), lostPasswordMenuLocParams ::: globalUserLocParams))) // not logged in
+    Full(Menu(Loc("LostPassword" + menuNameSuffix, lostPasswordPath, S.?("lost.password"), lostPasswordMenuLocParams ::: globalUserLocParams))) // not logged in
 
   /**
    * The LocParams for the menu item for lost password.
@@ -424,14 +424,14 @@ trait ProtoUser {
    */
   protected def lostPasswordMenuLocParams: List[LocParam[Unit]] =
     Template(() => wrapIt(lostPassword)) ::
-    If(notLoggedIn_? _, S.??("logout.first")) ::
+    If(notLoggedIn_? _, S.?("logout.first")) ::
     Nil
 
   /**
    * The menu item for resetting the password (make this "Empty" to disable)
    */
   def resetPasswordMenuLoc: Box[Menu] =
-    Full(Menu(Loc("ResetPassword" + menuNameSuffix, (passwordResetPath, true), S.??("reset.password"), resetPasswordMenuLocParams ::: globalUserLocParams))) //not Logged in
+    Full(Menu(Loc("ResetPassword" + menuNameSuffix, (passwordResetPath, true), S.?("reset.password"), resetPasswordMenuLocParams ::: globalUserLocParams))) //not Logged in
 
   /**
    * The LocParams for the menu item for resetting the password.
@@ -440,14 +440,14 @@ trait ProtoUser {
   protected def resetPasswordMenuLocParams: List[LocParam[Unit]] =
     Hidden ::
     Template(() => wrapIt(passwordReset(snarfLastItem))) ::
-    If(notLoggedIn_? _, S.??("logout.first")) ::
+    If(notLoggedIn_? _, S.?("logout.first")) ::
     Nil
 
   /**
    * The menu item for editing the user (make this "Empty" to disable)
    */
   def editUserMenuLoc: Box[Menu] =
-    Full(Menu(Loc("EditUser" + menuNameSuffix, editPath, S.??("edit.user"), editUserMenuLocParams ::: globalUserLocParams)))
+    Full(Menu(Loc("EditUser" + menuNameSuffix, editPath, S.?("edit.user"), editUserMenuLocParams ::: globalUserLocParams)))
 
   /**
    * The LocParams for the menu item for editing the user.
@@ -462,7 +462,7 @@ trait ProtoUser {
    * The menu item for changing password (make this "Empty" to disable)
    */
   def changePasswordMenuLoc: Box[Menu] =
-    Full(Menu(Loc("ChangePassword" + menuNameSuffix, changePasswordPath, S.??("change.password"), changePasswordMenuLocParams ::: globalUserLocParams)))
+    Full(Menu(Loc("ChangePassword" + menuNameSuffix, changePasswordPath, S.?("change.password"), changePasswordMenuLocParams ::: globalUserLocParams)))
 
   /**
    * The LocParams for the menu item for changing password.
@@ -477,7 +477,7 @@ trait ProtoUser {
    * The menu item for validating a user (make this "Empty" to disable)
    */
   def validateUserMenuLoc: Box[Menu] =
-    Full(Menu(Loc("ValidateUser" + menuNameSuffix, (validateUserPath, true), S.??("validate.user"), validateUserMenuLocParams ::: globalUserLocParams)))
+    Full(Menu(Loc("ValidateUser" + menuNameSuffix, (validateUserPath, true), S.?("validate.user"), validateUserMenuLocParams ::: globalUserLocParams)))
 
   /**
    * The LocParams for the menu item for validating a user.
@@ -486,7 +486,7 @@ trait ProtoUser {
   protected def validateUserMenuLocParams: List[LocParam[Unit]] =
     Hidden ::
     Template(() => wrapIt(validateUser(snarfLastItem))) ::
-    If(notLoggedIn_? _, S.??("logout.first")) ::
+    If(notLoggedIn_? _, S.?("logout.first")) ::
     Nil
 
   /**
@@ -546,13 +546,13 @@ trait ProtoUser {
   (for (r <- S.request) yield r.path.wholePath.last) openOr ""
 
   lazy val ItemList: List[MenuItem] =
-  List(MenuItem(S.??("sign.up"), signUpPath, false),
-       MenuItem(S.??("log.in"), loginPath, false),
-       MenuItem(S.??("lost.password"), lostPasswordPath, false),
+  List(MenuItem(S.?("sign.up"), signUpPath, false),
+       MenuItem(S.?("log.in"), loginPath, false),
+       MenuItem(S.?("lost.password"), lostPasswordPath, false),
        MenuItem("", passwordResetPath, false),
-       MenuItem(S.??("change.password"), changePasswordPath, true),
-       MenuItem(S.??("log.out"), logoutPath, true),
-       MenuItem(S.??("edit.profile"), editPath, true),
+       MenuItem(S.?("change.password"), changePasswordPath, true),
+       MenuItem(S.?("log.out"), logoutPath, true),
+       MenuItem(S.?("edit.profile"), editPath, true),
        MenuItem("", validateUserPath, false))
 
   var onLogIn: List[TheUserType => Unit] = Nil
@@ -638,7 +638,7 @@ trait ProtoUser {
 
   def signupXhtml(user: TheUserType) = {
     (<form method="post" action={S.uri}><table><tr><td
-              colspan="2">{ S.??("sign.up") }</td></tr>
+              colspan="2">{ S.?("sign.up") }</td></tr>
           {localForm(user, false, signupFields)}
           <tr><td>&nbsp;</td><td><user:submit/></td></tr>
                                         </table></form>)
@@ -648,23 +648,23 @@ trait ProtoUser {
   def signupMailBody(user: TheUserType, validationLink: String): Elem = {
     (<html>
         <head>
-          <title>{S.??("sign.up.confirmation")}</title>
+          <title>{S.?("sign.up.confirmation")}</title>
         </head>
         <body>
-          <p>{S.??("dear")} {user.getFirstName},
+          <p>{S.?("dear")} {user.getFirstName},
             <br/>
             <br/>
-            {S.??("sign.up.validation.link")}
+            {S.?("sign.up.validation.link")}
             <br/><a href={validationLink}>{validationLink}</a>
             <br/>
             <br/>
-            {S.??("thank.you")}
+            {S.?("thank.you")}
           </p>
         </body>
      </html>)
   }
 
-  def signupMailSubject = S.??("sign.up.confirmation")
+  def signupMailSubject = S.?("sign.up.confirmation")
 
   /**
    * Send validation email to the user.  The XHTML version of the mail
@@ -708,11 +708,11 @@ trait ProtoUser {
     theUser.save
     if (!skipEmailValidation) {
       sendValidationEmail(theUser)
-      S.notice(S.??("sign.up.message"))
+      S.notice(S.?("sign.up.message"))
       func()
     } else {
       logUserIn(theUser, () => {      
-        S.notice(S.??("welcome"))
+        S.notice(S.?("welcome"))
         func()
       })
     }
@@ -754,7 +754,7 @@ trait ProtoUser {
 
     def innerSignup = bind("user",
                            signupXhtml(theUser),
-                           "submit" -> signupSubmitButton(S.??("sign.up"), testSignup _))
+                           "submit" -> signupSubmitButton(S.?("sign.up"), testSignup _))
 
     innerSignup
   }
@@ -778,32 +778,32 @@ trait ProtoUser {
     case Full(user) if !user.validated_? =>
       user.setValidated(true).resetUniqueId().save
       logUserIn(user, () => {
-        S.notice(S.??("account.validated"))
+        S.notice(S.?("account.validated"))
         S.redirectTo(homePage)
       })
 
-    case _ => S.error(S.??("invalid.validation.link")); S.redirectTo(homePage)
+    case _ => S.error(S.?("invalid.validation.link")); S.redirectTo(homePage)
   }
 
   /**
    * How do we prompt the user for the username.  By default,
-   * it's S.??("email.address"), you can can change it to something else
+   * it's S.?("email.address"), you can can change it to something else
    */
-  def userNameFieldString: String = S.??("email.address")
+  def userNameFieldString: String = S.?("email.address")
 
   /**
    * The string that's generated when the user name is not found.  By
-   * default: S.??("email.address.not.found")
+   * default: S.?("email.address.not.found")
    */
-  def userNameNotFoundString: String = S.??("email.address.not.found")
+  def userNameNotFoundString: String = S.?("email.address.not.found")
 
   def loginXhtml = {
     (<form method="post" action={S.uri}><table><tr><td
-              colspan="2">{S.??("log.in")}</td></tr>
+              colspan="2">{S.?("log.in")}</td></tr>
           <tr><td>{userNameFieldString}</td><td><user:email /></td></tr>
-          <tr><td>{S.??("password")}</td><td><user:password /></td></tr>
+          <tr><td>{S.?("password")}</td><td><user:password /></td></tr>
           <tr><td><a href={lostPasswordPath.mkString("/", "/", "")}
-                >{S.??("recover.password")}</a></td><td><user:submit /></td></tr></table>
+                >{S.?("recover.password")}</a></td><td><user:submit /></td></tr></table>
      </form>)
   }
   
@@ -849,7 +849,7 @@ trait ProtoUser {
             }
 
             logUserIn(user, () => {
-              S.notice(S.??("logged.in"))
+              S.notice(S.?("logged.in"))
 
               preLoginState()
 
@@ -858,16 +858,16 @@ trait ProtoUser {
           }
 
         case Full(user) if !user.validated_? =>
-          S.error(S.??("account.validation.error"))
+          S.error(S.?("account.validation.error"))
 
-        case _ => S.error(S.??("invalid.credentials"))
+        case _ => S.error(S.?("invalid.credentials"))
       }
     }
 
     bind("user", loginXhtml,
          "email" -> (FocusOnLoad(<input type="text" name="username"/>)),
          "password" -> (<input type="password" name="password"/>),
-         "submit" -> loginSubmitButton(S.??("log.in")))
+         "submit" -> loginSubmitButton(S.?("log.in")))
   }
 
   def loginSubmitButton(name: String, func: () => Any = () => {}): NodeSeq = {
@@ -881,7 +881,7 @@ trait ProtoUser {
   def lostPasswordXhtml = {
     (<form method="post" action={S.uri}>
         <table><tr><td
-              colspan="2">{S.??("enter.email")}</td></tr>
+              colspan="2">{S.?("enter.email")}</td></tr>
           <tr><td>{userNameFieldString}</td><td><user:email /></td></tr>
           <tr><td>&nbsp;</td><td><user:submit /></td></tr>
         </table>
@@ -891,17 +891,17 @@ trait ProtoUser {
   def passwordResetMailBody(user: TheUserType, resetLink: String): Elem = {
     (<html>
         <head>
-          <title>{S.??("reset.password.confirmation")}</title>
+          <title>{S.?("reset.password.confirmation")}</title>
         </head>
         <body>
-          <p>{S.??("dear")} {user.getFirstName},
+          <p>{S.?("dear")} {user.getFirstName},
             <br/>
             <br/>
-            {S.??("click.reset.link")}
+            {S.?("click.reset.link")}
             <br/><a href={resetLink}>{resetLink}</a>
             <br/>
             <br/>
-            {S.??("thank.you")}
+            {S.?("thank.you")}
           </p>
         </body>
      </html>)
@@ -919,7 +919,7 @@ trait ProtoUser {
     List(xmlToMailBodyType(passwordResetMailBody(user, resetLink)))
 
 
-  def passwordResetEmailSubject = S.??("reset.password.request")
+  def passwordResetEmailSubject = S.?("reset.password.request")
 
   /**
    * Send password reset email to the user.  The XHTML version of the mail
@@ -941,12 +941,12 @@ trait ProtoUser {
                          generateResetEmailBodies(user, resetLink) :::
                          (bccEmail.toList.map(BCC(_)))) :_*)
 
-        S.notice(S.??("password.reset.email.sent"))
+        S.notice(S.?("password.reset.email.sent"))
         S.redirectTo(homePage)
 
       case Full(user) =>
         sendValidationEmail(user)
-        S.notice(S.??("account.validation.resent"))
+        S.notice(S.?("account.validation.resent"))
         S.redirectTo(homePage)
 
       case _ => S.error(userNameNotFoundString)
@@ -956,7 +956,7 @@ trait ProtoUser {
   def lostPassword = {
     bind("user", lostPasswordXhtml,
          "email" -> SHtml.text("", sendPasswordReset _),
-         "submit" -> lostPasswordSubmitButton(S.??("send.it")))
+         "submit" -> lostPasswordSubmitButton(S.?("send.it")))
   }
 
   def lostPasswordSubmitButton(name: String, func: () => Any = () => {}): NodeSeq = {
@@ -965,9 +965,9 @@ trait ProtoUser {
 
   def passwordResetXhtml = {
     (<form method="post" action={S.uri}>
-        <table><tr><td colspan="2">{S.??("reset.your.password")}</td></tr>
-          <tr><td>{S.??("enter.your.new.password")}</td><td><user:pwd/></td></tr>
-          <tr><td>{S.??("repeat.your.new.password")}</td><td><user:pwd/></td></tr>
+        <table><tr><td colspan="2">{S.?("reset.your.password")}</td></tr>
+          <tr><td>{S.?("enter.your.new.password")}</td><td><user:pwd/></td></tr>
+          <tr><td>{S.?("repeat.your.new.password")}</td><td><user:pwd/></td></tr>
           <tr><td>&nbsp;</td><td><user:submit/></td></tr>
         </table>
      </form>)
@@ -978,7 +978,7 @@ trait ProtoUser {
     case Full(user) =>
       def finishSet() {
         user.validate match {
-          case Nil => S.notice(S.??("password.changed"))
+          case Nil => S.notice(S.?("password.changed"))
             user.resetUniqueId().save
             logUserIn(user, () => S.redirectTo(homePage))
 
@@ -988,8 +988,8 @@ trait ProtoUser {
       bind("user", passwordResetXhtml,
            "pwd" -> SHtml.password_*("",(p: List[String]) =>
           user.setPasswordFromListString(p)),
-           "submit" -> resetPasswordSubmitButton(S.??("set.password"), finishSet _))
-    case _ => S.error(S.??("password.link.invalid")); S.redirectTo(homePage)
+           "submit" -> resetPasswordSubmitButton(S.?("set.password"), finishSet _))
+    case _ => S.error(S.?("password.link.invalid")); S.redirectTo(homePage)
   }
 
   def resetPasswordSubmitButton(name: String, func: () => Any = () => {}): NodeSeq = {
@@ -998,10 +998,10 @@ trait ProtoUser {
 
   def changePasswordXhtml = {
     (<form method="post" action={S.uri}>
-        <table><tr><td colspan="2">{S.??("change.password")}</td></tr>
-          <tr><td>{S.??("old.password")}</td><td><user:old_pwd /></td></tr>
-          <tr><td>{S.??("new.password")}</td><td><user:new_pwd /></td></tr>
-          <tr><td>{S.??("repeat.password")}</td><td><user:new_pwd /></td></tr>
+        <table><tr><td colspan="2">{S.?("change.password")}</td></tr>
+          <tr><td>{S.?("old.password")}</td><td><user:old_pwd /></td></tr>
+          <tr><td>{S.?("new.password")}</td><td><user:new_pwd /></td></tr>
+          <tr><td>{S.?("repeat.password")}</td><td><user:new_pwd /></td></tr>
           <tr><td>&nbsp;</td><td><user:submit /></td></tr>
         </table>
      </form>)
@@ -1013,11 +1013,11 @@ trait ProtoUser {
     var newPassword: List[String] = Nil
 
     def testAndSet() {
-      if (!user.testPassword(Full(oldPassword))) S.error(S.??("wrong.old.password"))
+      if (!user.testPassword(Full(oldPassword))) S.error(S.?("wrong.old.password"))
       else {
         user.setPasswordFromListString(newPassword)
         user.validate match {
-          case Nil => user.save; S.notice(S.??("password.changed")); S.redirectTo(homePage)
+          case Nil => user.save; S.notice(S.?("password.changed")); S.redirectTo(homePage)
           case xs => S.error(xs)
         }
       }
@@ -1026,7 +1026,7 @@ trait ProtoUser {
     bind("user", changePasswordXhtml,
          "old_pwd" -> SHtml.password("", s => oldPassword = s),
          "new_pwd" -> SHtml.password_*("", LFuncHolder(s => newPassword = s)),
-         "submit" -> changePasswordSubmitButton(S.??("change"), testAndSet _))
+         "submit" -> changePasswordSubmitButton(S.?("change"), testAndSet _))
   }
 
   def changePasswordSubmitButton(name: String, func: () => Any = () => {}): NodeSeq = {
@@ -1035,7 +1035,7 @@ trait ProtoUser {
 
   def editXhtml(user: TheUserType) = {
     (<form method="post" action={S.uri}>
-        <table><tr><td colspan="2">{S.??("edit")}</td></tr>
+        <table><tr><td colspan="2">{S.?("edit")}</td></tr>
           {localForm(user, true, editFields)}
           <tr><td>&nbsp;</td><td><user:submit/></td></tr>
         </table>
@@ -1068,7 +1068,7 @@ trait ProtoUser {
       theUser.validate match {
         case Nil =>
           theUser.save
-          S.notice(S.??("profile.updated"))
+          S.notice(S.?("profile.updated"))
           S.redirectTo(homePage)
 
         case xs => S.error(xs) ; editFunc(Full(innerEdit _))
@@ -1076,7 +1076,7 @@ trait ProtoUser {
     }
 
     def innerEdit = bind("user", editXhtml(theUser),
-                         "submit" -> editSubmitButton(S.??("save"), testEdit _))
+                         "submit" -> editSubmitButton(S.?("save"), testEdit _))
 
     innerEdit
   }

--- a/persistence/record/src/main/scala/net/liftweb/record/ProtoUser.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/ProtoUser.scala
@@ -112,7 +112,7 @@ trait ProtoUser[T <: ProtoUser[T]] extends Record[T] {
   lazy val email: EmailField[T] = new MyEmail(this, 48)
 
   protected class MyEmail(obj: T, size: Int) extends EmailField(obj, size) {
-    override def validations = valUnique(S.??("unique.email.address")) _ :: super.validations
+    override def validations = valUnique(S.?("unique.email.address")) _ :: super.validations
     override def displayName = owner.emailDisplayName
     override val fieldId = Some(Text("txtEmail"))
   }

--- a/persistence/record/src/main/scala/net/liftweb/record/field/CountryField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/CountryField.scala
@@ -62,7 +62,7 @@ object Countries extends Enumeration(1) {
 
   class I18NCountry extends Val {
     override def toString() =
-      S.??("country_" + id)
+      S.?("country_" + id)
   }
 }
 

--- a/persistence/record/src/main/scala/net/liftweb/record/field/EmailField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/EmailField.scala
@@ -37,7 +37,7 @@ trait EmailTypedField extends TypedField[String] {
   private def validateEmail(emailValue: ValueType): List[FieldError] =
     toBoxMyType(emailValue) match {
       case Full(email) if EmailField.validEmailAddr_?(email) => Nil
-      case _ => Text(S.??("invalid.email.address"))
+      case _ => Text(S.?("invalid.email.address"))
     }
 
   override def validations = validateEmail _ :: Nil

--- a/persistence/record/src/main/scala/net/liftweb/record/field/NumericField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/NumericField.scala
@@ -53,7 +53,7 @@ trait NumericTypedField[MyType] extends TypedField[MyType] {
       case _ => Full(elem)
     }
 
-  override def noValueErrorMessage = S.??("number.required")
+  override def noValueErrorMessage = S.?("number.required")
 
   def asJs = valueBox.map(v => JsRaw(String.valueOf(v))) openOr JsNull
 

--- a/persistence/record/src/main/scala/net/liftweb/record/field/PasswordField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/PasswordField.scala
@@ -71,7 +71,7 @@ trait PasswordTypedField extends TypedField[String] {
       case (h1: String) :: (h2: String) :: Nil if h1 == h2 => setBoxPlain(Full(h1))
       case (hash: String) if(hash.startsWith("$2a$")) => setBox(Full(hash))
       case Full(hash: String) if(hash.startsWith("$2a$")) => setBox(Full(hash))
-      case _ => {invalidPw = true; invalidMsg = S.??("passwords.do.not.match"); Failure(invalidMsg)}
+      case _ => {invalidPw = true; invalidMsg = S.?("passwords.do.not.match"); Failure(invalidMsg)}
     }
   }
 
@@ -86,7 +86,7 @@ trait PasswordTypedField extends TypedField[String] {
     else List(FieldError(this, Text(notOptionalErrorMessage)))
   }
 
-  override def notOptionalErrorMessage = S.??("password.must.be.set")
+  override def notOptionalErrorMessage = S.?("password.must.be.set")
 
   private def elem = S.fmapFunc(SFuncHolder(this.setFromAny(_))){
     funcName => <input type="password"
@@ -104,7 +104,7 @@ trait PasswordTypedField extends TypedField[String] {
     pwdValue match {
       case Empty|Full(""|null) if !optional_? => { invalidPw = true ; invalidMsg = notOptionalErrorMessage }
       case Full(s) if s == "" || s == PasswordField.blankPw || s.length < PasswordField.minPasswordLength => 
-        { invalidPw = true ; invalidMsg = S.??("password.too.short") }
+        { invalidPw = true ; invalidMsg = S.?("password.too.short") }
       case _ => { invalidPw = false; invalidMsg = "" }
     }
     invalidPw

--- a/persistence/record/src/main/scala/net/liftweb/record/field/PostalCodeField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/PostalCodeField.scala
@@ -37,17 +37,17 @@ trait PostalCodeTypedField extends StringTypedField {
   override def validations = validatePostalCode _ :: Nil
 
   def validatePostalCode(in: ValueType): List[FieldError] = country.value match {
-    case Countries.USA       => valRegex(RegexPattern.compile("[0-9]{5}(\\-[0-9]{4})?"), S.??("invalid.zip.code"))(in)
-    case Countries.Sweden    => valRegex(RegexPattern.compile("[0-9]{3}[ ]?[0-9]{2}"), S.??("invalid.postal.code"))(in)
-    case Countries.Australia => valRegex(RegexPattern.compile("(0?|[1-9])[0-9]{3}"), S.??("invalid.postal.code"))(in)
-    case Countries.Canada    => valRegex(RegexPattern.compile("[A-Z][0-9][A-Z][ ][0-9][A-Z][0-9]"), S.??("invalid.postal.code"))(in)
+    case Countries.USA       => valRegex(RegexPattern.compile("[0-9]{5}(\\-[0-9]{4})?"), S.?("invalid.zip.code"))(in)
+    case Countries.Sweden    => valRegex(RegexPattern.compile("[0-9]{3}[ ]?[0-9]{2}"), S.?("invalid.postal.code"))(in)
+    case Countries.Australia => valRegex(RegexPattern.compile("(0?|[1-9])[0-9]{3}"), S.?("invalid.postal.code"))(in)
+    case Countries.Canada    => valRegex(RegexPattern.compile("[A-Z][0-9][A-Z][ ][0-9][A-Z][0-9]"), S.?("invalid.postal.code"))(in)
     case _ => genericCheck(in)
   }
 
   private def genericCheck(zip: ValueType): List[FieldError] = {
     toBoxMyType(zip) flatMap {
-      case null => Full(Text(S.??("invalid.postal.code")))
-      case s if s.length < 3 => Full(Text(S.??("invalid.postal.code")))
+      case null => Full(Text(S.?("invalid.postal.code")))
+      case s if s.length < 3 => Full(Text(S.?("invalid.postal.code")))
       case _ => Empty
     }
   }

--- a/persistence/record/src/test/scala/net/liftweb/record/FieldSpec.scala
+++ b/persistence/record/src/test/scala/net/liftweb/record/FieldSpec.scala
@@ -411,7 +411,7 @@ object FieldSpec extends Specification("Record Field Specification") {
       val rec = PasswordTestRecord.createRecord.password("")
 
       rec.validate must_== (
-        FieldError(rec.password, Text(S.??("password.must.be.set"))) ::
+        FieldError(rec.password, Text(S.?("password.must.be.set"))) ::
         Nil
       )
     }
@@ -422,7 +422,7 @@ object FieldSpec extends Specification("Record Field Specification") {
       
       rec.password("1234")
       rec.validate must_== (
-        FieldError(rec.password, Text(S.??("password.too.short"))) ::
+        FieldError(rec.password, Text(S.?("password.too.short"))) ::
         Nil
       )
     }

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -797,7 +797,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * The default action to take when the JavaScript action fails
    */
   @volatile var ajaxDefaultFailure: Box[() => JsCmd] =
-  Full(() => JsCmds.Alert(S.??("ajax.error")))
+  Full(() => JsCmds.Alert(S.?("ajax.error")))
 
   /**
    * A function that takes the current HTTP request and returns the current

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
@@ -102,11 +102,11 @@ trait AbstractScreen extends Factory {
   def screenTitle: NodeSeq = screenNameAsHtml
 
   def cancelButton: Elem = <button>
-    {S.??("Cancel")}
+    {S.?("Cancel")}
   </button>
 
   def finishButton: Elem = <button>
-    {S.??("Finish")}
+    {S.?("Finish")}
   </button>
 
 

--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -491,14 +491,14 @@ trait SHtml {
 
     def displayMarkup : NodeSeq =
       displayContents ++ Text(" ") ++
-      <input value={S.??("edit")} type="button" onclick={setAndSwap(editName, editMarkup, dispName).toJsCmd + " return false;"} />
+      <input value={S.?("edit")} type="button" onclick={setAndSwap(editName, editMarkup, dispName).toJsCmd + " return false;"} />
 
     def editMarkup : NodeSeq = {
       val formData : NodeSeq =
         editForm ++
-        <input type="submit" value={S.??("ok")} /> ++
+        <input type="submit" value={S.?("ok")} /> ++
         hidden(onSubmit) ++
-        <input type="button" onclick={swapJsCmd(dispName,editName).toJsCmd + " return false;"} value={S.??("cancel")} />
+        <input type="button" onclick={swapJsCmd(dispName,editName).toJsCmd + " return false;"} value={S.?("cancel")} />
 
       ajaxForm(formData,
                Noop,

--- a/web/wizard/src/main/scala/net/liftweb/wizard/Wizard.scala
+++ b/web/wizard/src/main/scala/net/liftweb/wizard/Wizard.scala
@@ -347,19 +347,19 @@ trait Wizard extends StatefulSnippet with Factory with ScreenWizardRendered {
   def calcFirstScreen: Box[Screen] = screens.headOption
 
   def nextButton: Elem = <button>
-    {S.??("Next")}
+    {S.?("Next")}
   </button>
 
   def prevButton: Elem = <button>
-    {S.??("Previous")}
+    {S.?("Previous")}
   </button>
 
   def cancelButton: Elem = <button>
-    {S.??("Cancel")}
+    {S.?("Cancel")}
   </button>
 
   def finishButton: Elem = <button>
-    {S.??("Finish")}
+    {S.?("Finish")}
   </button>
 
   def currentScreen: Box[Screen] = CurrentScreen.is

--- a/web/wizard/src/test/scala/net/liftweb/wizard/WizardSpec.scala
+++ b/web/wizard/src/test/scala/net/liftweb/wizard/WizardSpec.scala
@@ -41,25 +41,25 @@ object WizardSpec extends Specification("Wizard Specification") {
 
     val nameAndAge = new Screen {
       val name = field(S ? "First Name", "",
-                       valMinLen(2, S ?? "Name Too Short"))
+                       valMinLen(2, S ? "Name Too Short"))
 
       val age = field(S ? "Age", 0,
-                      minVal(5, S ?? "Too young"),
-                      maxVal(120, S ?? "You should be dead"))
+                      minVal(5, S ? "Too young"),
+                      maxVal(120, S ? "You should be dead"))
 
       override def nextScreen = if (age.is < 18) parentName else favoritePet
     }
 
     val parentName = new Screen {
       val parentName = field(S ? "Mom or Dad's name", "",
-                             valMinLen(2, S ?? "Name Too Short"),
-                             valMaxLen(40, S ?? "Name Too Long"))
+                             valMinLen(2, S ? "Name Too Short"),
+                             valMaxLen(40, S ? "Name Too Long"))
     }
 
     val favoritePet = new Screen {
       val petName = field(S ? "Pet's name", "",
-                          valMinLen(2, S ?? "Name Too Short"),
-                          valMaxLen(40, S ?? "Name Too Long"))
+                          valMinLen(2, S ? "Name Too Short"),
+                          valMaxLen(40, S ? "Name Too Long"))
     }
   }
 


### PR DESCRIPTION
After I rebase #1233 Unify resource lookup using S.?? and S:.? into master, we are going to get a lot of warnings where we use S.??

This issue is to change all those areas to use S.?  instead.
