### PR TITLE
"withFilter" method on the BaseResponse class

### DIFF
--- a/web/testkit/src/main/scala/net/liftweb/http/testing/TestFramework.scala
+++ b/web/testkit/src/main/scala/net/liftweb/http/testing/TestFramework.scala
@@ -925,6 +925,8 @@ abstract class BaseResponse(override val baseUrl: String,
     f(st)
     st
   }
+
+  def withFilter(f: FuncType => Unit): FuncType = this.filter(f)
 }
 
 class CompleteFailure(val serverName: String, val exception: Box[Throwable]) extends TestResponse {


### PR DESCRIPTION
[Copied from the mailing list](https://groups.google.com/forum/?fromgroups#!topic/liftweb/bcQon7uigL8):

I'm cleaning up deprecation warnings on the Apache ESME project. We have some old tests that use for-comprehensions with filters and these tests are resulting in deprecation warnings like the following:

```
[warn] /Users/esjewett/svn_repos/esme/trunk/server/src/test/scala/org/apache/esme/api/ApiTest.scala:95: `withFilter' method does not yet exist on net.liftweb.http.testing.HttpResponse, using `filter' method instead
[warn]         login <- post("/api/login", "token" -> "00000000") !@ "Login should have failed: bad token" if shouldnt(testSuccess(login))
```

Would a "withFilter" method need to be added to the BaseResponse class in Lift, or is there maybe something that needs to be fixed on the ESMEs side that I'm missing?

Information to recreate is below. 

Offending test file: http://svn.apache.org/viewvc/esme/trunk/server/src/test/scala/org/apache/esme/api/ApiTest.scala?view=markup
SVN checkout URL: http://svn.apache.org/repos/asf/esme/trunk/server
SBT command to recreate warnings: sbt clean test (tested with sbt 0.11.2)
