### PR TITLE
allow for maps to contain Int and Long keys

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -120,3 +120,9 @@ Gregory Flanagan
 
 ### Email: ###
 gregmflanagan at gmail dot com
+
+### Name: ###
+Joseph Price
+
+### Email: ###
+pricejosephd at gmail dot com

--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -79,7 +79,11 @@ object Extraction {
         case null => JNull
         case x: JValue => x
         case x if primitive_?(x.getClass) => primitive2jvalue(x)(formats)
-        case x: Map[_, _] => JObject((x map { case (k: String, v) => JField(k, decompose(v)) }).toList)
+        case x: Map[_, _] => JObject((x map { 
+            case (k: String, v) => JField(k, decompose(v)) 
+            case (k: Int, v) => JField(k.toString, decompose(v))
+            case (k: Long, v) => JField(k.toString, decompose(v))
+        }).toList)
         case x: Iterable[_] => JArray(x.toList map decompose)
         case x if (x.getClass.isArray) => JArray(x.asInstanceOf[Array[_]].toList map decompose)
         case x: Option[_] => x.flatMap[JValue] { y => Some(decompose(y)) }.getOrElse(JNothing)

--- a/core/json/src/test/scala/net/liftweb/json/SerializationExamples.scala
+++ b/core/json/src/test/scala/net/liftweb/json/SerializationExamples.scala
@@ -25,6 +25,23 @@ object SerializationExamples extends Specification {
 
   implicit val formats = Serialization.formats(NoTypeHints)
 
+  "Numerical keys" in {
+    val data = Map[Int, Composer] (
+      18838 -> Composer("Mussorgsky"),
+      18839 -> Composer("Prokofiev"),
+      18840 -> Composer("Rimsky-Korsakov")
+    )
+
+    val written = swrite(data)
+
+    val data2:Map[Int, Composer] = read[Map[Int, Composer]](written)
+
+    swrite(data) mustEqual swrite(data2)
+  }
+
+  case class Composer(name:String)
+  case class ComposersFromCountry(name: String, composers: Map[Int, Composer])
+
   val project = Project("test", new Date, Some(Language("Scala", 2.75)), List(
     Team("QA", List(Employee("John Doe", 5), Employee("Mike", 3))),
     Team("Impl", List(Employee("Mark", 4), Employee("Mary", 5), Employee("Nick Noob", 1)))))


### PR DESCRIPTION
The current way of handling maps only allows for keys to be strings. This results in a match error at runtime. Sometimes json apis use an object with numeric ids as the fields, for easy access of an element in the js. 
