### PR TITLE
PostgreSQL limit reserved word

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -50,7 +50,9 @@ an [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) license.
 
 
 ### Name: ###
+Gilberto T. Garcia Jr
 
 ### Email: ###
+ggarcia at eureka dot inf dot br
 
 

--- a/persistence/db/src/main/scala/net/liftweb/db/DB.scala
+++ b/persistence/db/src/main/scala/net/liftweb/db/DB.scala
@@ -885,6 +885,7 @@ trait DB extends Loggable {
        "layer",
        "level",
        "like",
+       "limit", // reserved word for PostgreSQL
        "limited",
        "link",
        "lists",


### PR DESCRIPTION
limit is a reserved word for PostgreSQL.
So it should be included in the default list of reserved words
1. Here is the sample app to demonstrate the problem ->
   https://github.com/colt44/limitcolumn
2. Here is a known workaround:
   Adding DB.userReservedWords = Full(Set("limit")) into Boot.scala
   does solve the problem.
