### PR TITLE
SqlServerBaseDriver should set brokenLimit_? to true

### DIFF
--- a/persistence/db/src/main/scala/net/liftweb/db/Driver.scala
+++ b/persistence/db/src/main/scala/net/liftweb/db/Driver.scala
@@ -364,6 +364,8 @@ abstract class SqlServerBaseDriver extends DriverType("Microsoft SQL Server") {
   // Microsoft doesn't use "COLUMN" syntax when adding a column to a table
   override def alterAddColumn = "ADD"
 
+  override def brokenLimit_? = true
+
 }
 
 /**


### PR DESCRIPTION
I am developing a new application with Lift 2.5.1 and MS SQL 2012 using the Microsoft JDBC driver. I run into the same problem that I found in this Google Group discussion here:

https://groups.google.com/forum/#!topic/liftweb/lIxSPe-zuhE

However, I haven't seen an issue being opened for this, so this is why I am opening this issue. (I hope I am not violating your guidelines for contributing with that - although I think I am not).

The SqlServerBaseDriver class should set the  brokenLimit_? to true. At the moment I am using the workaround as described in the discussion. Defining my own DriverType object:

``` scala
object FixSqlServerDriver extends SqlServerBaseDriver {
  override def brokenLimit_? : Boolean = true
}
```

and simply overriding the DriverType.calcDriver in the Boot class with 

``` scala
DriverType.calcDriver = _ => FixSqlServerDriver
```

It would be nice to see the brokenLimit_? set to true in the SqlServerBaseDriver already, so that one does not have to do the ugly workarounds.

If this has been fixed already or I am just super ugly wrong with my issue here, my deepest apologies.
