### PR TITLE
We don't build in 2.10.3

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
@@ -360,7 +360,7 @@ trait AbstractScreen extends Factory {
         case AVal(v: (T => List[FieldError])) => v
       },
       stuff.toList.collect {
-        case AFilter(v) => v
+        case filter: AFilter[T] => filter.f
       },
       stuff)
   }
@@ -484,7 +484,7 @@ trait AbstractScreen extends Factory {
       }.toList
 
       override def setFilter = stuff.collect {
-        case AFilter(f) => f
+        case filter: AFilter[T] => filter.f
       }.toList
 
       override def is = underlying.get
@@ -586,7 +586,7 @@ trait AbstractScreen extends Factory {
       }.toList
 
       override def setFilter = stuff.collect {
-        case AFilter(f) => f
+        case filter: AFilter[T] => filter.f
       }.toList
 
       override def is = underlying.openOrThrowException("Legacy code").get
@@ -617,7 +617,7 @@ trait AbstractScreen extends Factory {
       case AVal(v: (T => List[FieldError])) => List(v)
       case _ => Nil
     }, stuff.toList.flatMap {
-      case AFilter(v) => List(v)
+      case filter: AFilter[T] => List(filter.f)
       case _ => Nil
     }, stuff).make
 
@@ -755,7 +755,7 @@ trait AbstractScreen extends Factory {
           override lazy val formElemAttrs: Seq[SHtml.ElemAttr] = grabParams(stuff)
 
           override val setFilter = stuff.flatMap {
-            case AFilter(f) => List(f)
+            case filter: AFilter[T] => List(filter.f)
             case _ => Nil
           }.toList
           override val validations = stuff.flatMap {
@@ -792,7 +792,7 @@ trait AbstractScreen extends Factory {
           override lazy val formElemAttrs: Seq[SHtml.ElemAttr] = grabParams(stuff)
 
           override val setFilter = stuff.flatMap {
-            case AFilter(f) => List(f)
+            case filter: AFilter[T] => List(filter.f)
             case _ => Nil
           }.toList
           override val validations = stuff.flatMap {


### PR DESCRIPTION
I noticed today that Lift WebKit's LiftScreen doesn't build in 2.10.3, as discussed [here](https://groups.google.com/d/msg/liftweb/5ka_RzZrQSo/PBBr0QqPV08J). It appears to be a type issue associated with how the latest 2.10's handle parameterized types. Specifically, in this code, 2.10.0 used to allow for the following:

``` scala
stuff.collect {
  case AFilter(f) => f
}.toList
```

Where `f` is of type `T=>T`. This would result in a `List[T=>T]` so you could feed it into areas requiring a `List[T=>T]`. Except, the newer 2.10's seem to think that this code can generate a "list of something to something where some of those somethings are descendants of T" (best English rendering of the error message).

The fix appears to be to replace these with

``` scala
stuff.collect {
  case filter: AFilter[T] => filter.f
}
```

Fix is in progress.
