### PR TITLE
ListenerManager.listenerService AddAListener fix

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
@@ -201,7 +201,7 @@ trait ListenerManager {
       val pair = (who, wantsMessage)
       listeners ::= pair
 
-      updateListeners(who :: Nil)
+      updateListeners(pair :: Nil)
 
     case RemoveAListener(who) =>
       listeners = listeners.filter(_._1 ne who)


### PR DESCRIPTION
Ensure the correct updateListeners function is called when a listener is added.

I've tested this fix in our application and confirmed that it works correctly.
