### PR TITLE
lift_uriSuffix can get lost during long-running AJAX requests

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/js/ScriptRenderer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/ScriptRenderer.scala
@@ -47,6 +47,12 @@ object ScriptRenderer {
 	  toSend.onFailure = theFailure;
 	  toSend.responseType = responseType;
 
+	  if (liftAjax.lift_uriSuffix) {
+	    theData += '&' + liftAjax.lift_uriSuffix;
+	    toSend.theData = theData;
+	    liftAjax.lift_uriSuffix = undefined;
+	  }
+
 	  liftAjax.lift_ajaxQueue.push(toSend);
 	  liftAjax.lift_ajaxQueueSort();
 	  liftAjax.lift_doCycleQueueCnt++;
@@ -161,11 +167,6 @@ object ScriptRenderer {
                liftAjax.lift_actualJSONCall(aboutToSend.theData, successFunc, failureFunc);
              } else {
                var theData = aboutToSend.theData;
-               if (liftAjax.lift_uriSuffix) {
-                 theData += '&' + liftAjax.lift_uriSuffix;
-                 aboutToSend.theData = theData;
-                 liftAjax.lift_uriSuffix = undefined;
-               }
                liftAjax.lift_actualAjaxCall(theData, successFunc, failureFunc);
              }
             }


### PR DESCRIPTION
Because lift_uriSuffix is read during doAjaxCycle, a long-running AJAX request that blocks processing of two sequentially queued AJAX calls can result in mangled uriSuffix reads.

The situation is as such:
- I do an AJAX request with suffix A. It takes 5s.
- I do an AJAX request with suffix B. lift_uriSuffix is now B.
- I do an AJAX request with suffix C. lift_uriSuffix is now C.
- The first request completes, the second is processed. This request now sees suffix C. It is fired off with the wrong suffix.
- The second request completes, the third is processed. This request now sees no suffix at all. It is fired off with no suffix.

The solution to this is to read the suffix during lift_ajaxHandler where we queue the request up, rather than waiting for other requests to complete.
