### PR TITLE
Added java.sql.Timestamp to net.liftweb.json Extraction

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -391,7 +391,7 @@ object Extraction {
     case JDouble(x) if (targetType == classOf[Number]) => x
     case JString(s) if (targetType == classOf[String]) => s
     case JString(s) if (targetType == classOf[Symbol]) => Symbol(s)
-    case JString(s) if (targetType == classOf[Date]) => formats.dateFormat.parse(s).getOrElse(fail("Invalid date '" + s + "'"))
+    case JString(s) if (classOf[Date].isAssignableFrom(targetType)) => formats.dateFormat.parse(s).getOrElse(fail("Invalid date '" + s + "'"))
     case JBool(x) if (targetType == classOf[Boolean]) => x
     case JBool(x) if (targetType == classOf[JavaBoolean]) => new JavaBoolean(x)
     case j: JValue if (targetType == classOf[JValue]) => j

--- a/core/json/src/main/scala/net/liftweb/json/Meta.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Meta.scala
@@ -19,6 +19,7 @@ package json
 
 import java.lang.reflect.{Constructor => JConstructor, Field, Type, ParameterizedType, GenericArrayType}
 import java.util.Date
+import java.sql.Timestamp
 
 case class TypeInfo(clazz: Class[_], parameterizedType: Option[ParameterizedType])
 
@@ -215,7 +216,7 @@ private[json] object Meta {
       classOf[Short], classOf[java.lang.Integer], classOf[java.lang.Long],
       classOf[java.lang.Double], classOf[java.lang.Float],
       classOf[java.lang.Byte], classOf[java.lang.Boolean], classOf[Number],
-      classOf[java.lang.Short], classOf[Date], classOf[Symbol], classOf[JValue],
+      classOf[java.lang.Short], classOf[Date], classOf[Timestamp], classOf[Symbol], classOf[JValue],
       classOf[JObject], classOf[JArray]).map((_, ())))
 
     private val primaryConstructors = new Memo[Class[_], List[(String, Type)]]
@@ -392,6 +393,7 @@ private[json] object Meta {
       case x: java.lang.Byte => JInt(BigInt(x.asInstanceOf[Byte]))
       case x: java.lang.Boolean => JBool(x.asInstanceOf[Boolean])
       case x: java.lang.Short => JInt(BigInt(x.asInstanceOf[Short]))
+      case x: java.sql.Timestamp => JString(formats.dateFormat.format(x))
       case x: Date => JString(formats.dateFormat.format(x))
       case x: Symbol => JString(x.name)
       case _ => sys.error("not a primitive " + a.asInstanceOf[AnyRef].getClass)


### PR DESCRIPTION
I ran into a problem where a Mapper MappedDateTime was not being serialized by net.liftweb.json.Extraction. It turns out this is because MappedDateTime.is returns a java.sql.Timestamp, which although is a subclass of java.util.Date, lift json did not support.
