### PR TITLE
Parse NaN value as Double.NaN

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -296,6 +296,12 @@ object JsonParser {
               return NullVal
             }
             fail("expected null")
+          case 'N' =>
+            fieldNameMode = true
+            if (buf.next == 'a' && buf.next == 'N') {
+              return DoubleVal(Double.NaN)
+            }
+            fail("expected null")
           case ':' =>
             if (blocks.peek == ARRAY) fail("Colon in an invalid position")
             fieldNameMode = false


### PR DESCRIPTION
Since NaN values are supported in serialization to JSON, we decided to add support for deserialization as well, even though it's not part of the official JSON spec.
