### PR TITLE
Spelling Bee: General spelling fixes + deprecations for 2.x series

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1560,9 +1560,13 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   /**
    * Compute the headers to be sent to the browser in addition to anything else that's sent
    */
-  val listOfSupplimentalHeaders: FactoryMaker[List[(String, String)]] = new FactoryMaker(() => List(("X-Lift-Version", liftVersion), ("X-Frame-Options", "SAMEORIGIN"))) {}
+  val supplementalHeaders: FactoryMaker[List[(String, String)]] = new FactoryMaker(() => List(("X-Lift-Version", liftVersion), ("X-Frame-Options", "SAMEORIGIN"))) {}
 
-  @volatile var supplimentalHeaders: HTTPResponse => Unit = s => listOfSupplimentalHeaders.vend.foreach{case (k, v) => s.addHeaders(List(HTTPParam(k, v)))}
+  @deprecated("Use supplementalHeaders with an 'e'. This misspelled variant will be removed in Lift 3.0.", "2.6")
+  final val listOfSupplimentalHeaders = supplementalHeaders
+
+  @deprecated("Use the supplementalHeaders (with an 'e') FactoryMaker. This misspelled variant will be removed in Lift 3.0.", "2.6")
+  @volatile var supplimentalHeaders: HTTPResponse => Unit = s => supplementalHeaders.vend.foreach{case (k, v) => s.addHeaders(List(HTTPParam(k, v)))}
 
   @volatile var calcIE6ForResponse: () => Boolean = () => S.request.map(_.isIE6) openOr false
 


### PR DESCRIPTION
This PR and branch is intended for general misspellings in the Lift API done in the
2.x series. These should:
- Deprecate the old version with a note indicating what the correct version is and the
  fact that the misspelled version will be gone in Lift 3.0.
- Delegate calls to the old version to the new, correctly-spelled version.

This for #1529.
