### PR TITLE
Listener Renaming: Rename updateListeners(Any) in ListenerManager

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
@@ -162,7 +162,7 @@ object ListenerManager {
  *
  *   override def mediumPriority = {
  *     case Tick => {
- *       updateListeners(Tick)
+ *       sendListenersMessage(Tick)
  *       ActorPing.schedule(this, Tick, 1000L)
  * }
  * }
@@ -230,10 +230,10 @@ trait ListenerManager {
   }
 
   /**
-   * Update the listeners with a message that we create. Note that
-   * with this invocation the createUpdate method is not used.
+   * Send a message we create to all of the listeners. Note that with this
+   * invocation the createUpdate method is not used.
    */
-  protected def updateListeners(msg: Any) {
+  protected def sendListenersMessage(msg: Any) {
     listeners foreach (_._1 ! msg)
   }
 


### PR DESCRIPTION
We do this because there is an updateListeners overload that takes a
list of actors to update, which is optional. Having an updateListeners
overload that takes an Any makes it really easy to accidentally call the
wrong updateListeners method by having the wrong type of List.
Additionally, it's particularly confusing to have the two methods named
the same thing when they behave differently.

We name the method that sends all listeners a message that is passed in
`sendListenersMessage` and leave `updateListeners` for sending all
listeners the message generated by `createUpdate`.
