### PR TITLE
Define Box.get

### DIFF
--- a/core/common/src/main/scala/net/liftweb/common/Box.scala
+++ b/core/common/src/main/scala/net/liftweb/common/Box.scala
@@ -234,6 +234,7 @@ sealed abstract class Box[+A] extends Product with Serializable{
    */
   def openOrThrowException(justification: String): A
 
+
   /**
    * Return the value contained in this Box if it is Full;
    * throw an exception otherwise.
@@ -251,6 +252,17 @@ sealed abstract class Box[+A] extends Product with Serializable{
    */
   @deprecated("use openOrThrowException, or better yet, do the right thing with your code and use map, flatMap or foreach", "2.4")
   final def open_! : A = openOrThrowException("Legacy method implementation")
+
+  /**
+   * Return the value contained in this Box if it is Full; throw an
+   * exception otherwise.  Please use openOrThrowException instead. In
+   * the past, this method triggered an implicit conversion to Option
+   * and could throw an unintended NullPointerException. That is no longer
+   * the case, and in Lift 3 this method will be changed to return
+   * a useless type so that the compiler will break attempts to use it.
+   */
+  @deprecated("use map/flatMap/foreach if possible, or openOrThrowException if you must", "2.6")
+  final def get: A = open_!
 
   /**
    * Return the value contained in this Box if it is Full;

--- a/core/common/src/test/scala/net/liftweb/common/BoxSpec.scala
+++ b/core/common/src/test/scala/net/liftweb/common/BoxSpec.scala
@@ -79,6 +79,11 @@ class BoxSpec extends Specification with ScalaCheck with BoxGenerator {
     "be defined from some legacy code (possibly passing null values). If the passed value is null, an Empty is returned" in {
       Box.legacyNullTest(null) must_== Empty
     }
+
+    "have get defined in a way compatible with Option" in {
+      Full(1).get must_== 1
+      (Empty: Box[Int]).get must throwA[NullPointerException]
+    }
   }
 
   "A Box" should {


### PR DESCRIPTION
Folks frequently use `.get` on `Box`, triggering the implicit `Box`->`Option` conversion
and thus both making it easier to open the box (bad) and making that process slower
(baddd).

Let's define a `get` method on `Box` that is declared to return an internal class and
throws an Exception. This will fail compiler checks and also not work at runtime. For
2.6, we can define a `get` method that works like `open_!` and immediately deprecate it.
