### PR TITLE
Squeryl-record CRUDify lacks transaction in delete

### DIFF
--- a/persistence/squeryl-record/src/main/scala/net/liftweb/squerylrecord/CRUDify.scala
+++ b/persistence/squeryl-record/src/main/scala/net/liftweb/squerylrecord/CRUDify.scala
@@ -58,7 +58,9 @@ trait CRUDify[K, T <: Record[T] with KeyedEntity[K]] extends Crudify {
 
   protected class SquerylBridge(in: TheCrudType) extends CrudBridge {
 
-    def delete_! = table.delete(in.id)
+    def delete_! = inTransaction {
+      table.delete(in.id)
+    }
 
     def save = {
       if (in.isPersisted) {


### PR DESCRIPTION
in net.liftweb.squerylrecord.CRUDify.scala

``` scala
 protected class SquerylBridge(in: TheCrudType) extends CrudBridge {

    def delete_! = table.delete(in.id)
```

should be changed to:

``` scala
    def delete_! = inTransaction { table.delete(in.id) }
```

to be consistient with other operations, which already are in transaction. Delete is the only operation that is not in transaction, and therefore it does not work if you don't wrap delete request in transaction by other means
