### PR TITLE
use compactRender in Serialization.write

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/Serialization.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Serialization.scala
@@ -35,7 +35,7 @@ object Serialization {
   /** Serialize to String.
    */
   def write[A <: AnyRef](a: A)(implicit formats: Formats): String =
-    (write(a, new StringWriter)(formats)).toString
+    compactRender(Extraction.decompose(a)(formats))
 
   /** Serialize to Writer.
    */


### PR DESCRIPTION
should improve performance without any breaking api changes. thanks for the suggestion  @viktortnk
