### PR TITLE
[Breaking change] - Remove ActorWatcher from Lift 2.6

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -109,7 +109,6 @@ object BuildDef extends Build {
                   libraryDependencies <++= scalaVersion { sv =>
                     Seq(commons_fileupload, servlet_api, specs2(sv).copy(configurations = Some("provided")), jetty6, jwebunit)
                   },
-                  libraryDependencies <++= scalaVersion { case "2.10.0" => scalaactors::Nil  case _ => Nil },
                   initialize in Test <<= (sourceDirectory in Test) { src =>
                     System.setProperty("net.liftweb.webapptest.src.test.webapp", (src / "webapp").absString)
                   })

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,6 @@ object Dependencies {
   lazy val scalaz7_core: ModuleMap = sv => scalazGroup(sv)       % "scalaz-core"        % scalaz7Version(sv) cross CVMapping29
   lazy val slf4j_api              = "org.slf4j"                  % "slf4j-api"          % slf4jVersion
   lazy val squeryl                = "org.squeryl"                % "squeryl"            % "0.9.5-6" cross CVMapping29
-  @deprecated lazy val scalaactors= "org.scala-lang"             % "scala-actors"       % "2.10.0"
 
   // Aliases
   lazy val mongo_driver = mongo_java_driver

--- a/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
@@ -19,63 +19,16 @@ package http
 
 import net.liftweb.common._
 import net.liftweb.actor._
-import scala.collection.mutable.{ListBuffer}
 import net.liftweb.util.Helpers._
 import net.liftweb.util._
 import net.liftweb.json._
 import scala.xml.{NodeSeq, Text, Elem, Node, Group, Null, PrefixedAttribute, UnprefixedAttribute}
-import scala.collection.immutable.TreeMap
-import scala.collection.mutable.{HashSet, ListBuffer}
+import scala.collection.mutable.ListBuffer
 import net.liftweb.http.js._
 import JsCmds._
 import JE._
-import java.util.concurrent.atomic.AtomicLong
 import java.util.Locale
 
-/**
- * An actor that monitors other actors that are linked with it. If a watched
- * actor terminates, this actor captures the Exit message, executes failureFuncs
- * and resurrects the actor.
- */
-object ActorWatcher extends scala.actors.Actor with Loggable {
-
-  import scala.actors.Actor._
-
-  def act = loop {
-    react {
-      case scala.actors.Exit(actor: scala.actors.Actor, why: Throwable) =>
-        failureFuncs.foreach(f => tryo(f(actor, why)))
-
-      case _ =>
-    }
-  }
-
-  private def startAgain(a: scala.actors.Actor, ignore: Throwable) {
-    a.start
-    a ! RelinkToActorWatcher
-  }
-
-  private def logActorFailure(actor: scala.actors.Actor, why: Throwable) {
-    logger.warn("The ActorWatcher restarted " + actor + " because " + why, why)
-  }
-
-  /**
-   * If there's something to do in addition to starting the actor up, pre-pend the
-   * actor to this List
-   */
-  @volatile var failureFuncs: List[(scala.actors.Actor, Throwable) => Unit] = logActorFailure _ ::
-    startAgain _ :: Nil
-
-  this.trapExit = true
-  this.start
-}
-
-/**
- * This is used as an indicator message for linked actors.
- *
- * @see ActorWatcher
- */
-case object RelinkToActorWatcher
 
 trait DeltaTrait {
   def toJs: JsCmd


### PR DESCRIPTION
Based on this thread
https://groups.google.com/d/topic/liftweb/NIWsVfXbvZ4/discussion

We are removing the `ActorWatcher` object on Lift 2.6

It is not used anywhere in the code base, and even the scala standard library deprecated it
