### PR TITLE
2.6: Add proper deprecation warnings to two methods.

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -304,6 +304,7 @@ trait TimeHelpers { self: ControlHelpers =>
    * @deprecated use today instead
    * @return the current Day as a Date object
    */
+  @deprecated("use today instead", "2.6")
   def dayNow: Date = 0.seconds.later.noTime
 
   /** alias for new Date(millis) */

--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -1679,6 +1679,7 @@ trait SHtml {
    *
    * @deprecated Use ajaxForm(NodeSeq,JsCmd) instead
    */
+  @deprecated("Use ajaxForm(NodeSeq, JsCmd) instead.", "2.6")
   def ajaxForm(onSubmit: JsCmd, body: NodeSeq) = (<lift:form onsubmit={onSubmit.toJsCmd}>{body}</lift:form>)
 
   /**


### PR DESCRIPTION
These were deprecated in the scaladoc but not annotated as such, so did not
emit warnings.
