### PR TITLE
Do not call valueBox at lift record Field.setBox

### DIFF
--- a/persistence/record/src/main/scala/net/liftweb/record/Field.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/Field.scala
@@ -217,7 +217,7 @@ trait TypedField[ThisType] extends BaseField {
 
   def setBox(in: Box[MyType]): Box[MyType] = synchronized {
     needsDefault = false
-    val oldValue = valueBox
+    val oldValue = data
     data = in match {
       case _ if !canWrite_?      => Failure(noValueErrorMessage)
       case Full(_)               => set_!(in)
@@ -225,11 +225,13 @@ trait TypedField[ThisType] extends BaseField {
       case (f: Failure)          => set_!(f) // preserve failures set in
       case _                     => Failure(notOptionalErrorMessage)
     }
-    val same = (oldValue, valueBox) match {
-      case (Full(ov), Full(nv)) => ov == nv
-      case (a, b) => a == b
+    if(!dirty_?) {
+	    val same = (oldValue, data) match {
+	      case (Full(ov), Full(nv)) => ov == nv
+	      case (a, b) => a == b
+	    }
+	    dirty_?(!same)
     }
-    dirty_?(!same)
     data
   }
 

--- a/persistence/record/src/test/scala/net/liftweb/record/FieldSpec.scala
+++ b/persistence/record/src/test/scala/net/liftweb/record/FieldSpec.scala
@@ -130,6 +130,9 @@ object FieldSpec extends Specification {
 	        (valueBox === exampleBox) must_== false
 	        in.setBox(exampleBox)
 	        in.dirty_? must_== true
+	        //dirty value should remain true, even if the same value is set twice before persisting
+	        in.setBox(exampleBox)
+	        in.dirty_? must_== true
 	        in.setBox(valueBox)
 	        success
 	      }


### PR DESCRIPTION
at Field.scala
at method setBox

val same = (oldValue, valueBox) match {
      case (Full(ov), Full(nv)) => ov == nv
      case (a, b) => a == b
    }

should be changed to

val same = (oldValue, data) match {
      case (Full(ov), Full(nv)) => ov == nv
      case (a, b) => a == b
    }

discussed at Lift mailing list:
https://groups.google.com/forum/?fromgroups=#!topic/liftweb/cE86gzcDR_w
