### PR TITLE
None should result in JNothing rather than JNull to optimize the rendered JSON.

### DIFF
--- a/core/json-scalaz/src/main/scala/net/liftweb/json/scalaz/Base.scala
+++ b/core/json-scalaz/src/main/scala/net/liftweb/json/scalaz/Base.scala
@@ -99,7 +99,7 @@ trait Base { this: Types =>
     }
   }
   implicit def optionJSONW[A: JSONW]: JSONW[Option[A]] = new JSONW[Option[A]] {
-    def write(value: Option[A]) = value.map(x => toJSON(x)).getOrElse(JNull)
+    def write(value: Option[A]) = value.map(x => toJSON(x)).getOrElse(JNothing)
   }
 
   implicit def mapJSONR[A: JSONR]: JSONR[Map[String, A]] = new JSONR[Map[String, A]] {

--- a/core/json-scalaz7/src/main/scala/net/liftweb/json/scalaz/Base.scala
+++ b/core/json-scalaz7/src/main/scala/net/liftweb/json/scalaz/Base.scala
@@ -103,7 +103,7 @@ trait Base { this: Types =>
     }
   }
   implicit def optionJSONW[A: JSONW]: JSONW[Option[A]] = new JSONW[Option[A]] {
-    def write(value: Option[A]) = value.map(x => toJSON(x)).getOrElse(JNull)
+    def write(value: Option[A]) = value.map(x => toJSON(x)).getOrElse(JNothing)
   }
 
   implicit def mapJSONR[A: JSONR]: JSONR[Map[String, A]] = new JSONR[Map[String, A]] {

--- a/liftsh.cmd
+++ b/liftsh.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 @REM Internal options, always specified
-set INTERNAL_OPTS=-Dfile.encoding=UTF-8 -Xmx768m -noverify -XX:ReservedCodeCacheSize=96m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=512m
+set INTERNAL_OPTS=-Dfile.encoding=UTF-8 -Xmx768m -noverify -XX:ReservedCodeCacheSize=256m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:MaxPermSize=512m
 
 @REM Add 64bit specific option
 java -version 2>&1 | find "64-Bit" >nul:


### PR DESCRIPTION
None should result in JNothing rather than JNull to optimize the rendered JSON. Also bumped the reserved code cache size to prevent errors when building locally.
