### PR TITLE
unexpected WARN while using `with-resource-id`, lift-3.0-SNAPSHOT

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -254,7 +254,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
 
   // Unique identifier for this particular instance of Lift, used for
   // tagging resources below in attachResourceId.
-  private val instanceResourceId = Helpers.nextFuncName
+  private val instanceResourceId = "instance-" + Helpers.nextFuncName
 
   /**
    * Attaches an ID entity for resource URI specified in


### PR DESCRIPTION
Mailing list topic: https://groups.google.com/forum/#!msg/liftweb/z5rKAxR0y08/S811GG3BLmsJ

The actual bug is with having a WARNing:
01:50:52.564 WARN  [qtp1170205978-851126 - /img/favicon.png?F1171910628180AB1FAH=_] net.liftweb.http.LiftRules - Unmapped Lift-like parameter seen in request [/img/favicon.png]: F1171910628180AB1FAH
