### PR TITLE
SHtml.ajaxSelect doesn't serialize ampersands (&) correctly.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -992,7 +992,7 @@ trait SHtml {
 
   private def ajaxSelect_*(opts: Seq[SelectableOption[String]], deflt: Box[String],
                            jsFunc: Box[Call], func: AFuncHolder, attrs: ElemAttr*): Elem = {
-    val raw = (funcName: String, value: String) => JsRaw("'" + funcName + "=' + " + value + ".options[" + value + ".selectedIndex].value")
+    val raw = (funcName: String, value: String) => JsRaw("'" + funcName + "=' + encodeURIComponent(" + value + ".options[" + value + ".selectedIndex].value)")
     val key = formFuncName
 
     val vals = opts.map(_.value)


### PR DESCRIPTION
In working with a dynamic set of select boxes similar to the one at http://demo.liftweb.net/ajax-form, I had difficulty if the values in the first select contained ampersands.  We discussed this on the forum at https://groups.google.com/d/topic/liftweb/v2H5tvkiTPk/discussion. 

I went ahead and verified that an SHtml.ajaxText does not have this trouble.  
