### PR TITLE
Memoize declared fields to avoid reflection during case class decomposition

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -84,7 +84,7 @@ object Extraction {
         case x if (x.getClass.isArray) => JArray(x.asInstanceOf[Array[_]].toList map decompose)
         case x: Option[_] => x.flatMap[JValue] { y => Some(decompose(y)) }.getOrElse(JNothing)
         case x => 
-          val fields = x.getClass.getDeclaredFields.map(field => (field.getName, field)).toMap
+          val fields = getDeclaredFields(x.getClass)
           val constructorArgs = primaryConstructorArgs(x.getClass).map{ case (name, _) => (name,fields.get(name)) }
           constructorArgs.collect { case (name, Some(f)) =>
             f.setAccessible(true)

--- a/core/json/src/main/scala/net/liftweb/json/Meta.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Meta.scala
@@ -222,6 +222,7 @@ private[json] object Meta {
 
     private val primaryConstructors = new Memo[Class[_], List[(String, Type)]]
     private val declaredFields = new Memo[(Class[_], String), Boolean]
+    private val declaredFieldsMap = new Memo[Class[_], Map[String,Field]]
 
     def constructors(t: Type, names: ParameterNameReader, context: Option[Context]): List[(JConstructor[_], List[(String, Type)])] =
       rawClassOf(t).getDeclaredConstructors.map(c => (c, constructorArgs(t, c, names, context))).toList
@@ -355,6 +356,11 @@ private[json] object Meta {
         else findField(clazz.getSuperclass, name)
     }
 
+    def getDeclaredFields(clazz: Class[_]) : Map[String,Field] = {
+      def extractDeclaredFields = clazz.getDeclaredFields.map(field => (field.getName, field)).toMap
+      declaredFieldsMap.memoize(clazz, _ => extractDeclaredFields)
+    }
+    
     def hasDeclaredField(clazz: Class[_], name: String): Boolean = {
       def declaredField = try {
         clazz.getDeclaredField(name)


### PR DESCRIPTION
This change uses the memoize pattern in Meta to cache class fields avoiding reflection on subsequent calls.  

The change discussion on the mailing list:
https://groups.google.com/forum/#!topic/liftweb/O9DDgSZqkkc

Contributor file signature:
https://github.com/lift/framework/blob/master/contributors.md#name-23 
