### PR TITLE
Add ajaxOnSubmit to SHtml

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -1582,7 +1582,10 @@ trait SHtml {
   /**
    * Add appropriate attributes to an input type="submit" or button
    * element to make it submit an ajaxForm correctly and return a JsCmd
-   * to the client.
+   * to the client. Note that the key difference between this and ajaxSubmit
+   * is that ajaxSubmit returns a complete input type="submit" element, while
+   * ajaxOnSubmit applies the right attributes to any input type="submit" *or*
+   * button element.
    *
    * Example:
    *


### PR DESCRIPTION
`ajaxOnSubmit` should be used similarly to `onSubmit`/`onSubmitUnit`, to
add proper attributes for AJAX submission to a submit `input` or `button` element
without changing the element itself. It should take a `()=>JsCmd` like `ajaxSubmit`
and transform the element it's applied to by adding the right `name` and `onclick`
attributes (the same ones that `ajaxSubmit` puts on the element it generates).
