### PR TITLE
The fix for e-mails with attachments.

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -101,3 +101,9 @@ Kristof Jozsa
 
 ### Email: ###
 kristof.jozsa at gmail dot com
+
+### Name: ###
+Mikhail Limansky
+
+### Email: ###
+mike.limansky at gmail dot com

--- a/core/util/src/main/scala/net/liftweb/util/Mailer.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Mailer.scala
@@ -286,7 +286,7 @@ trait Mailer extends SimpleInjector {
             case XHTMLMailBodyType(html) => bp.setContent(encodeHtmlBodyPart(html), "text/html; charset=" + charSet)
 
             case XHTMLPlusImages(html, img@_*) =>
-              val html_mp = new MimeMultipart("related")
+              val html_mp = new MimeMultipart(if (img.exists(_.attachment)) "mixed" else "related")
               val bp2 = new MimeBodyPart
               bp2.setContent(encodeHtmlBodyPart(html), "text/html; charset=" + charSet)
               html_mp.addBodyPart(bp2)
@@ -295,7 +295,7 @@ trait Mailer extends SimpleInjector {
                 val rel_bpi = new MimeBodyPart
                 rel_bpi.setFileName(i.name)
                 rel_bpi.setContentID(i.name)
-                rel_bpi.setDisposition(if (!i.attachment) "inline" else "attachment")
+                rel_bpi.setDisposition(if (!i.attachment) Part.INLINE else Part.ATTACHMENT)
                 rel_bpi.setDataHandler(new javax.activation.DataHandler(new javax.activation.DataSource {
                       def getContentType = i.mimeType
 


### PR DESCRIPTION
Microsoft Outlook does not show attachments if the mail body has type "multipart/related". The solution is set it to "multipart/mixed". Tested with pdf attachments and Outlook 2010.
