### PR TITLE
Optionally relevant: Support for custom attributes on each option of a select.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -940,8 +940,7 @@ trait SHtml {
       secure.find(_.value == d).map(_.nonce)
     }
 
-    val nonces = secure.map {
-      case selectableOptionWithNonce =>
+    val nonces = secure.map { selectableOptionWithNonce =>
         SelectableOption(selectableOptionWithNonce.nonce, selectableOptionWithNonce.label, selectableOptionWithNonce.attrs: _*)
     }
 


### PR DESCRIPTION
This pull request implements the feature I described [in this mailing list thread](https://groups.google.com/d/msg/liftweb/u0Rw0sFKYuI/RLGmL7ojNvIJ) by allowing you to do things like disable particular options in a Lift-ed out select tag.

To use it, you'll do something like this...

``` scala
val optionsForSelect =
  // regular option
  SelectableOption(someValue, "Label") ::
  // disabled option
  SelectableOption(someValue2, "Label2", "disabled" -> "disabled") ::
  Nil

...

selectObj(optionsForSelect, ...)
```

Additionally, there is an implicit conversion between `(T, String)` and `SelectableOption[T]`, such that legacy code using the tuple format will continue to work, and those that don't need the additional attribute functionality can continue to use it.

**Go over this with a fine-toothed comb.** I'm almost certain I mixed up an nonce and a real value parameter somewhere, which we can all agree would be problematic (mostly because it would break things). I'll be going over it again soon, but my eyes need a break. Hah!

Also, this guy includes a few readability improvements elsewhere in the SHtml trait.
