### PR TITLE
Add a way to avoid restarting of Executors after 'shutdownFully' is call...

### DIFF
--- a/core/actor/src/main/scala/net/liftweb/actor/LAPinger.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAPinger.scala
@@ -41,11 +41,15 @@ object LAPinger {
 
   /**The underlying <code>java.util.concurrent.ScheduledExecutor</code> */
   private var service = Executors.newSingleThreadScheduledExecutor(TF)
-
+		  
+  private var isFullyShutdown = false;
+  
   /**
    * Re-create the underlying <code>SingleThreadScheduledExecutor</code>
    */
   def restart: Unit = synchronized {
+    if(isFullyShutdown) return
+    
     if ((service eq null) || service.isShutdown)
       service = Executors.newSingleThreadScheduledExecutor(TF)
   }
@@ -55,6 +59,12 @@ object LAPinger {
    */
   def shutdown: Unit = synchronized {
     service.shutdown
+  }
+
+  def shutdownFully() {
+    service.shutdownNow()
+    
+    isFullyShutdown = true;
   }
 
   /**

--- a/core/util/src/main/scala/net/liftweb/util/Schedule.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Schedule.scala
@@ -74,11 +74,15 @@ sealed trait Schedule extends Loggable {
 
   private var pool = buildExecutor()
 
+  private var isFullyShutdown = false;
+    
   /**
    * Re-create the underlying <code>SingleThreadScheduledExecutor</code>
    */
   def restart: Unit = synchronized
-  { if ((service eq null) || service.isShutdown)
+  { 
+    if(isFullyShutdown) return
+    if ((service eq null) || service.isShutdown)
     service = Executors.newSingleThreadScheduledExecutor(TF) 
    if ((pool eq null) || pool.isShutdown)
      pool = buildExecutor()
@@ -91,6 +95,13 @@ sealed trait Schedule extends Loggable {
   def shutdown(): Unit = synchronized {
     service.shutdown 
     pool.shutdown
+  }
+  
+  def shutdownFully() {
+    service.shutdownNow()
+    pool.shutdownNow()
+    
+    isFullyShutdown = true;
   }
 
   /**


### PR DESCRIPTION
I needed a way of completely shutting down all threads after Lift's servlet context is destroyed. Before, the Lift Scheduler and ActorPinger threads would continue running because they would be continually rescheduled and the relevant Executors restarted. I added a method into Schedule and LAPinger to 'shutdownFully' which meant to not allow the executor to be rescheduled. This I call from unloadHooks.
