### PR TITLE
updateListeners(Any)->sendListenersMessage.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
@@ -225,12 +225,15 @@ trait ListenerManager {
   }
 
   /**
-   * Update the listeners with a message that we create. Note that
-   * with this invocation the createUpdate method is not used.
+   * Send a message we create to all of the listeners. Note that with this
+   * invocation the createUpdate method is not used.
    */
-  protected def updateListeners(msg: Any) {
+  protected def sendListenersMessage(msg: Any) {
     listeners foreach (_._1 ! msg)
   }
+
+  @deprecated("Use sendListenersMessage instead.", "2.6")
+  protected def updateListeners(msg: Any) { sendListenersMessage(msg) }
 
   /**
    * This method provides legacy functionality for filtering messages


### PR DESCRIPTION
We do this because it's particularly confusing to have the two methods
named the same thing when they behave differently.

We name the method that sends all listeners a message that is passed in
`sendListenersMessage` and leave `updateListeners` for sending all
listeners the message generated by `createUpdate`.

The old updateListeners(Any) method is deprecated for the 2.6 cycle.
