### PR TITLE
Add prompt expression to JsCommands

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -50,7 +50,7 @@ an [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) license.
 
 
 ### Name: ###
+Marko Elezović
 
 ### Email: ###
-
-
+marko at element dot hr

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -822,6 +822,10 @@ object JsCmds {
     def toJsCmd = "alert(" + text.encJs + ");"
   }
 
+  case class Prompt(text: String, default: String = "") extends JsExp {
+    def toJsCmd = "prompt(" + text.encJs + "," + default.encJs + ")"
+  }
+
   case class Confirm(text: String, yes: JsCmd) extends JsCmd {
     def toJsCmd = "if (confirm(" + text.encJs + ")) {" + yes.toJsCmd + "}"
   }


### PR DESCRIPTION
Prompt expression should be available since it is similar to its colleagues alert and confirm.
The input box will be filled with an empty string by default, identical to invoking the prompt javascript function without the second argument.
