### PR TITLE
(2.6 and 3.0) fix json parser e+ bug

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -250,7 +250,7 @@ object JsonParser {
           if (c == '.' || c == 'e' || c == 'E') {
             doubleVal = true
             s.append(c)
-          } else if (!(Character.isDigit(c) || c == '.' || c == 'e' || c == 'E' || c == '-')) {
+          } else if (!(Character.isDigit(c) || c == '.' || c == 'e' || c == 'E' || c == '-' || c == '+')) {
             wasInt = false
             buf.back
           } else s.append(c)

--- a/core/json/src/test/scala/net/liftweb/json/ParserBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ParserBugs.scala
@@ -52,6 +52,12 @@ object ParserBugs extends Specification {
     parse(s) mustEqual json
   }
 
+  "Double in scientific notation with + can be parsed" in {
+    val json = JObject(List(JField("t", JDouble(12.3))))
+    val s = """{"t" : 1.23e+1}"""
+    parse(s) mustEqual json
+  }
+
   private val discardParser = (p : JsonParser.Parser) => {
      var token: JsonParser.Token = null
      do {


### PR DESCRIPTION
According to http://www.json.org/ the double in JSON can be represented in scientific notation, and e symbol can be one of the following:
e
e+
e-
E
E+
E-
net.liftweb.json.parse was working ok with e, e-, E, E- but was throwing exception "can't parse" for e+ and E+.
Added unit test (was failing). Added c == '+' analogous to c == '-' to JsonParser.scala. This fixed unit test.
P.S. The same issue exists in master, but we use 2.4 so I fixed it in 2.4 branch. The change is atomic and can be merged to any lift version, including master.
