### PR TITLE
Your data-lift is my data-lift: Reimplement data-lift as a data attribute parser.

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/HtmlHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/HtmlHelpers.scala
@@ -328,7 +328,7 @@ trait HtmlHelpers extends CssBindImplicits {
    * Make a MetaData instance from a key and a value. If key contains a colon, this
    * method will generate a PrefixedAttribute with the text before the colon used as
    * the prefix. Otherwise, it will produce an UnprefixedAttribute.
-  **/
+   */
   def makeMetaData(key: String, value: String, rest: MetaData): MetaData = key.indexOf(":") match {
     case x if x > 0 => new PrefixedAttribute(key.substring(0, x),
       key.substring(x + 1),
@@ -341,7 +341,7 @@ trait HtmlHelpers extends CssBindImplicits {
    * Convert a list of strings into a MetaData of attributes.
    *
    * The strings in the list must be in the format of key=value.
-  **/
+   */
   def pairsToMetaData(in: List[String]): MetaData = in match {
     case Nil => Null
     case x :: xs => {

--- a/core/util/src/main/scala/net/liftweb/util/HtmlHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/HtmlHelpers.scala
@@ -19,6 +19,8 @@ package util
 
 import scala.language.higherKinds
 
+import StringHelpers._
+
 import scala.xml._
 
 import common._
@@ -319,6 +321,36 @@ trait HtmlHelpers extends CssBindImplicits {
           </div>)
 
         case _ => Empty
+    }
+  }
+
+  /**
+   * Make a MetaData instance from a key and a value. If key contains a colon, this
+   * method will generate a PrefixedAttribute with the text before the colon used as
+   * the prefix. Otherwise, it will produce an UnprefixedAttribute.
+  **/
+  def makeMetaData(key: String, value: String, rest: MetaData): MetaData = key.indexOf(":") match {
+    case x if x > 0 => new PrefixedAttribute(key.substring(0, x),
+      key.substring(x + 1),
+      value, rest)
+
+    case _ => new UnprefixedAttribute(key, value, rest)
+  }
+
+  /**
+   * Convert a list of strings into a MetaData of attributes.
+   *
+   * The strings in the list must be in the format of key=value.
+  **/
+  def pairsToMetaData(in: List[String]): MetaData = in match {
+    case Nil => Null
+    case x :: xs => {
+      val rest = pairsToMetaData(xs)
+      x.charSplit('=').map(Helpers.urlDecode) match {
+        case Nil => rest
+        case x :: Nil => makeMetaData(x, "", rest)
+        case x :: y :: _ => makeMetaData(x, y, rest)
+      }
     }
   }
 }

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -897,26 +897,6 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    */
   val dataAttributeProcessor: RulesSeq[DataAttributeProcessor] = new RulesSeq()
 
-  private def makeMetaData(key: String, value: String, rest: MetaData): MetaData = key.indexOf(":") match {
-    case x if x > 0 => new PrefixedAttribute(key.substring(0, x),
-      key.substring(x + 1),
-      value, rest)
-
-    case _ => new UnprefixedAttribute(key, value, rest)
-  }
-
-  private def pairsToMetaData(in: List[String]): MetaData = in match {
-    case Nil => Null
-    case x :: xs => {
-      val rest = pairsToMetaData(xs)
-      x.charSplit('=').map(Helpers.urlDecode) match {
-        case Nil => rest
-        case x :: Nil => makeMetaData(x, "", rest)
-        case x :: y :: _ => makeMetaData(x, y, rest)
-      }
-    }
-  }
-
   dataAttributeProcessor.append {
     case ("lift", snippetInvocation, element, liftSession) =>
       snippetInvocation.charSplit('?') match {

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -929,7 +929,14 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
 
         case snippetName :: encodedArguments =>
           val decodedMetaData = pairsToMetaData(encodedArguments.flatMap(_.roboSplit("[;&]")))
-          new Elem("lift", snippetName, decodedMetaData, element.scope, false, element)
+
+          if (decodedMetaData("parallel").headOption == Some(Text("true"))) {
+            DataAttributeProcessorAnswerFuture(LAFuture(() =>
+              new Elem("lift", snippetName, decodedMetaData, element.scope, false, element)
+            ))
+          } else {
+            new Elem("lift", snippetName, decodedMetaData, element.scope, false, element)
+          }
       }
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -918,8 +918,8 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   }
 
   dataAttributeProcessor.append {
-    case ("lift", dataLiftContents, element, liftSession) =>
-      dataLiftContents.charSplit('?') match {
+    case ("lift", snippetInvocation, element, liftSession) =>
+      snippetInvocation.charSplit('?') match {
         case Nil =>
           // This shouldn't ever happen.
           NodeSeq.Empty

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2185,11 +2185,11 @@ class LiftSession(private[http] val _contextPath: String, val uniqueId: String,
   private object _lastFoundSnippet extends ThreadGlobal[String]
 
   private object DataAttrNode {
-    val rules = LiftRules.dataAttributeProcessor.toList
+    val dataAttributeProcessors = LiftRules.dataAttributeProcessor.toList
 
     def unapply(in: Node): Option[DataAttributeProcessorAnswer] = {
       in match {
-        case element: Elem if ! rules.isEmpty =>
+        case element: Elem if dataAttributeProcessors.nonEmpty =>
           element.attributes.toStream.flatMap {
             case UnprefixedAttribute(key, value, _) if key.toLowerCase().startsWith("data-") =>
               val dataProcessorName = key.substring(5).toLowerCase()
@@ -2201,7 +2201,7 @@ class LiftSession(private[http] val _contextPath: String, val uniqueId: String,
 
               NamedPF.applyBox(
                 (dataProcessorName, dataProcessorInputValue, element.copy(attributes = filteredAttributes), LiftSession.this),
-                rules
+                dataAttributeProcessors
               )
             case _ => Empty
           }.headOption

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2194,13 +2194,10 @@ class LiftSession(private[http] val _contextPath: String, val uniqueId: String,
             case UnprefixedAttribute(key, value, _) if key.toLowerCase().startsWith("data-") =>
               val dataProcessorName = key.substring(5).toLowerCase()
               val dataProcessorInputValue = value.text
-              val filteredAttributes = element.attributes.filter{
-                case UnprefixedAttribute(k2, _, _) => k2 != key
-                case _ => true
-              }
+              val filteredElement = removeAttribute(key, element)
 
               NamedPF.applyBox(
-                (dataProcessorName, dataProcessorInputValue, element.copy(attributes = filteredAttributes), LiftSession.this),
+                (dataProcessorName, dataProcessorInputValue, filteredElement, LiftSession.this),
                 dataAttributeProcessors
               )
             case _ => Empty

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -3003,26 +3003,6 @@ private object SnippetNode {
       case _ => str
     }
 
-  private def makeMetaData(key: String, value: String, rest: MetaData): MetaData = key.indexOf(":") match {
-    case x if x > 0 => new PrefixedAttribute(key.substring(0, x),
-      key.substring(x + 1),
-      value, rest)
-
-    case _ => new UnprefixedAttribute(key, value, rest)
-  }
-
-  private def pairsToMetaData(in: List[String]): MetaData = in match {
-    case Nil => Null
-    case x :: xs => {
-      val rest = pairsToMetaData(xs)
-      x.charSplit('=').map(Helpers.urlDecode) match {
-        case Nil => rest
-        case x :: Nil => makeMetaData(x, "", rest)
-        case x :: y :: _ => makeMetaData(x, y, rest)
-      }
-    }
-  }
-
   private def isLiftClass(s: String): Boolean =
     s.startsWith("lift:") || s.startsWith("l:")
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -3026,19 +3026,24 @@ private object SnippetNode {
   private def isLiftClass(s: String): Boolean =
     s.startsWith("lift:") || s.startsWith("l:")
 
-  private def snippy(in: Elem): Option[(String, MetaData)] =
-    ((for {
-      cls <- in.attribute("class")
-      snip <- cls.text.charSplit(' ').find(isLiftClass)
-    } yield snip) orElse in.attribute("lift").map(_.text)
-      orElse in.attribute("data-lift").map(_.text)).map {
-      snip =>
-        snip.charSplit('?') match {
-          case Nil => "this should never happen" -> Null
-          case x :: Nil => urlDecode(removeLift(x)) -> Null
-          case x :: xs => urlDecode(removeLift(x)) -> pairsToMetaData(xs.flatMap(_.roboSplit("[;&]")))
-        }
+  private def snippy(in: Elem): Option[(String, MetaData)] = {
+    val snippetContents = {
+      for {
+        cls <- in.attribute("class")
+        snip <- cls.text.charSplit(' ').find(isLiftClass)
+      } yield {
+        snip
+      }
+    } orElse in.attribute("lift").map(_.text)
+
+    snippetContents.map { snip =>
+      snip.charSplit('?') match {
+        case Nil => "this should never happen" -> Null
+        case x :: Nil => urlDecode(removeLift(x)) -> Null
+        case x :: xs => urlDecode(removeLift(x)) -> pairsToMetaData(xs.flatMap(_.roboSplit("[;&]")))
+      }
     }
+  }
 
   private def liftAttrsAndParallel(in: MetaData): (Boolean, MetaData) = {
     var next = in

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2185,20 +2185,20 @@ class LiftSession(private[http] val _contextPath: String, val uniqueId: String,
 
     def unapply(in: Node): Option[DataAttributeProcessorAnswer] = {
       in match {
-        case e: Elem if !rules.isEmpty =>
-
-          val attrs = e.attributes
-
-          e.attributes.toStream.flatMap {
+        case element: Elem if ! rules.isEmpty =>
+          element.attributes.toStream.flatMap {
             case UnprefixedAttribute(key, value, _) if key.toLowerCase().startsWith("data-") =>
-              val nk = key.substring(5).toLowerCase()
-              val vs = value.text
-              val a2 = attrs.filter{
+              val dataProcessorName = key.substring(5).toLowerCase()
+              val dataProcessorInputValue = value.text
+              val filteredAttributes = element.attributes.filter{
                 case UnprefixedAttribute(k2, _, _) => k2 != key
                 case _ => true
               }
 
-              NamedPF.applyBox((nk, vs, new Elem(e.prefix, e.label, a2, e.scope, e.minimizeEmpty, e.child :_*), LiftSession.this), rules)
+              NamedPF.applyBox(
+                (dataProcessorName, dataProcessorInputValue, element.copy(attributes = filteredAttributes), LiftSession.this),
+                rules
+              )
             case _ => Empty
           }.headOption
 

--- a/web/webkit/src/test/scala/net/liftweb/webapptest/snippet/DeferredSnippet.scala
+++ b/web/webkit/src/test/scala/net/liftweb/webapptest/snippet/DeferredSnippet.scala
@@ -40,10 +40,9 @@ class DeferredSnippet {
   }
 
    def stackWhack: NodeSeq = {
-     val inActor: Boolean = Thread.currentThread.getStackTrace.
-     find(_.getClassName.contains("net.liftweb.actor.")).isDefined
+     val inActor: Boolean = Thread.currentThread.getStackTrace.find(_.getClassName.contains("net.liftweb.actor.")).isDefined
 
-   <span id={"actor_"+inActor}>stackWhack</span>
+     <span id={"actor_"+inActor}>stackWhack</span>
    }
 }
 

--- a/web/webkit/src/test/scala/net/liftweb/webapptest/snippet/DeferredSnippet.scala
+++ b/web/webkit/src/test/scala/net/liftweb/webapptest/snippet/DeferredSnippet.scala
@@ -40,7 +40,7 @@ class DeferredSnippet {
   }
 
    def stackWhack: NodeSeq = {
-     val inActor: Boolean = Thread.currentThread.getStackTrace.find(_.getClassName.contains("net.liftweb.actor.")).isDefined
+     val inActor: Boolean = Thread.currentThread.getStackTrace.exists(_.getClassName.contains("net.liftweb.actor."))
 
      <span id={"actor_"+inActor}>stackWhack</span>
    }


### PR DESCRIPTION
This PR reimplements data-lift as a data attribute parser. This stemmed from a Lift hack day a few months ago, and I'm just now getting around to wrapping this up...

Few points of concern:

* I want to go through at some point and clean up the copy-pasting of helper methods that I did wrt MetaData parsing.
* I'm not entirely sure why I'm having to manually check for the parallel attribute in my parser. My understanding was that if my parser generates a `lift:` node, that should be processed subsequently by the regular SnippetNode parser, which does checks for parallel processing.
* Can someone make sure my implementation of handling parallel is even functional while we're at it? lol

All specs are passing, though. So that's something.

closes #1582 