### PR TITLE
Lift could annotate type of primaryKeyField as a workaround to Scala regression SI-7612

### DIFF
--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/Mapper.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/Mapper.scala
@@ -315,7 +315,7 @@ trait BaseLongKeyedMapper extends BaseKeyedMapper {
 
 trait IdPK /* extends BaseLongKeyedMapper */ {
   self: BaseLongKeyedMapper =>
-  def primaryKeyField = id
+  def primaryKeyField: MappedLongIndex[MapperType] = id
   object id extends MappedLongIndex[MapperType](this.asInstanceOf[MapperType])
 }
 

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
@@ -29,7 +29,7 @@ trait ProtoExtendedSession[T <: ProtoExtendedSession[T]] extends
 KeyedMapper[Long, T] {
   self: T =>
 
-  override def primaryKeyField = id
+  override def primaryKeyField: MappedLongIndex[T] = id
 
   // the primary key for the database
   object id extends MappedLongIndex(this)

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoTag.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoTag.scala
@@ -72,7 +72,7 @@ abstract class ProtoTag[MyType <: ProtoTag[MyType]] extends KeyedMapper[Long, My
   // the primary key for the database
   object id extends MappedLongIndex(this)
 
-  def primaryKeyField = id
+  def primaryKeyField: MappedLongIndex[MyType] = id
 
   object name extends MappedPoliteString(this, 256) {
     override def setFilter = getSingleton.capify :: super.setFilter

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoUser.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoUser.scala
@@ -38,7 +38,7 @@ import net.liftweb.proto.{ProtoUser => GenProtoUser}
 trait ProtoUser[T <: ProtoUser[T]] extends KeyedMapper[Long, T] with UserIdAsString {
   self: T =>
 
-  override def primaryKeyField = id
+  override def primaryKeyField: MappedLongIndex[T] = id
 
   /**
    * The primary key field for the User.  You can override the behavior

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/MapperSpecsModel.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/MapperSpecsModel.scala
@@ -129,7 +129,7 @@ class SampleModel extends KeyedMapper[Long, SampleModel] {
   def getSingleton = SampleModel
 
   // what's the "meta" server
-  def primaryKeyField = id
+  def primaryKeyField: MappedLongIndex[SampleModel] = id
 
   object id extends MappedLongIndex(this)
 


### PR DESCRIPTION
The Scala team has just been notified of a [regression](https://issues.scala-lang.org/browse/SI-7612) in Scala 2.10.1 that can trigger a StackOverflowError during typechecking. The reporter was using Lift mapper.

We'll fix the regression in Scala (probably in 2.10.3, but certainly in 2.11.0). But in the meantime you might consider annotating the type of `primaryKeyField` in `IdPK` to `MappedLongIndex[MapperType]`, rather the relying on the inferred type of `id.type`.

Here's where I found that code.

``` scala
trait IdPK /* extends BaseLongKeyedMapper */ {
  self: BaseLongKeyedMapper =>
  def primaryKeyField = id
  def primaryKeyField = id
  object id extends MappedLongIndex[MapperType](this.asInstanceOf[MapperType])
}
```

A few more:

```
Searching 865 files for "primaryKeyField = id" (regex)

/Users/jason/code/lift-framework/persistence/mapper/src/main/scala/net/liftweb/mapper/Mapper.scala:
  316  trait IdPK /* extends BaseLongKeyedMapper */ {
  317    self: BaseLongKeyedMapper =>
  318:   def primaryKeyField = id
  319    object id extends MappedLongIndex[MapperType](this.asInstanceOf[MapperType])
  320  }

/Users/jason/code/lift-framework/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala:
   30    self: T =>
   31  
   32:   override def primaryKeyField = id
   33  
   34    // the primary key for the database

/Users/jason/code/lift-framework/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoTag.scala:
   73    object id extends MappedLongIndex(this)
   74  
   75:   def primaryKeyField = id
   76  
   77    object name extends MappedPoliteString(this, 256) {

/Users/jason/code/lift-framework/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoUser.scala:
   39    self: T =>
   40  
   41:   override def primaryKeyField = id
   42  
   43    /**

/Users/jason/code/lift-framework/persistence/mapper/src/test/scala/net/liftweb/mapper/MapperSpecsModel.scala:
  130  
  131    // what's the "meta" server
  132:   def primaryKeyField = id
  133  
  134    object id extends MappedLongIndex(this)
  ...
  201  
  202    // what's the "meta" server
  203:   def primaryKeyField = id
  204  
  205    object id extends MappedLongIndex(this)
```

Apologies for the regression!
