### PR TITLE
Deprecate JSONParser

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/JSONParser.scala
+++ b/core/util/src/main/scala/net/liftweb/util/JSONParser.scala
@@ -19,6 +19,7 @@ package util
 
 import scala.util.parsing.combinator.{Parsers, ImplicitConversions}
 import common._
+@deprecated("Use lift-json instead", "2.5")
 object JSONParser extends SafeSeqParser with ImplicitConversions {
   implicit def strToInput(in: String): Input = new scala.util.parsing.input.CharArrayReader(in.toCharArray)
   type Elem = Char


### PR DESCRIPTION
As discussed here
https://groups.google.com/forum/?fromgroups#!topic/liftweb/1eEQjR02Lf0
We'll deprecate JSONParser in favor of using lift-json
