### PR TITLE
Change autoIncludeAjaxCalc to a volatile var to support a JQueryMobile use case

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -192,4 +192,10 @@ Christopher Webster
 ### Email: ###
 cwebster93 at gmail .. com
 
+### Name: ###
+Kevin Grigorenko
+
+### Email: ###
+kevgrig at gmail dot com
+
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1533,7 +1533,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   @deprecated("Use autoIncludeAjaxCalc", "2.4")
   @volatile var autoIncludeAjax: LiftSession => Boolean = session => autoIncludeAjaxCalc.vend().apply(session)
 
-  val autoIncludeAjaxCalc: FactoryMaker[() => LiftSession => Boolean] = 
+  @volatile var autoIncludeAjaxCalc: FactoryMaker[() => LiftSession => Boolean] = 
   new FactoryMaker(() => () => (session: LiftSession) => true) {}
 
   /**


### PR DESCRIPTION
By default, JQueryMobile (JQM) uses AJAX to load pages. This is primarily necessary in Phonegap so that the initial page load occurs at file:/// (with access to phonegap.js and thus some phone APIs through JavaScript) and all links can be enhanced to access a remote server through AJAX. The AJAX call requests the full page, searches for the data-role="page" DIV and injects that into the DOM (and removes the previous page). It is useful in some cases to control either the content or the location of liftAjax.js and thus include it manually in page content (or on an AJAX call). This is currently impossible because LiftRules.autoIncludeAjaxCalc is a val (and this is how LiftMerge decides whether to include liftAjax.js). This commit simply changes it to a var.
