### PR TITLE
More time for spec

### DIFF
--- a/core/util/src/test/scala/net/liftweb/util/TimeHelpersSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/TimeHelpersSpec.scala
@@ -91,12 +91,12 @@ object TimeHelpersSpec extends Specification with ScalaCheck with TimeAmountsGen
     "have a later method returning a date relative to now plus the time span" in {
       val expectedTime = new Date().getTime + 3.seconds.millis
 
-      3.seconds.later.getTime must beCloseTo(expectedTime, 700L)
+      3.seconds.later.getTime must beCloseTo(expectedTime, 1000L)
     }
     "have an ago method returning a date relative to now minus the time span" in {
       val expectedTime = new Date().getTime - 3.seconds.millis
 
-      3.seconds.ago.getTime must beCloseTo(expectedTime, 500L)
+      3.seconds.ago.getTime must beCloseTo(expectedTime, 1000L)
     }
     "have a toString method returning the relevant number of weeks, days, hours, minutes, seconds, millis" in {
       val conversionIsOk = forAll(timeAmounts)((t: TimeAmounts) => { val (timeSpanToString, timeSpanAmounts) = t


### PR DESCRIPTION
When tests run on cloudbees (or any other slow server), the time specs tend to take longer that 500 ms,
so give these two tests up to a second to still be considered correct (this is how master is right now)
