### PR TITLE
Added LiftRules.funcNameGenerator which controls the logic of S.formFuncName

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -146,6 +146,11 @@ object LiftRules extends LiftRulesMocker {
     val ExecutionFailure = Value(11, "Execution Failure")
   }
 
+  def defaultFuncNameGenerator(runMode: Props.RunModes.Value): () => String =
+    runMode match {
+      case Props.RunModes.Test => S.generateTestFuncName _
+      case _                   => S.generateFuncName _
+    }
 }
 
 /**
@@ -1790,6 +1795,9 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
 
   /** Controls whether or not the service handling timing messages (Service request (GET) ... took ... Milliseconds) are logged. Defaults to true. */
   @volatile var logServiceRequestTiming = true
+
+  /** Provides a function that returns random names for form variables, page ids, callbacks, etc. */
+  @volatile var funcNameGenerator: () => String = defaultFuncNameGenerator(Props.mode)
 
   import provider.servlet._
   import containers._

--- a/web/webkit/src/test/scala/net/liftweb/http/SSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/SSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package http
+
+import org.specs2.mutable.Specification
+import util.Helpers
+import util.Props.RunModes
+import LiftRules.defaultFuncNameGenerator
+
+object SSpec extends Specification  {
+  "S Specification".title
+
+  "formFuncName" should {
+    "generate random names when not in Test mode" in {
+      for (mode <- RunModes.values if mode != RunModes.Test) {
+        val a,b = defaultFuncNameGenerator(mode)()
+        a must startWith("F")
+        a.length must_== Helpers.nextFuncName.length
+        a must_!= b
+      }
+    }
+
+    "generate predictable names in Test mode" in {
+      val a,b = S.formFuncName
+      a must startWith("f")
+      a.length must_!= Helpers.nextFuncName.length
+      a must_== b
+      a must_!= S.formFuncName
+    }
+
+    "generate resort back to random names when test func-names disabled" in {
+      S.disableTestFuncNames {
+        val a,b = S.formFuncName
+        a must startWith("F")
+        a.length must_== Helpers.nextFuncName.length
+        a must_!= b
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
Just as before, TestMode gets different logic until names are generated when `S._disableTestFuncNames` is true.

https://groups.google.com/forum/#!topic/liftweb/5G0UyCn0HBc
