### PR TITLE
Tweak some TimeHelpers specs for reliability.

### DIFF
--- a/core/util/src/test/scala/net/liftweb/util/TimeHelpersSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/TimeHelpersSpec.scala
@@ -91,7 +91,7 @@ object TimeHelpersSpec extends Specification with ScalaCheck with TimeAmountsGen
     "have a later method returning a date relative to now plus the time span" in {
       val expectedTime = new Date().getTime + 3.seconds.millis
 
-      3.seconds.later.getTime must beCloseTo(expectedTime, 500L)
+      3.seconds.later.getTime must beCloseTo(expectedTime, 700L)
     }
     "have an ago method returning a date relative to now minus the time span" in {
       val expectedTime = new Date().getTime - 3.seconds.millis


### PR DESCRIPTION
Because of the way specs2 matchers work, calculating the expected time
in the call-by-name matcher could result in some weirdness. We now
precompute the expected time.

Can't guarantee this'll fix the issues, but I think it could help.
