### PR TITLE
ajaxSubmit actions are not re-invoked when retries occur

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/js/ScriptRenderer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/ScriptRenderer.scala
@@ -163,6 +163,7 @@ object ScriptRenderer {
                var theData = aboutToSend.theData;
                if (liftAjax.lift_uriSuffix) {
                  theData += '&' + liftAjax.lift_uriSuffix;
+                 aboutToSend.theData = theData;
                  liftAjax.lift_uriSuffix = undefined;
                }
                liftAjax.lift_actualAjaxCall(theData, successFunc, failureFunc);


### PR DESCRIPTION
See the discussion here: https://groups.google.com/d/msg/liftweb/q21dIosJ_oY/p3WgQDeEMmAJ

Because buttons aren't serialized with the rest of a form's fields, Lift sets a global liftAjax.lift_uriSuffix variable to the function id of the button that was clicked.  Currently, that value is only sent during the first request and isn't stored with the rest of the form data for use during a retry.  I've got a fix coming today to take care of that.
