### PR TITLE
Fixed #1485 - Replace console.log for lift_defaultLogError - Lift 3.0

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/js/ScriptRenderer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/ScriptRenderer.scala
@@ -91,15 +91,15 @@ object ScriptRenderer {
         '_failed': false,
         processMsg: function(evt) {if (this._done || this._failed) return;
                                 this._events.push(evt);
-                                for (var v in this._eventFuncs) {try {this._eventFuncs[v](evt);} catch (e) {console.log(e);}};
+                                for (var v in this._eventFuncs) {try {this._eventFuncs[v](evt);} catch (e) {""" + (LiftRules.jsLogFunc.map(_(JsVar("e")).toJsCmd) openOr "") + """}};
                                 if (evt.done) {this.doneMsg();} else if (evt.success) {this.successMsg(evt.success);} else if (evt.failure) {this.failMsg(evt.failure);}},
         successMsg: function(value) {if (this._done || this._failed) return; this._values.push(value); for (var f in this._valueFuncs) {this._valueFuncs[f](value);}},
         failMsg: function(msg) {if (this._done || this._failed) return; liftAjax._removeIt(this.guid); this._failed = true; this._failMsg = msg; for (var f in this._failureFuncs) {this._failureFuncs[f](msg);}},
         doneMsg: function() {if (this._done || this._failed) return; liftAjax._removeIt(this.guid); this._done = true; for (var f in this._doneFuncs) {this._doneFuncs[f]();}},
-        then: function(f) {this._valueFuncs.push(f); for (var v in this._values) {try {f(this._values[v]);} catch (e) {console.log(e);}} return this;},
-        fail: function(f) {this._failureFuncs.push(f); if (this._failed) {try {f(this._failMsg);} catch (e) {console.log(e);}}; return this;},
-        done: function(f) {this._doneFuncs.push(f); if (this._done) {try {f();} catch (e) {console.log(e);}} return this;},
-        onEvent: function(f) {this._eventFuncs.push(f); for (var v in this._events) {try {f(this._events[v]);} catch (e) {console.log(e);}}; return this;},
+        then: function(f) {this._valueFuncs.push(f); for (var v in this._values) {try {f(this._values[v]);} catch (e) {""" + (LiftRules.jsLogFunc.map(_(JsVar("e")).toJsCmd) openOr "") + """;}} return this;},
+        fail: function(f) {this._failureFuncs.push(f); if (this._failed) {try {f(this._failMsg);} catch (e) {""" + (LiftRules.jsLogFunc.map(_(JsVar("e")).toJsCmd) openOr "") + """;}}; return this;},
+        done: function(f) {this._doneFuncs.push(f); if (this._done) {try {f();} catch (e) {""" + (LiftRules.jsLogFunc.map(_(JsVar("e")).toJsCmd) openOr "") + """;}} return this;},
+        onEvent: function(f) {this._eventFuncs.push(f); for (var v in this._events) {try {f(this._events[v]);} catch (e) {""" + (LiftRules.jsLogFunc.map(_(JsVar("e")).toJsCmd) openOr "") + """;}}; return this;},
         map: function(f) {var ret = new liftAjax.Promise(); this.done(function() {ret.doneMsg();}); this.fail(function (m) {ret.failMsg(m);}); this.then(function (v) {ret.successMsg(f(v));}); return ret;}
       };
     },


### PR DESCRIPTION
closes #1485 

We have some a few calls to console.log which should be replace for a custom function that checks if the console function is available client side or not.

See this related thread: https://groups.google.com/d/topic/liftweb/T3BxrGp2xss/discussion

This pull request is for 3.0
