### PR TITLE
Support form=ajax as snippet-attribute

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Form.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Form.scala
@@ -94,7 +94,7 @@ object Form extends DispatchSnippet {
   private def addAjaxForm: MetaData = {
     val id = Helpers.nextFuncName
 
-    val attr = S.currentAttrsToMetaData(name => name != "id" && name != "onsubmit" && name != "action")
+    val attr = S.currentAttrsToMetaData(name => name != "id" && name != "onsubmit" && name != "action" && name != "form")
 
     val pre = S.attr.~("onsubmit").map(_.text + ";") getOrElse ""
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -1866,11 +1866,18 @@ class LiftSession(private[http] val _contextPath: String, val uniqueId: String,
             case x => x
           }
 
+        case Some("ajax") =>
+          net.liftweb.builtin.snippet.Form.render(ret) match {
+            case e: Elem => e % LiftRules.formAttrs.vend.foldLeft[MetaData](Null)((base, name) => checkAttr(name, attrs, base))
+            case x => x
+          }
+
         case Some(ft) =>
           <form action={S.uri} method={ft}>
             {ret}
           </form> %
             checkMultiPart(attrs) % LiftRules.formAttrs.vend.foldLeft[MetaData](Null)((base, name) => checkAttr(name, attrs, base))
+
         case _ => ret
       }
 


### PR DESCRIPTION
When appending form=post to a snippet-invokation, Lift generates a <form>-element and wraps the output of the snippet in the form.
Extend this to also support ajax-forms and reuse as much as possible from the built-in Form-snippet.
