### PR TITLE
LiftScreen buttons are not localized

### DIFF
--- a/web/webkit/src/main/resources/i18n/lift-core.properties
+++ b/web/webkit/src/main/resources/i18n/lift-core.properties
@@ -346,3 +346,20 @@ country_269 = Ross Dependency
 country_270 = Peter I Island
 country_271 = Queen Maud Land
 country_272 = British Antarctic Territory
+# LiftScreen + Wizard
+Next = Next
+Previous = Previous
+Finish = Finish
+Cancel = Cancel
+
+# Crudify
+Create = Create
+Save = Save
+Edit = Edit
+Delete = Delete
+delete = delete
+View = View
+List = List %s
+Created = Created
+Edited = Edited
+Deleted = Deleted

--- a/web/webkit/src/main/resources/i18n/lift-core_de.properties
+++ b/web/webkit/src/main/resources/i18n/lift-core_de.properties
@@ -343,3 +343,21 @@ country_269 = Ross-Nebengebiet
 country_270 = Peter-I.-Insel
 country_271 = Königin-Maud-Land
 country_272 = Britisches Antarktis-Territorium
+
+# Liftscreen + Wizard
+Next = Weiter
+Previous = Zurück
+Finish = Fertig
+Cancel = Abbrechen
+
+# Crudify
+Create = Erstellen
+Save = Speichern
+Edit = Bearbeiten
+Delete = Löschen
+delete = löschen
+View = Zeige
+List = Alle %s anzeigen
+Created = Erstellt
+Edited = Bearbeitet
+Deleted = Gelöscht

--- a/web/webkit/src/main/resources/i18n/lift-core_en_AU.properties
+++ b/web/webkit/src/main/resources/i18n/lift-core_en_AU.properties
@@ -336,3 +336,22 @@ country_269 = Ross Dependency
 country_270 = Peter I Island
 country_271 = Queen Maud Land
 country_272 = British Antarctic Territory
+
+
+# LiftScreen + Wizard
+Next = Next
+Previous = Previous
+Finish = Finish
+Cancel = Cancel
+
+# Crudify
+Create = Create
+Save = Save
+Edit = Edit
+Delete = Delete
+delete = delete
+View = View
+List = List %s
+Created = Created
+Edited = Edited
+Deleted = Deleted

--- a/web/webkit/src/main/resources/i18n/lift-core_en_US.properties
+++ b/web/webkit/src/main/resources/i18n/lift-core_en_US.properties
@@ -336,3 +336,21 @@ country_269 = Ross Dependency
 country_270 = Peter I Island
 country_271 = Queen Maud Land
 country_272 = British Antarctic Territory
+
+# LiftScreen + Wizard
+Next = Next
+Previous = Previous
+Finish = Finish
+Cancel = Cancel
+
+# Crudify
+Create = Create
+Save = Save
+Edit = Edit
+Delete = Delete
+delete = delete
+View = View
+List = List  %s
+Created = Created
+Edited = Edited
+Deleted = Deleted

--- a/web/webkit/src/main/resources/i18n/lift-core_fr.properties
+++ b/web/webkit/src/main/resources/i18n/lift-core_fr.properties
@@ -362,3 +362,21 @@ country_269 = D\u00e9pendance de Ross
 country_270 = \u00cele Pierre Ier
 country_271 = Terre de la Reine-Maud
 country_272 = Territoire antarctique britannique
+
+# Liftscreen + Wizard
+Next = Suivant
+Previous = Pr\u00e9c\u00e9dent
+Finish = Finir
+Cancel = Annuler
+
+# Crudify
+Create = Cr\u00e9er
+Save = Sauvegarder
+Edit = \u00e9diter
+Delete = Supprimer
+delete = supprimer
+View = Voir
+List = Lister %s
+Created = Cr\u00e9 \u00e9
+Edited = \u00e9dit\u00e9
+Deleted = Supprim\u00e9

--- a/web/webkit/src/main/resources/i18n/lift-core_it.properties
+++ b/web/webkit/src/main/resources/i18n/lift-core_it.properties
@@ -336,3 +336,23 @@ country_269 = Ross Dependency
 country_270 = Isola Peter I
 country_271 = Terra della Regina Maud
 country_272 = Territorio Antarcico Inglese
+
+# LiftScreen + Wizard
+Next = Prossimo
+Previous = Precedente
+Finish = Finisci
+Cancel = Annulla
+
+# Crudify
+Create = Crea
+Save = Salva
+
+Edit = Modifica
+Delete = Cancella
+delete = cancella
+
+View = Vista
+List = Lista %s
+Created = Creato
+Edited = Modificato
+Deleted = Cancellato

--- a/web/webkit/src/main/resources/i18n/lift-core_it_IT.properties
+++ b/web/webkit/src/main/resources/i18n/lift-core_it_IT.properties
@@ -336,3 +336,21 @@ country_269 = Ross Dependency
 country_270 = Isola Peter I
 country_271 = Terra della Regina Maud
 country_272 = Territorio Antarcico Inglese
+
+# LiftScreen + Wizard
+Next = Prossimo
+Previous = Precedente
+Finish = Finisci
+Cancel = Annulla
+
+# Crudify
+Create = Crea
+Save = Salva
+Edit = Modifica
+Delete = Cancella
+delete = cancella
+View = Vista
+List = Lista %s
+Created = Creato
+Edited = Modificato
+Deleted = Cancellato

--- a/web/webkit/src/main/resources/i18n/lift-core_nl.properties
+++ b/web/webkit/src/main/resources/i18n/lift-core_nl.properties
@@ -333,3 +333,21 @@ country_269 = Ross Dependency
 country_270 = Peter I-eiland
 country_271 = Koningin Maudland
 country_272 = Brits Antarctisch Territorium
+
+# LiftScreen + Wizard
+Next = Volgende
+Previous = Vorige
+Finish = Voltooien
+Cancel = Annuleren
+
+# Crudify
+Create = Aanmaken
+Save = Opslaan
+Edit = Bewerken
+Delete = Verwijderen
+delete = verwijderen
+View = Afbeelden
+List = Lijst %s
+Created = Aangemaakt
+Edited = Gewijzigd
+Deleted = Verwijderd

--- a/web/webkit/src/main/resources/i18n/lift-core_nl_NL.properties
+++ b/web/webkit/src/main/resources/i18n/lift-core_nl_NL.properties
@@ -333,3 +333,21 @@ country_269 = Ross Dependency
 country_270 = Peter I-eiland
 country_271 = Koningin Maudland
 country_272 = Brits Antarctisch Territorium
+
+# LiftScreen + Wizard
+Next = Volgende
+Previous = Vorige
+Finish = Voltooien
+Cancel = Annuleren
+
+# Crudify
+Create = Aanmaken
+Save = Opslaan
+Edit = Bewerken
+Delete = Verwijderen
+delete = verwijderen
+View = Afbeelden
+List = Lijst %s
+Created = Aangemaakt
+Edited = Gewijzigd
+Deleted = Verwijderd


### PR DESCRIPTION
LiftScreen's default button implementation uses S.??("Cancel") and S.??("Finish") but Cancel and Finish are not listed in lift's localization files. So if we overload LiftRules.localizationLookupFailureNotice to log notices to error log then errors are generated.

https://groups.google.com/d/topic/liftweb/R73Dx-ubONw/discussion
