### PR TITLE
Fix MongoDB specs.

### DIFF
--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectSpec.scala
@@ -231,7 +231,7 @@ class MongoDirectSpec extends Specification with MongoTestKit {
       coll.save(doc)
       db.getLastError.get("err") must beNull
       coll.save(doc2) must throwA[MongoException]
-      db.getLastError.get("err").toString must startWith("E11000 duplicate key error index")
+      db.getLastError.get("err").toString must contain("E11000 duplicate key error index")
       coll.save(doc3)
       db.getLastError.get("err") must beNull
 

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDocumentExamplesSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDocumentExamplesSpec.scala
@@ -493,7 +493,7 @@ class MongoDocumentExamplesSpec extends Specification with MongoTestKit {
       SessCollection.save(tc, db)
       db.getLastError.get("err") must beNull
       SessCollection.save(tc2, db) must throwA[MongoException]
-      db.getLastError.get("err").toString must startWith("E11000 duplicate key error index")
+      db.getLastError.get("err").toString must contain("E11000 duplicate key error index")
       SessCollection.save(tc3, db)
       db.getLastError.get("err") must beNull
 


### PR DESCRIPTION
MongoDB changed how they report errors a bit in one of the latest
releases. Error messages no longer start with the string we were
checking, but they do contain it - so this commit will get our specs
passing again and should keep them passing on older mongos.
