### PR TITLE
change all deprecated messages to be 2.9.x compatible

### DIFF
--- a/core/common/src/main/scala/net/liftweb/common/Box.scala
+++ b/core/common/src/main/scala/net/liftweb/common/Box.scala
@@ -106,7 +106,7 @@ sealed trait BoxTrait {
    * 
    * @return <code>Full(in)</code> if <code>in</code> is not null; Empty otherwise
    */
-  @deprecated("Use legacyNullTest")
+  @deprecated("Use legacyNullTest", "2.5")
   def apply[T](in: T): Box[T] = legacyNullTest(in)
 
   /**
@@ -192,8 +192,7 @@ sealed trait BoxTrait {
  *   <li> you can "pass" a Box to a function for side effects: <code>Full(1) $ { x: Box[Int] => println(x openOr 0) }</code></li>
  * </ul>
  */
-@serializable
-sealed abstract class Box[+A] extends Product {
+sealed abstract class Box[+A] extends Product with Serializable{
   self =>
   /**
    * Returns true if this Box contains no value (is Empty or Failure or ParamFailure)
@@ -472,8 +471,7 @@ sealed abstract class Box[+A] extends Product {
 /**
  * Full is a Box containing a value.
  */
-@serializable
-final case class Full[+A](value: A) extends Box[A] {
+final case class Full[+A](value: A) extends Box[A]{
 
   def isEmpty: Boolean = false
 
@@ -551,14 +549,12 @@ final case class Full[+A](value: A) extends Box[A] {
 /**
  * Singleton object representing an Empty Box
  */
-@serializable
 case object Empty extends EmptyBox
 
 /**
  * The EmptyBox is a Box containing no value.
  */
-@serializable
-sealed abstract class EmptyBox extends Box[Nothing] {
+sealed abstract class EmptyBox extends Box[Nothing] with Serializable {
 
   def isEmpty: Boolean = true
 
@@ -600,8 +596,7 @@ object Failure {
  * A Failure is an EmptyBox with an additional failure message explaining the reason for its being empty.
  * It can also optionally provide an exception or a chain of causes represented as a list of other Failure objects
  */
-@serializable
-sealed case class Failure(msg: String, exception: Box[Throwable], chain: Box[Failure]) extends EmptyBox {
+sealed case class Failure(msg: String, exception: Box[Throwable], chain: Box[Failure]) extends EmptyBox{
   type A = Nothing
 
   /**
@@ -683,11 +678,10 @@ sealed case class Failure(msg: String, exception: Box[Throwable], chain: Box[Fai
  * A ParamFailure is a Failure with an additional typesafe parameter that can
  * allow an application to store other information related to the failure.
  */
-@serializable
 final class ParamFailure[T](override val msg: String,
 		            override val exception: Box[Throwable],
 		            override val chain: Box[Failure], val param: T) extends
-  Failure(msg, exception, chain) {
+  Failure(msg, exception, chain) with Serializable{
     override def toString(): String = "ParamFailure("+msg+", "+exception+
     ", "+chain+", "+param+")"
 

--- a/core/common/src/main/scala/net/liftweb/common/HList.scala
+++ b/core/common/src/main/scala/net/liftweb/common/HList.scala
@@ -101,7 +101,7 @@ sealed trait ExcludeThisType[A, B]
  * that a type is not a subtype of another type
  */
 object ExcludeThisType {
-  def unexpected: Nothing = error("Unexpected invocation")
+  def unexpected: Nothing = sys.error("Unexpected invocation")
 
   // Uses ambiguity to rule out the cases we're trying to exclude
   implicit def nsub[A, B]: A ExcludeThisType B = null

--- a/core/common/src/main/scala/net/liftweb/common/ParseDouble.scala
+++ b/core/common/src/main/scala/net/liftweb/common/ParseDouble.scala
@@ -27,7 +27,7 @@ package common
  *
  * @see http://blogs.oracle.com/security/entry/security_alert_for_cve-2010-44
  */
-@deprecated("Use a newer or patched JVM instead.")
+@deprecated("Use a newer or patched JVM instead.", "2.5")
 object ParseDouble {
   private val BrokenDouble = BigDecimal("2.2250738585072012e-308")
 

--- a/core/json/benchmark/Serbench.scala
+++ b/core/json/benchmark/Serbench.scala
@@ -41,12 +41,8 @@ object Serbench extends Benchmark {
     }
   }
 
-  @serializable
-  case class Project(name: String, startDate: Date, lang: Option[Language], teams: List[Team])
-  @serializable
-  case class Language(name: String, version: Double)
-  @serializable
-  case class Team(role: String, members: List[Employee])
-  @serializable
-  case class Employee(name: String, experience: Int)
+  case class Project(name: String, startDate: Date, lang: Option[Language], teams: List[Team]) extends Serializable
+  case class Language(name: String, version: Double) extends Serializable
+  case class Team(role: String, members: List[Employee]) extends Serializable
+  case class Employee(name: String, experience: Int) extends Serializable
 }

--- a/core/json/src/main/scala/net/liftweb/json/Formats.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Formats.scala
@@ -166,7 +166,7 @@ trait TypeHints {
      * Chooses most specific class.
      */
     def hintFor(clazz: Class[_]): String = components.filter(_.containsHint_?(clazz))
-        .map(th => (th.hintFor(clazz), th.classFor(th.hintFor(clazz)).getOrElse(error("hintFor/classFor not invertible for " + th))))
+        .map(th => (th.hintFor(clazz), th.classFor(th.hintFor(clazz)).getOrElse(sys.error("hintFor/classFor not invertible for " + th))))
         .sort((x, y) => (delta(x._2, clazz) - delta(y._2, clazz)) < 0).head._1
 
     def classFor(hint: String): Option[Class[_]] = {
@@ -197,7 +197,7 @@ private[json] object ClassDelta {
     else if (class2.isAssignableFrom(class1)) {
       1 + delta(class1.getSuperclass, class2)
     }
-    else error("Don't call delta unless one class is assignable from the other")
+    else sys.error("Don't call delta unless one class is assignable from the other")
   }
 }
 
@@ -205,7 +205,7 @@ private[json] object ClassDelta {
  */
 case object NoTypeHints extends TypeHints {
   val hints = Nil
-  def hintFor(clazz: Class[_]) = error("NoTypeHints does not provide any type hints.")
+  def hintFor(clazz: Class[_]) = sys.error("NoTypeHints does not provide any type hints.")
   def classFor(hint: String) = None
 }
 

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -396,7 +396,7 @@ object JsonAST {
     case JDouble(n)    => text(n.toString)
     case JInt(n)       => text(n.toString)
     case JNull         => text("null")
-    case JNothing      => error("can't render 'nothing'")
+    case JNothing      => sys.error("can't render 'nothing'")
     case JString(null) => text("null")
     case JString(s)    => text("\"" + quote(s) + "\"")
     case JArray(arr)   => text("[") :: series(trimArr(arr).map(render)) :: text("]")

--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -134,7 +134,7 @@ object JsonParser {
   private val BrokenDouble = BigDecimal("2.2250738585072012e-308")
   private[json] def parseDouble(s: String) = {
     val d = BigDecimal(s)
-    if (d == BrokenDouble) error("Error parsing 2.2250738585072012e-308")
+    if (d == BrokenDouble) sys.error("Error parsing 2.2250738585072012e-308")
     else d.doubleValue
   }
 

--- a/core/json/src/main/scala/net/liftweb/json/Meta.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Meta.scala
@@ -394,7 +394,7 @@ private[json] object Meta {
       case x: java.lang.Short => JInt(BigInt(x.asInstanceOf[Short]))
       case x: Date => JString(formats.dateFormat.format(x))
       case x: Symbol => JString(x.name)
-      case _ => error("not a primitive " + a.asInstanceOf[AnyRef].getClass)
+      case _ => sys.error("not a primitive " + a.asInstanceOf[AnyRef].getClass)
     }
   }
 }

--- a/core/util/src/main/scala/net/liftweb/util/BindHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/BindHelpers.scala
@@ -708,7 +708,7 @@ trait BindHelpers {
   /**
    *  transforms a Box into a Text node
    */
-  @deprecated("use -> instead")
+  @deprecated("use -> instead", "2.4")
   object BindParamAssoc {
     implicit def canStrBoxNodeSeq(in: Box[Any]): Box[NodeSeq] = in.map(_ match {
       case null => Text("null")
@@ -789,7 +789,7 @@ trait BindHelpers {
    *
    * @deprecated use -> instead
    */
-  @deprecated("use -> instead")
+  @deprecated("use -> instead", "2.4")
   class BindParamAssoc(val name: String) {
     def -->(value: String): BindParam = TheBindParam(name, if (null eq value) NodeSeq.Empty else Text(value))
     def -->(value: NodeSeq): BindParam = TheBindParam(name, value)
@@ -812,7 +812,7 @@ trait BindHelpers {
    *
    * @deprecated use -> instead
    */
-  @deprecated("use -> instead")
+  @deprecated("use -> instead", "2.4")
   implicit def strToBPAssoc(in: String): BindParamAssoc = new BindParamAssoc(in)
 
   /**
@@ -822,7 +822,7 @@ trait BindHelpers {
    *
    * @deprecated use -> instead
    */
-  @deprecated("use -> instead")
+  @deprecated("use -> instead", "2.4")
   implicit def symToSAAssoc(in: Symbol): SuperArrowAssoc = new SuperArrowAssoc(in.name)
 
   /**
@@ -831,7 +831,7 @@ trait BindHelpers {
    *
    * @deprecated use bind instead
    */
-  @deprecated("use bind instead")
+  @deprecated("use bind instead", "2.4")
   def xbind(namespace: String, xml: NodeSeq)(transform: PartialFunction[String, NodeSeq => NodeSeq]): NodeSeq = {
     def rec_xbind(xml: NodeSeq): NodeSeq = {
       xml.flatMap {
@@ -1133,7 +1133,7 @@ trait BindHelpers {
    * @param atWhat data to bind
    * @deprecated use the bind function instead
    */
-  @deprecated("use the bind function instead")
+  @deprecated("use the bind function instead", "2.3")
   def processBind(around: NodeSeq, atWhat: Map[String, NodeSeq]): NodeSeq = {
 
     /** Find element matched predicate f(x).isDefined, and return f(x) if found or None otherwise. */

--- a/core/util/src/main/scala/net/liftweb/util/ClassHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/ClassHelpers.scala
@@ -151,9 +151,12 @@ trait ClassHelpers { self: ControlHelpers =>
   def findClass(where: List[(String, List[String])]): Box[Class[AnyRef]] =
   findType[AnyRef](where)
 
-  @deprecated("Use StringHelpers.camelify") def camelCase(name : String): String = StringHelpers.camelify(name)
-  @deprecated("Use StringHelpers.camelifyMethod") def camelCaseMethod(name: String): String = StringHelpers.camelifyMethod(name)
-  @deprecated("Use StringHelpers.snakify") def unCamelCase(name : String) = StringHelpers.snakify(name)
+  @deprecated("Use StringHelpers.camelify", "2.3")
+  def camelCase(name : String): String = StringHelpers.camelify(name)
+  @deprecated("Use StringHelpers.camelifyMethod", "2.3")
+  def camelCaseMethod(name: String): String = StringHelpers.camelifyMethod(name)
+  @deprecated("Use StringHelpers.snakify", "2.3")
+  def unCamelCase(name : String) = StringHelpers.snakify(name)
 
   /**
    * @return true if the method is public and has no parameters

--- a/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala
@@ -364,7 +364,7 @@ trait StringHelpers {
   /** @return a SuperString with more available methods such as roboSplit or commafy */
   implicit def listStringToSuper(in: List[String]): SuperListString = new SuperListString(in)
 
-  @deprecated("Use blankForNull instead")
+  @deprecated("Use blankForNull instead", "2.3")
   def emptyForNull(s: String) = blankForNull(s)
 
   /**

--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -295,9 +295,9 @@ trait TimeHelpers { self: ControlHelpers =>
   def currentYear: Int = Calendar.getInstance.get(Calendar.YEAR)
 
   /**
-   * @deprecated use now instead
    * @return the current time as a Date object
    */
+  @deprecated("use now instead", "2.4")
   def timeNow = new Date
 
   /**

--- a/core/util/src/main/scala/net/liftweb/util/ValueHolder.scala
+++ b/core/util/src/main/scala/net/liftweb/util/ValueHolder.scala
@@ -25,7 +25,7 @@ trait ValueHolder {
    *
    * @deprecated
    */
-  @deprecated("Use get")
+  @deprecated("Use get", "2.4")
   def is: ValueType
 
   /**

--- a/core/util/src/main/scala/net/liftweb/util/package.scala
+++ b/core/util/src/main/scala/net/liftweb/util/package.scala
@@ -26,6 +26,6 @@ package object util {
   /**
    * Changed the name ActorPing to Schedule
    */
-  @deprecated("Use Schedule")
+  @deprecated("Use Schedule", "2.3")
   val ActorPing = Schedule
 }

--- a/persistence/db/src/main/scala/net/liftweb/db/DB.scala
+++ b/persistence/db/src/main/scala/net/liftweb/db/DB.scala
@@ -147,7 +147,7 @@ trait DB extends Loggable {
    * perform this function after transaction has ended.  This is helpful for sending messages to Actors after we know
    * a transaction has been either committed or rolled back
    */
-  @deprecated("Use appendPostTransaction {committed => ...}")
+  @deprecated("Use appendPostTransaction {committed => ...}", "2.4")
   def performPostCommit(f: => Unit) {
     postCommit = (() => f) :: postCommit
   }
@@ -326,7 +326,7 @@ trait DB extends Loggable {
   /**
    *  Append a function to be invoked after the transaction has ended for the given connection identifier
    */
-  @deprecated("Use appendPostTransaction (name, {committed => ...})")
+  @deprecated("Use appendPostTransaction (name, {committed => ...})", "2.4")
   def appendPostFunc(name: ConnectionIdentifier, func: () => Unit) {
     appendPostTransaction(name, dontUse => func())
   }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedField.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedField.scala
@@ -66,8 +66,7 @@ trait MixableMappedField extends BaseField {
  * The base (not Typed) trait that defines a field that is mapped to a column or more than 1 column
  * (e.g., MappedPassword) in the database
  */
-@serializable
-trait BaseMappedField extends SelectableField with Bindable with MixableMappedField {
+trait BaseMappedField extends SelectableField with Bindable with MixableMappedField with Serializable{
 
   def dbDisplay_? = true
 
@@ -695,7 +694,7 @@ trait MappedField[FieldType <: Any,OwnerType <: Mapper[OwnerType]] extends Typed
 }
 
 object MappedField {
-  @deprecated("Automatic conversion to the field's type is not safe and will be removed. Please use field.get instead")
+  @deprecated("Automatic conversion to the field's type is not safe and will be removed. Please use field.get instead", "2.5")
   implicit def mapToType[T, A<:Mapper[A]](in : MappedField[T, A]): T = in.is
 }
 

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedForeignKey.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedForeignKey.scala
@@ -210,12 +210,12 @@ with LifecycleCallbacks {
 }
 
 
-@deprecated("Functionality folded into MappedForeignKey, so just use MappedLongForeignKey. Will be removed in 2.5")
+@deprecated("Functionality folded into MappedForeignKey, so just use MappedLongForeignKey. Will be removed in 2.5", "2.4")
 class LongMappedMapper[T<:Mapper[T], O<:KeyedMapper[Long,O]](theOwner: T, foreign: => KeyedMetaMapper[Long, O])
   extends MappedLongForeignKey[T,O](theOwner, foreign)
 
 
-@deprecated("Functionality folded into MappedForeignKey, so just use MappedLongForeignKey. Will be removed in 2.5")
+@deprecated("Functionality folded into MappedForeignKey, so just use MappedLongForeignKey. Will be removed in 2.5", "2.4")
 trait LongMappedForeignMapper[T<:Mapper[T],O<:KeyedMapper[Long,O]]
                               extends MappedLongForeignKey[T,O]
 
@@ -226,7 +226,7 @@ extends MappedLong[T](theOwner) with MappedForeignKey[Long,T,O] with BaseForeign
 
   def foreignMeta = _foreignMeta
 
-  @deprecated("Use 'box' instead")
+  @deprecated("Use 'box' instead", "2.4")
   def can: Box[Long] = if (defined_?) Full(is) else Empty
 
   def box: Box[Long] = if (defined_?) Full(is) else Empty

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedString.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedString.scala
@@ -52,7 +52,7 @@ trait ValidateLength extends MixableMappedField {
 }
 
 trait HasApplyBoxString[T] {
-  @deprecated("Just use apply(x openOr null). Will be removed in 2.5.")
+  @deprecated("Just use apply(x openOr null). Will be removed in 2.5.", "2.4")
   def apply(ov: Box[String])(implicit disambiguateFromApplyBoxedForeign: BoxedStringToken): T = apply(ov openOr null)
   def apply(x: String): T
 }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedUniqueId.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedUniqueId.scala
@@ -35,10 +35,10 @@ abstract class MappedUniqueId[T<:Mapper[T]](override val fieldOwner: T, override
   * A field that holds the birth year for the user
   */
 abstract class MappedBirthYear[T <: Mapper[T]](owner: T, minAge: Int) extends MappedInt[T](owner) {
-  override def defaultValue = year(timeNow) - minAge
+  override def defaultValue = year(now) - minAge
 
   override def _toForm: Box[NodeSeq] = {
-    val end = (year(timeNow) - minAge)
+    val end = (year(now) - minAge)
     val start = end - 100
     Full(SHtml.selectObj((start to end).
 		  toList.

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/Mapper.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/Mapper.scala
@@ -32,8 +32,7 @@ trait BaseMapper extends FieldContainer {
   def save: Boolean
 }
 
-@serializable
-trait Mapper[A<:Mapper[A]] extends BaseMapper {
+trait Mapper[A<:Mapper[A]] extends BaseMapper with Serializable{
   self: A =>
   type MapperType = A
 

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoUser.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoUser.scala
@@ -78,7 +78,7 @@ trait ProtoUser[T <: ProtoUser[T]] extends KeyedMapper[Long, T] with UserIdAsStr
   /**
    * The string name for the first name field
    */
-  def firstNameDisplayName = ??("first.name")
+  def firstNameDisplayName = S.?("first.name")
 
   /**
    * The last field for the User.  You can override the behavior
@@ -99,7 +99,7 @@ trait ProtoUser[T <: ProtoUser[T]] extends KeyedMapper[Long, T] with UserIdAsStr
   /**
    * The last name string
    */
-  def lastNameDisplayName = ??("last.name")
+  def lastNameDisplayName = S.?("last.name")
 
   /**
    * The email field for the User.  You can override the behavior
@@ -122,7 +122,7 @@ trait ProtoUser[T <: ProtoUser[T]] extends KeyedMapper[Long, T] with UserIdAsStr
   /**
    * The email first name
    */
-  def emailDisplayName = ??("email.address")
+  def emailDisplayName = S.?("email.address")
 
   /**
    * The password field for the User.  You can override the behavior
@@ -142,7 +142,7 @@ trait ProtoUser[T <: ProtoUser[T]] extends KeyedMapper[Long, T] with UserIdAsStr
   /**
    * The display name for the password field
    */
-  def passwordDisplayName = ??("password")
+  def passwordDisplayName = S.?("password")
 
   /**
    * The superuser field for the User.  You can override the behavior
@@ -422,12 +422,12 @@ trait MegaProtoUser[T <: MegaProtoUser[T]] extends ProtoUser[T] {
   /**
    * The string for the timezone field
    */
-  def timezoneDisplayName = ??("time.zone")
+  def timezoneDisplayName = S.?("time.zone")
 
   /**
    * The string for the locale field
    */
-  def localeDisplayName = ??("locale")
+  def localeDisplayName = S.?("locale")
 
 }
 

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/package.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/package.scala
@@ -27,6 +27,6 @@ package object mapper {
   def DefaultConnectionIdentifier = db.DefaultConnectionIdentifier
   def DriverType = db.DriverType
 
-  @deprecated("Use util.Safe instead.")
+  @deprecated("Use util.Safe instead.", "2.4")
   def Safe = util.Safe
 }

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JObjectParser.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JObjectParser.scala
@@ -124,7 +124,7 @@ object JObjectParser extends SimpleInjector {
       case JInt(n) => renderInteger(n)
       case JDouble(n) => new java.lang.Double(n)
       case JNull => null
-      case JNothing => error("can't render 'nothing'")
+      case JNothing => sys.error("can't render 'nothing'")
       case JString(null) => "null"
       case JString(s) => stringProcessor.vend(s)
       case _ =>  ""

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Meta.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Meta.scala
@@ -65,7 +65,7 @@ private[mongodb] object Meta {
       case x: java.lang.Byte => JInt(BigInt(x.asInstanceOf[Byte]))
       case x: java.lang.Boolean => JBool(x.asInstanceOf[Boolean])
       case x: java.lang.Short => JInt(BigInt(x.asInstanceOf[Short]))
-      case _ => error("not a primitive " + a.asInstanceOf[AnyRef].getClass)
+      case _ => sys.error("not a primitive " + a.asInstanceOf[AnyRef].getClass)
     }
 
     /*
@@ -100,8 +100,8 @@ private[mongodb] object Meta {
       case x: ObjectId => objectIdAsJValue(x, formats)
       case x: Pattern => patternAsJValue(x)
       case x: UUID => uuidAsJValue(x)
-      case x: DBRef => error("DBRefs are not supported.")
-      case _ => error("not a mongotype " + a.asInstanceOf[AnyRef].getClass)
+      case x: DBRef => sys.error("DBRefs are not supported.")
+      case _ => sys.error("not a mongotype " + a.asInstanceOf[AnyRef].getClass)
     }
   }
 

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Mongo.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Mongo.scala
@@ -68,7 +68,7 @@ object MongoHost {
 /*
 * Wrapper for creating a Replica Pair
 */
-@deprecated("Use `MongoSet` with `List[ServerAddress]` as argument instead")
+@deprecated("Use `MongoSet` with `List[ServerAddress]` as argument instead", "2.5")
 case class MongoPair(left: ServerAddress, right: ServerAddress, options: MongoOptions = new MongoOptions) extends MongoHostBase {
   lazy val mongo = new Mongo(left, right, options)
 }

--- a/persistence/record/src/main/scala/net/liftweb/record/ProtoUser.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/ProtoUser.scala
@@ -77,7 +77,7 @@ trait ProtoUser[T <: ProtoUser[T]] extends Record[T] {
   /**
    * The string name for the first name field
    */
-  def firstNameDisplayName = ??("first.name")
+  def firstNameDisplayName = S.?("first.name")
 
   /**
    * The last field for the User.  You can override the behavior
@@ -98,7 +98,7 @@ trait ProtoUser[T <: ProtoUser[T]] extends Record[T] {
   /**
    * The last name string
    */
-  def lastNameDisplayName = ??("last.name")
+  def lastNameDisplayName = S.?("last.name")
 
   /**
    * The email field for the User.  You can override the behavior
@@ -122,7 +122,7 @@ trait ProtoUser[T <: ProtoUser[T]] extends Record[T] {
   /**
    * The email first name
    */
-  def emailDisplayName = ??("email.address")
+  def emailDisplayName = S.?("email.address")
 
   /**
    * The password field for the User.  You can override the behavior
@@ -142,7 +142,7 @@ trait ProtoUser[T <: ProtoUser[T]] extends Record[T] {
   /**
    * The display name for the password field
    */
-  def passwordDisplayName = ??("password")
+  def passwordDisplayName = S.?("password")
 
   /**
    * The superuser field for the User.  You can override the behavior
@@ -419,12 +419,12 @@ trait MegaProtoUser[T <: MegaProtoUser[T]] extends ProtoUser[T] {
   /**
    * The string for the timezone field
    */
-  def timezoneDisplayName = ??("time.zone")
+  def timezoneDisplayName = S.?("time.zone")
 
   /**
    * The string for the locale field
    */
-  def localeDisplayName = ??("locale")
+  def localeDisplayName = S.?("locale")
 
 }
 

--- a/persistence/record/src/main/scala/net/liftweb/record/RecordHelpers.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/RecordHelpers.scala
@@ -29,7 +29,7 @@ object RecordHelpers {
       case JArray(vs)  => JsArray(vs.map(jvalueToJsExp): _*)
       case JBool(b)    => if (b) JsTrue else JsFalse
       case JDouble(d)  => Num(d)
-      case JField(n,v) => error("no parallel")
+      case JField(n,v) => sys.error("no parallel")
       case JInt(i)     => Num(i)
       case JNothing    => JsNull
       case JNull       => JsNull

--- a/persistence/squeryl-record/src/main/scala/net/liftweb/squerylrecord/SquerylRecord.scala
+++ b/persistence/squeryl-record/src/main/scala/net/liftweb/squerylrecord/SquerylRecord.scala
@@ -63,7 +63,7 @@ object SquerylRecord extends Loggable {
    * */
   private object currentSession extends DynoVar[Session]
   
-  @deprecated(message = "Lift DB.use style transactions do not properly clean up Squeryl resources.  Please use initWithSquerylSession instead.")
+  @deprecated(message = "Lift DB.use style transactions do not properly clean up Squeryl resources.  Please use initWithSquerylSession instead.", "2.5")
   def init(mkAdapter: () => DatabaseAdapter) = {
     FieldMetaData.factory = new RecordMetaDataFactory
     SessionFactory.externalTransactionManagementAdapter = Some(() => 

--- a/web/testkit/src/main/scala/net/liftweb/mocks/MockHttpServletRequest.scala
+++ b/web/testkit/src/main/scala/net/liftweb/mocks/MockHttpServletRequest.scala
@@ -59,10 +59,10 @@ import json.JsonAST._
  *
  */
 class MockHttpServletRequest(val url : String = null, var contextPath : String = "") extends HttpServletRequest {
-  @deprecated("Use the \"attributes\" var instead")
+  @deprecated("Use the \"attributes\" var instead", "2.4")
   def attr = attributes
 
-  @deprecated("Use the \"attributes\" var instead")
+  @deprecated("Use the \"attributes\" var instead", "2.4")
   def attr_= (attrs : Map[String,Object]) = attributes = attrs
 
   var attributes: Map[String, Object] = Map()
@@ -183,10 +183,10 @@ class MockHttpServletRequest(val url : String = null, var contextPath : String =
    */
   var parameters : List[(String,String)] = Nil
 
-  @deprecated("Use the \"parameters\" var instead")
+  @deprecated("Use the \"parameters\" var instead", "2.4")
   def parameterMap = Map(parameters : _*)
 
-  @deprecated("Use the \"parameters\" var instead")
+  @deprecated("Use the \"parameters\" var instead", "2.4")
   def parameterMap_= (params : Map[String, List[String]]) {
     parameters = params.toList.flatMap {
       case (key,values) => values.map{(key,_)}

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/A.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/A.scala
@@ -23,7 +23,7 @@ import net.liftweb.http._
 import net.liftweb.http.js._
 import net.liftweb.util._
 
-@deprecated("Use any of the ajax methods in SHtml instead.")
+@deprecated("Use any of the ajax methods in SHtml instead.", "2.5")
 object A extends DispatchSnippet {
 
   def dispatch : DispatchIt = {

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msgs.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msgs.scala
@@ -23,10 +23,9 @@ import scala.xml._
 import net.liftweb.util.Helpers._
 import net.liftweb.http.js._
 import JsCmds._
-import net.liftweb.common.{Box, Full, Empty}
+import net.liftweb.common.{Box, Empty}
 import common.Full
 import xml.Text
-import snippet.AjaxMessageMeta
 
 
 /**

--- a/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
@@ -285,7 +285,7 @@ trait ListenerManager {
    * favor of doing the filtering in the registered Actor's
    * message handling partial functions instead.
    */
-  @deprecated("Accept/reject logic should be done in the partial function that handles the message.")
+  @deprecated("Accept/reject logic should be done in the partial function that handles the message.", "2.4")
   protected def updateIfPassesTest(update: Any)(info: ActorTest) {
     info match {
       case (who, test) => if (test.isDefinedAt(update) && test(update)) who ! update
@@ -329,7 +329,7 @@ trait ListenerManager {
  *
  * @see CometListener
  */
-@deprecated("Use the CometListener trait instead.")
+@deprecated("Use the CometListener trait instead.", "2.4")
 trait CometListenee extends CometListener {
   self: CometActor =>
 }
@@ -372,7 +372,7 @@ trait CometListener extends CometActor {
    * the session's context.  This causes problems.  Accept/reject logic should be done
    * in the partial function that handles the message.
    */
-  @deprecated("Accept/reject logic should be done in the partial function that handles the message.")
+  @deprecated("Accept/reject logic should be done in the partial function that handles the message.", "2.4")
   protected def shouldUpdate: PartialFunction[Any, Boolean] = {
     case _ => true
   }
@@ -572,7 +572,7 @@ trait CometActor extends LiftActor with LiftCometActor with BindHelpers {
 
   @volatile private var _defaultHtml: NodeSeq = _
 
-  @deprecated("Use defaultHtml")
+  @deprecated("Use defaultHtml", "2.3")
   def defaultXml = _defaultHtml
 
   /**
@@ -1525,7 +1525,6 @@ object Notice {
  * @param destroyScript is executed when the comet widget is redrawn ( e.g., if you register drag or mouse-over or some events, you unregister them here so the page doesn't leak resources.)
  * @param ignoreHtmlOnJs -- if the reason for sending the render is a Comet update, ignore the xhtml part and just run the JS commands.  This is useful in IE when you need to redraw the stuff inside <table><tr><td>... just doing innerHtml on <tr> is broken in IE
  */
-@serializable
 case class RenderOut(xhtml: Box[NodeSeq], fixedXhtml: Box[NodeSeq], script: Box[JsCmd], destroyScript: Box[JsCmd], ignoreHtmlOnJs: Boolean) {
   def this(xhtml: NodeSeq) = this (Full(xhtml), Empty, Empty, Empty, false)
 
@@ -1538,6 +1537,5 @@ case class RenderOut(xhtml: Box[NodeSeq], fixedXhtml: Box[NodeSeq], script: Box[
       destroyScript, ignoreHtmlOnJs)
 }
 
-@serializable
-private[http] object Never
+private[http] object Never extends Serializable
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftResponse.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftResponse.scala
@@ -481,7 +481,7 @@ object DocType {
  * Avoid using this in favor of LiftRules.docType
  *
  */
-@deprecated("Avoid using this in favor of LiftRules.docType")
+@deprecated("Avoid using this in favor of LiftRules.docType", "2.3")
 object ResponseInfo {
 
    def docType: PartialFunction[Req, Box[String]] = new PartialFunction[Req, Box[String]](){

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -366,7 +366,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * has been deprecated in favor of statelessReqTest which also passes
    * the HTTPRequest instance for testing of the user agent and other stuff.
    */
-  @deprecated("Use statelessReqTest")
+  @deprecated("Use statelessReqTest", "2.4")
   val statelessTest = RulesSeq[StatelessTestPF]
 
 
@@ -462,7 +462,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   /**
    * Set the doc type used.  Use the HtmlProperties
    */
-  @deprecated("Use the HtmlProperties")
+  @deprecated("Use the HtmlProperties", "2.4")
   val docType: FactoryMaker[Req => Box[String]] = new FactoryMaker( (r: Req) => r  match {
     case _ if S.skipDocType => Empty
     case _ if S.getDocType._1 => S.getDocType._2
@@ -602,7 +602,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * contingent on an unchanged LiftRules.noCometSessionCommand and on
    * liftComet.lift_sessionLost not being overridden client-side.
    */
-  @scala.deprecated("Use LiftRules.noCometSessionCmd.")
+  @deprecated("Use LiftRules.noCometSessionCmd.", "2.5")
   @volatile var noCometSessionPage = "/"
 
   /**
@@ -1024,7 +1024,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * no session will be created and no JSESSIONID cookie will be presented to the user (unless
    * the user has presented a JSESSIONID cookie).
    */
-  @scala.deprecated("Use statelessDispatch")
+  @deprecated("Use statelessDispatch", "2.4")
   def statelessDispatchTable = statelessDispatch
 
   /**
@@ -1221,7 +1221,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   /**
    * Use statelessRewrite or statefuleRewrite
    */
-  @deprecated("Use statelessRewrite or statefuleRewrite")
+  @deprecated("Use statelessRewrite or statefuleRewrite", "2.3")
   val rewrite = statelessRewrite
 
   /**
@@ -1355,9 +1355,9 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * LiftRules.noCometSessionCmd).
    */
   @volatile var redirectAsyncOnSessionLoss = true
-  @deprecated("Use redirectAsyncOnSessionLoss instead.")
+  @deprecated("Use redirectAsyncOnSessionLoss instead.", "2.5")
   def redirectAjaxOnSessionLoss = redirectAsyncOnSessionLoss
-  @deprecated("Use redirectAsyncOnSessionLoss instead.")
+  @deprecated("Use redirectAsyncOnSessionLoss instead.", "2.5")
   def redirectAjaxOnSessionLoss_=(updated:Boolean) = redirectAsyncOnSessionLoss = updated
 
   /**
@@ -1490,7 +1490,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   /**
    * Tells Lift if the Ajax JavaScript shoukd be included. By default it is set to true.
    */
-  @deprecated("Use autoIncludeAjaxCalc")
+  @deprecated("Use autoIncludeAjaxCalc", "2.4")
   @volatile var autoIncludeAjax: LiftSession => Boolean = session => autoIncludeAjaxCalc.vend().apply(session)
 
   val autoIncludeAjaxCalc: FactoryMaker[() => LiftSession => Boolean] = 
@@ -1716,7 +1716,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * A function to format a Date... can be replaced by a function that is user-specific
    Replaced by dateTimeConverter
    */
-  @deprecated("Replaced by dateTimeConverter")
+  @deprecated("Replaced by dateTimeConverter", "2.3")
   @volatile var formatDate: Date => String = date => date match {
     case null => LiftRules.dateTimeConverter.vend.formatDate(new Date(0L))
     case s    => toInternetDate(s)
@@ -1726,7 +1726,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * A function that parses a String into a Date... can be replaced by something that's user-specific
    Replaced by dateTimeConverter
    */
-  @deprecated("Replaced by dateTimeConverter")
+  @deprecated("Replaced by dateTimeConverter", "2.3")
   @volatile var parseDate: String => Box[Date] = str => str match {
     case null => Empty
     case s => Helpers.toDate(s)
@@ -1752,7 +1752,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   /**
    * Provides the async provider instance responsible for suspending/resuming requests
    */
-  @deprecated("Register your povider via addSyncProvider")
+  @deprecated("Register your povider via addSyncProvider", "2.4")
   var servletAsyncProvider: (HTTPRequest) => ServletAsyncProvider = null // (req) => new Jetty6AsyncProvider(req)
 
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
@@ -67,7 +67,7 @@ trait AbstractScreen extends Factory {
    *
    * @deprecated
    */
-  @deprecated("use addFields()")
+  @deprecated("use addFields()", "2.4")
   protected def _register(field: () => FieldContainer) = addFields(field)
 
   protected def hasUploadField: Boolean = screenFields.foldLeft(false)(_ | _.uploadField_?)

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -143,7 +143,7 @@ object LiftSession {
    * Check to see if the template is marked designer friendly
    * and lop off the stuff before the first surround
    */
-  @deprecated("Use Templates.checkForContentId")
+  @deprecated("Use Templates.checkForContentId", "2.3")
   def checkForContentId(in: NodeSeq): NodeSeq =
     Templates.checkForContentId(in)
 

--- a/web/webkit/src/main/scala/net/liftweb/http/Paginator.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Paginator.scala
@@ -164,9 +164,9 @@ trait PaginatorSnippet[T] extends Paginator[T] {
    */
   def currentXml: NodeSeq = 
     if(count==0)
-      Text(??("paginator.norecords"))
+      Text(S.?("paginator.norecords"))
     else
-      Text(??("paginator.displayingrecords", 
+      Text(S.?("paginator.displayingrecords",
               Array(recordsFrom, recordsTo, count).map(_.asInstanceOf[AnyRef]) : _*))
 
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/Req.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Req.scala
@@ -212,11 +212,10 @@ trait UserAgentCalculator {
   def userAgent: Box[String]
 }
 
-@serializable
-sealed trait ParamHolder {
+sealed trait ParamHolder extends Serializable{
   def name: String
 }
-@serializable
+
 final case class NormalParamHolder(name: String, value: String) extends ParamHolder
 
 /**
@@ -227,9 +226,8 @@ final case class NormalParamHolder(name: String, value: String) extends ParamHol
  * @param mimeType the mime type, as specified in the Content-Type field
  * @param fileName The local filename on the client
  */
-@serializable
 abstract class FileParamHolder(val name: String, val mimeType: String,
-                               val fileName: String) extends ParamHolder
+                               val fileName: String) extends ParamHolder with Serializable
 {
   /**
    * Returns the contents of the uploaded file as a Byte array.
@@ -1222,7 +1220,6 @@ final case class RewriteRequest(path: ParsePath, requestType: RequestType, httpR
 /**
  * The representation of an URI path
  */
-@serializable
 case class ParsePath(partPath: List[String], suffix: String, absolute: Boolean, endSlash: Boolean) {
   def drop(cnt: Int) = ParsePath(partPath.drop(cnt), suffix, absolute, endSlash)
 

--- a/web/webkit/src/main/scala/net/liftweb/http/RequestType.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/RequestType.scala
@@ -19,8 +19,7 @@ package http
 
 import provider._
 
-@serializable
-abstract class RequestType {
+abstract class RequestType extends Serializable{
   def post_? : Boolean = false
 
   def get_? : Boolean = false
@@ -34,32 +33,26 @@ abstract class RequestType {
   def method: String
 }
 
-@serializable
 case object GetRequest extends RequestType {
   override def get_? = true
   def method = "GET"
 }
-@serializable
 case object PostRequest extends RequestType {
   override def post_? = true
   def method = "POST"
 }
-@serializable
 case object HeadRequest extends RequestType {
   override def head_? = true
   def method = "HEAD"
 }
-@serializable
 case object PutRequest extends RequestType {
   override def put_? = true
   def method = "PUT"
 }
-@serializable
 case object DeleteRequest extends RequestType {
   override def delete_? = true
   def method = "DELETE"
 }
-@serializable
 case class UnknownRequest(val method: String) extends RequestType
 
 object RequestType {

--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -206,7 +206,7 @@ trait SHtml {
    *
    * @return the function ID and JavaScript that makes the call
    */
-  @scala.deprecated("Use jsonCall with a function that takes JValue => JsCmd")
+  @deprecated("Use jsonCall with a function that takes JValue => JsCmd", "2.5")
   def jsonCall(jsCalcValue: JsExp, func: Any => JsCmd)(implicit d: AvoidTypeErasureIssues1): GUIDJsExp =
     jsonCall_*(jsCalcValue, SFuncHolder(s => JSONParser.parse(s).map(func) openOr Noop))
 
@@ -219,7 +219,7 @@ trait SHtml {
    *
    * @return the function ID and JavaScript that makes the call
    */
-  @scala.deprecated("Use jsonCall with a function that takes JValue => JsCmd")
+  @deprecated("Use jsonCall with a function that takes JValue => JsCmd", "2.5")
   def jsonCall(jsCalcValue: JsExp, jsContext: JsContext, func: Any => JsCmd)(implicit d: AvoidTypeErasureIssues1): GUIDJsExp =
     jsonCall_*(jsCalcValue, jsContext, SFuncHolder(s => JSONParser.parse(s).map(func) openOr Noop))
 

--- a/web/webkit/src/main/scala/net/liftweb/http/Templates.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Templates.scala
@@ -91,7 +91,7 @@ object Templates {
    *
    * @return the template if it can be found
    */
-  @deprecated("use apply")
+  @deprecated("use apply", "2.4")
   def findAnyTemplate(places: List[String]): Box[NodeSeq] =
     findRawTemplate(places, S.locale)
 
@@ -103,7 +103,7 @@ object Templates {
    *
    * @return the template if it can be found
    */
-  @deprecated("use apply")
+  @deprecated("use apply", "2.4")
   def findAnyTemplate(places: List[String], locale: Locale): Box[NodeSeq] = findRawTemplate(places, locale)
 
 

--- a/web/webkit/src/main/scala/net/liftweb/http/jquery/JqSHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/jquery/JqSHtml.scala
@@ -26,7 +26,7 @@ import JqJsCmds._
 /**
  * This contains Html artifacts that are heavily relying on JQuery
  */
-@deprecated("This contains Html artifacts that are heavily relying on JQuery")
+@deprecated("This contains Html artifacts that are heavily relying on JQuery", "2.3")
 object JqSHtml {
   def fadeOutErrors(duration: TimeSpan, fadeTime: TimeSpan): JsCmd = {
     FadeOut(LiftRules.noticesContainerId + "_error", duration, fadeTime)

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -188,7 +188,7 @@ trait JsExp extends HtmlFixer with ToJsCmd {
    * This exists for backward compatibility reasons for JQueryLeft and JQueryRight
    * which are now deprecated. Use ~> whenever possible as this will be removed soon.
    */
-  @deprecated("Use `~>` instead")
+  @deprecated("Use `~>` instead", "2.3")
   def >>(right: JsMember): JsExp = ~>(right)
 
 
@@ -553,7 +553,7 @@ trait HtmlFixer {
    * This method must be run in the context of the thing creating the XHTML
    * to capture the bound functions
    */
-  @deprecated("Use fixHtmlAndJs or fixHtmlFunc")
+  @deprecated("Use fixHtmlAndJs or fixHtmlFunc", "2.4")
   protected def fixHtml(uid: String, content: NodeSeq): String = {
     val w = new java.io.StringWriter
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/jquery/JqJsCmds.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/jquery/JqJsCmds.scala
@@ -36,7 +36,7 @@ import JsCmds._
  */
 @deprecated(""" As JQueryRight
 is deprecated clases mixing this trait with stop doing so soon and they
-will mixin JsMember instead.""")
+will mixin JsMember instead.""", "2.3")
 trait JQueryRight {
   this: JsExp =>
   def toJsCmd: String
@@ -44,7 +44,7 @@ trait JQueryRight {
 /**
  * Classes mixing JQuryLeft will soon stop doing so. Extending/Mixing JsExp will be enough
  */ 
-@deprecated("Classes mixing JQuryLeft will soon stop doing so. Extending/Mixing JsExp will be enough")
+@deprecated("Classes mixing JQuryLeft will soon stop doing so. Extending/Mixing JsExp will be enough", "2.3")
 trait JQueryLeft {
   this: JsExp =>
 }
@@ -668,7 +668,7 @@ object JqJsCmds {
   /**
    * Use SetValueAndFocus from JsCmds
    */
-  @deprecated("Use SetValueAndFocus from JsCmds")
+  @deprecated("Use SetValueAndFocus from JsCmds", "2.3")
   case class SetValueAndFocus(id: String, value: String) extends JsCmd {
     def toJsCmd = "document.getElementById(" + id.encJs + ").value = " +
             value.encJs +

--- a/web/webkit/src/main/scala/net/liftweb/http/package.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/package.scala
@@ -22,7 +22,7 @@ import xml.{Elem, MetaData, NodeSeq}
 import java.util.{ResourceBundle, Locale, Date}
 
 package object http {
-  @deprecated("Use Templates")
+  @deprecated("Use Templates", "2.3")
   lazy val TemplateFinder = Templates
 }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPResponseServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPResponseServlet.scala
@@ -81,7 +81,7 @@ class HTTPResponseServlet(resp: HttpServletResponse) extends HTTPResponse {
  
   def setStatusWithReason(status: Int, reason: String) = {
     _status = status
-    resp setStatus (status, reason)
+    resp sendError  (status, reason)
   }
 
   def outputStream: OutputStream = resp getOutputStream

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPServletSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPServletSession.scala
@@ -50,7 +50,6 @@ class HTTPServletSession(session: HttpSession) extends HTTPSession {
 /**
  * Represents the "bridge" between HttpSession and LiftSession
  */
-@serializable
 case class SessionToServletBridge(uniqueId: String) extends HttpSessionBindingListener with HttpSessionActivationListener {
   def sessionDidActivate(se: HttpSessionEvent) = {
     SessionMaster.getSession(uniqueId, Empty).foreach(ls =>

--- a/web/webkit/src/main/scala/net/liftweb/http/rest/RestContinuation.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/rest/RestContinuation.scala
@@ -81,7 +81,7 @@ object RestContinuation {
    *            is invoked asynchronously in the context of a different thread.
    * 
    */
-  @deprecated("Use RestContinuation.async.  It provides much better resource management")
+  @deprecated("Use RestContinuation.async.  It provides much better resource management", "2.4")
   def respondAsync(req: Req)(f: => Box[LiftResponse]): () => Box[LiftResponse] = {
     val store = ContinuationsStore.is
     val key = ContinuationKey(req.path, req.requestType)


### PR DESCRIPTION
Now that we don't build Lift for 2.8.x, we can add the second parameter to all the deprecated messages we have.
Thus would eliminate the compiler warnings we get at build time.
