### PR TITLE
NullPointerException in LiftScreen

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
@@ -225,7 +225,7 @@ trait AbstractScreen extends Factory {
     private lazy val _theFieldId: NonCleanAnyVar[String] =
       vendAVar(Helpers.nextFuncName)
 
-    override def toString = is.toString
+    override def toString = if (is != null) is.toString else ""
 
     def binding: Box[FieldBinding] = Empty
 


### PR DESCRIPTION
There's a NullPointerException being thrown for MappedDate (and MappedDateTime) fields that are not set yet (the defaultValue is NULL).

The Field trait definition in LiftScreen:228 defines:

override def toString = is.toString

For a not set field that boils down to null.toString.
