### PR TITLE
Extract-o-matic: Extract event handlers to page JS

### DIFF
--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -65,7 +65,7 @@
         consoleOrAlert("ajaxGet function must be defined in settings");
       },
       onDocumentReady: function(fn) {
-        consoleOrAlert("documentReady function must be defined in settings");
+        consoleOrAlert("onDocumentReady function must be defined in settings");
       },
       cometGetTimeout: 140000,
       cometFailureRetryTimeout: 10000,

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -581,7 +581,7 @@
         // start the cycle
         doCycleIn200();
       },
-      logError: settings.logError,
+      logError: function() { settings.logError.apply(this, arguments) },
       ajax: appendToQueue,
       startGc: successRegisterGC,
       ajaxOnSessionLost: function() {

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -550,7 +550,7 @@
         this.extend(settings, options);
 
         var lift = this;
-        options.onDocumentReady(function() {
+        settings.onDocumentReady(function() {
           var gc = document.body.getAttribute('data-lift-gc');
           if (gc) {
             lift.startGc();

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -170,7 +170,7 @@ private[http] trait LiftMerge {
               Nil
             } else {
               // When using javascript:-style URIs, return false is implied.
-              List(strippedJs + "; return false;")
+              List(strippedJs + "; event.preventDefault();")
             }
           }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -138,9 +138,9 @@ private[http] trait LiftMerge {
           fixAttrs(original, toFix, attrs.next, fixURL, EventAttribute(u.key.substring(2), u.value.text) :: eventAttributes)
 
         case u: UnprefixedAttribute if u.key == "id" =>
-          val (_, remainingAttributes, updatedEventAttributes) = fixAttrs(original, toFix, attrs.next, fixURL)
+          val (_, fixedAttributes, updatedEventAttributes) = fixAttrs(original, toFix, attrs.next, fixURL, eventAttributes)
 
-          (Option(u.value.text).filter(_.nonEmpty), remainingAttributes, updatedEventAttributes)
+          (Option(u.value.text).filter(_.nonEmpty), attrs.copy(fixedAttributes), updatedEventAttributes)
 
         case _ =>
           val (id, remainingAttributes, updatedEventAttributes) = fixAttrs(original, toFix, attrs.next, fixURL, eventAttributes)

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -67,7 +67,7 @@ private[http] trait LiftMerge {
         (elementId, eventAttributes) <- eventAttributesByElementId
         EventAttribute(eventName, jsString) <- eventAttributes
       } yield {
-        Call("lift.onEvent", elementId, eventName, AnonFunc(JsRaw(jsString).cmd)).cmd
+        Call("lift.onEvent", elementId, eventName, AnonFunc("event", JsRaw(jsString).cmd)).cmd
       }
 
     val allJs =


### PR DESCRIPTION
The main functionality here moves event handler attachment from inline attributes to the page JavaScript that Lift 3 now supports. The reason for this is so that, out of the box, Lift will be compatible with very restrictive [Content Security Policy](http://en.wikipedia.org/wiki/Content_Security_Policy) settings even when using built-in Lift features.

To do this, we add a `lift.onEvent` function that has both jQuery and vanilla implementations. There are also a couple of fixes to existing JS functionality here.

Still two things missing that I know of:
 - [x] Extract `javascript://` `href`s from `a` elements into event handlers (these should `preventDefault()`).
 - [x] Extract `javascript://` `action`s from `form` elements into event handlers (these should also `preventDefault()`).

Looking for some early thoughts/feedback from folks.