### PR TITLE
Add RestoringWeakReference

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/RestoringWeakReference.scala
+++ b/core/util/src/main/scala/net/liftweb/util/RestoringWeakReference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2011 WorldWide Conferencing, LLC
+ * Copyright 2006-2012 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
`RestoringWeakReference` contains a `scala.ref.WeakReference` that,
after it has been nulled out, uses a restorer function to restore
the value.  This can be used for data that can afford to be evicted
by the garbage collector, but will be needed later. One good example
is Lift form callbacks, which may need the value of an object, but
where you don't necessarily want to be retaining the object
indefinitely while someone is on a page in the face of GC contention.

Examples are in the doc header.
