### PR TITLE
Fix the field() method in LiftScreen that uses an underlying field so it...

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -120,3 +120,9 @@ Gregory Flanagan
 
 ### Email: ###
 gregmflanagan at gmail dot com
+
+### Name: ###
+Chris Gaudreau
+
+### Email: ###
+webmaster at crystala dot net

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
@@ -477,13 +477,11 @@ trait AbstractScreen extends Factory {
 
       override def helpAsHtml = newHelp or underlying.helpAsHtml
 
-      override def validate: List[FieldError] = underlying.validate
+      override def validate = underlying.validate ::: super.validate
 
-      /*
       override def validations = stuff.collect {
-        case AVal(f) => f
-      }.toList ::: underlying.validations
-      */
+        case AVal(f) => f.asInstanceOf[ValueType => List[FieldError]]
+      }.toList
 
       override def setFilter = stuff.collect {
         case AFilter(f) => f
@@ -581,7 +579,11 @@ trait AbstractScreen extends Factory {
 
       override def helpAsHtml = newHelp or underlying.flatMap(_.helpAsHtml)
 
-      override def validate: List[FieldError] = underlying.toList.flatMap(_.validate)
+      override def validate = underlying.toList.flatMap(_.validate) ::: super.validate
+
+      override def validations = stuff.collect {
+        case AVal(f) => f.asInstanceOf[ValueType => List[FieldError]]
+      }.toList
 
       override def setFilter = stuff.collect {
         case AFilter(f) => f


### PR DESCRIPTION
... incorporates passes in validations as well as the validations on the underlying field. Previously, validations passed were ignored:

val username = field(User.username, valMinLen(2, "Your username is too short. Please go die (or make it longer)."))

Now they aren't ignored.

https://groups.google.com/forum/?fromgroups=#!topic/liftweb/QceKSZ2_WIA
