### PR TITLE
Improve performance of decomposing case classes to Json

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -186,3 +186,10 @@ Kenji Yoshida
 ### Email: ###
 6b656e6a69 at gmail dot com
 
+### Name: ###
+Christopher Webster
+
+### Email: ###
+cwebster93 at gmail .. com
+
+


### PR DESCRIPTION
The Extraction.decompose method used Class.getDeclaredField which performs a linear scan of the fields for each element in the case class constructor. This pull request does a single pass over the fields storing them in a map hence reducing the algorithm complexity to O(n). 

A benchmark (https://gist.github.com/chriswebster/7291295) before and after the change showed:

Before change:
[info] Running ExtractionBenchmark 3 100000
ExtractionBenchmark$    2675     2390 2418 

After change:
info] Running ExtractionBenchmark 3 100000
ExtractionBenchmark$    1131     843     817
