### PR TITLE
Conditionally exclude the Position.scala file in Scala <2.11.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -103,8 +103,15 @@ object BuildDef extends Build {
         .settings(description := "Utilities Library",
                   parallelExecution in Test := false,
                   libraryDependencies <++= scalaVersion {sv =>  Seq(scala_compiler(sv), joda_time,
-                    joda_convert, commons_codec, javamail, log4j, htmlparser)})
-
+                    joda_convert, commons_codec, javamail, log4j, htmlparser)},
+                  excludeFilter <<= scalaVersion { scalaVersion =>
+println(scalaVersion)
+                    if (scalaVersion.startsWith("2.11")) {
+                      HiddenFileFilter
+                    } else {
+                      HiddenFileFilter || "Position.scala"
+                    }
+                  })
 
   // Web Projects
   // ------------


### PR DESCRIPTION
Position is something we imported from scala.io because it was removed in Scala
2.11; in 2.10, we can lean on the one in the scala library. For people who used
sbt assembly to build fat JARs, having both in two different JARs resulted in
nasty-sauce. We now exclude it when building for Scala versions below 2.11 so
this issue doesn't come up.

This fixes #1588.
