### PR TITLE
JObjectField doesn't serialize to BSON

### DIFF
--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/Fixtures.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/Fixtures.scala
@@ -469,10 +469,12 @@ object RefFieldTestRecord extends RefFieldTestRecord with MongoMetaRecord[RefFie
 }
 
 
-class JObjectFieldTestRecord private () extends Record[JObjectFieldTestRecord] {
+class JObjectFieldTestRecord private () extends MongoRecord[JObjectFieldTestRecord]  with ObjectIdPk[JObjectFieldTestRecord] {
   def meta = JObjectFieldTestRecord
 
   object mandatoryJObjectField extends JObjectField(this)
 }
 
-object JObjectFieldTestRecord extends JObjectFieldTestRecord with MetaRecord[JObjectFieldTestRecord]
+object JObjectFieldTestRecord extends JObjectFieldTestRecord with MongoMetaRecord[JObjectFieldTestRecord] {
+  override def formats = allFormats
+}


### PR DESCRIPTION
JObjectField isn't fully working [following issue 1314 being fixed](https://github.com/lift/framework/pull/1338).  In the current builds, JObjectField will serialize to something like "JObject(List(JField(minutes,Jint(59))))", rather than the intended BSON data structure.

The issue is that -fieldDbValue in BsonRecord falls through to the o.toString option when it asDBObject tried to create the DBObject. 

 I was able to shim in something that uses the mongo driver's JSON parser to deserialize a serialized JObject into a DBObject in the case that fieldDbValue gets a JObject, but it feels kinda hacky.

The current "get set from JValue" test only covers the fact that the JObject can in-fact be set on a given record, but it doesn't cover a round trip to BSON and back.
