### PR TITLE
Off-by-1 in JSON string escaping

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -427,7 +427,9 @@ object JsonAST {
         case '\n' => "\\n"
         case '\r' => "\\r"
         case '\t' => "\\t"
-        case c if ((c >= '\u0000' && c < '\u001f') || (c >= '\u0080' && c < '\u00a0') || (c >= '\u2000' && c < '\u2100')) => "\\u%04x".format(c: Int)
+        case c if ((c >= '\u0000' && c < '\u0020') ||
+                   (c >= '\u0080' && c < '\u00a0') ||
+                   (c >= '\u2000' && c < '\u2100')) => "\\u%04x".format(c: Int)
         case c => c
       })
     }


### PR DESCRIPTION
Hi,

This was a bug which affected a deployed application (with v2.4). Hope you can consider this fix.

(Also, just curious, why not c.toInt instead of c:Int; and what is the purpose of the other two range checks? Are they needed?)

--Toby

PS. Was not able to do a test build at this time, I only have JDK 1.5 (sbt 0.7.7) on this machine.
