### PR TITLE
Fix #1418 (problem with JSON unflatten when using common prefixes)

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -126,3 +126,9 @@ Chris Gaudreau
 
 ### Email: ###
 webmaster at crystala dot net
+
+### Name: ###
+Olivier Bruchez
+
+### Email: ###
+olivier at bruchez dot org

--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -155,7 +155,7 @@ object Extraction {
   
     def submap(prefix: String): Map[String, String] = 
       Map(
-        map.filter(t => t._1.startsWith(prefix)).map(
+        map.filter(t => t._1 == prefix || t._1.startsWith(prefix + ".") || t._1.startsWith(prefix + "[")).map(
           t => (t._1.substring(prefix.length), t._2)
         ).toList.toArray: _*
       )

--- a/core/json/src/test/scala/net/liftweb/json/ExtractionExamplesSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ExtractionExamplesSpec.scala
@@ -142,6 +142,12 @@ object ExtractionExamples extends Specification {
     
     Extraction.unflatten(m) mustEqual JObject(List(JField("foo", JArray(List(JInt(0), JInt(1), JInt(2))))))
   }
+
+  "Unflatten example with common prefixes" in {
+    val m = Map(".photo" -> "\"photo string\"", ".photographer" -> "\"photographer string\"", ".other" -> "\"other string\"")
+
+    Extraction.unflatten(m) mustEqual JObject(List(JField("photo", JString("photo string")), JField("photographer", JString("photographer string")), JField("other", JString("other string"))))
+  }
   
   "Flatten and unflatten are symmetric" in {
     val parsed = parse(testJson)


### PR DESCRIPTION
This is a fix for issue #1418 that doesn't break the tests. I've also added a new unit test for my case (i.e. property names with common prefixes, such as "photo" and "photographer").
