### PR TITLE
Fix for Issue #1442. NPE in compactRender for List with null values

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -469,9 +469,13 @@ object JsonAST {
   private def bufRenderArr(xs: List[JValue], buf: StringBuilder): StringBuilder = {
     buf.append("[") //open array
     if (!xs.isEmpty) {
-      xs.foreach(elem => if (elem.values != JNothing) {
-        bufRender(elem, buf)
-        buf.append(",")
+      xs.foreach(elem => Option(elem) match {
+        case Some(e) =>
+          if (e != JNothing) {
+            bufRender(e, buf)
+            buf.append(",")
+          }
+        case None => buf.append("null,")
       })
       if (buf.last == ',')
         buf.deleteCharAt(buf.length - 1) //delete last comma

--- a/core/json/src/test/scala/net/liftweb/json/Examples.scala
+++ b/core/json/src/test/scala/net/liftweb/json/Examples.scala
@@ -147,6 +147,11 @@ trait AbstractExamples extends Specification {
     print(json) mustEqual """{"id":5,"tags":{"a":5,"b":7}}"""
   }
 
+  "Naked JArray with null values" in {
+    val json = JArray(List(null))
+    print(json) mustEqual """[null]"""
+  }
+
 }
 
 object Examples {


### PR DESCRIPTION
check elem.values in an Option to prevent NPE
