### PR TITLE
Build clean up now that we are only building for scala 2.11.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ scalaVersion in ThisBuild          := "2.11.2"
 
 crossScalaVersions in ThisBuild    := Seq("2.11.2")
 
-libraryDependencies in ThisBuild <++= scalaVersion {sv => Seq(specs2(sv), scalacheck, scalatest(sv)) }
+libraryDependencies in ThisBuild <++= scalaVersion {sv => Seq(specs2, scalacheck, scalatest) }
 
 // Settings for Sonatype compliance
 pomIncludeRepository in ThisBuild  := { _ => false }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -52,7 +52,7 @@ object BuildDef extends Build {
     coreProject("markdown")
         .settings(description := "Markdown Parser",
                   parallelExecution in Test := false,
-                  libraryDependencies <++= scalaVersion { sv => Seq(scalatest(sv), junit, scala_xml, scala_parser) }
+                  libraryDependencies <++= scalaVersion { sv => Seq(scalatest, junit, scala_xml, scala_parser) }
       )
 
   lazy val json =
@@ -70,7 +70,7 @@ object BuildDef extends Build {
     coreProject("json-scalaz7")
         .dependsOn(json)
         .settings(description := "JSON Library based on Scalaz 7",
-                  libraryDependencies <+= scalaVersion(scalaz7))
+                  libraryDependencies ++= Seq(scalaz7))
 
   lazy val json_ext =
     coreProject("json-ext")
@@ -84,14 +84,8 @@ object BuildDef extends Build {
         .settings(description := "Utilities Library",
                   parallelExecution in Test := false,
                   libraryDependencies <++= scalaVersion {sv =>  Seq(scala_compiler(sv), joda_time,
-                    joda_convert, commons_codec, javamail, log4j, htmlparser)},
-                  excludeFilter <<= scalaVersion { scalaVersion =>
-                    if (scalaVersion.startsWith("2.11")) {
-                      HiddenFileFilter
-                    } else {
-                      HiddenFileFilter || "Position.scala"
-                    }
-                  })
+                    joda_convert, commons_codec, javamail, log4j, htmlparser)}
+                  )
 
   // Web Projects
   // ------------
@@ -111,7 +105,7 @@ object BuildDef extends Build {
         .settings(description := "Webkit Library",
                   parallelExecution in Test := false,
                   libraryDependencies <++= scalaVersion { sv =>
-                    Seq(commons_fileupload, rhino, servlet_api, specs2(sv).copy(configurations = Some("provided")), jetty6,
+                    Seq(commons_fileupload, rhino, servlet_api, specs2.copy(configurations = Some("provided")), jetty6,
                       jwebunit)
                   },
                   initialize in Test <<= (sourceDirectory in Test) { src =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2013 WorldWide Conferencing, LLC
+ * Copyright 2011-2014 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,15 +23,9 @@ object Dependencies {
 
   type ModuleMap = String => ModuleID
 
-  lazy val CVMappingAll  = crossMapped("2.10.0" -> "2.10", "2.10.1" -> "2.10", "2.10.2" -> "2.10", "2.10.3" -> "2.10", "2.10.4" -> "2.10", "2.11.0" -> "2.11", "2.11.1" -> "2.11", "2.11.2" -> "2.11")
+  lazy val CVMappingAll  = crossMapped("2.11.2" -> "2.11")
 
   lazy val slf4jVersion = "1.7.2"
-
-  lazy val scalazGroup        = defaultOrMapped("org.scalaz")
-  lazy val scalazVersion      = defaultOrMapped("6.0.4")
-  lazy val scalaz7Version     = defaultOrMapped("7.0.0",  "2.11.2" -> "7.0.6")
-  lazy val specs2Version      = defaultOrMapped("1.12.3", "2.11.2" -> "2.3.11")
-  lazy val scalatestVersion   = defaultOrMapped("1.9.1",  "2.11.2" -> "2.1.3")
 
   // Compile scope:
   // Scope available in all classpath, transitive by default.
@@ -47,17 +41,15 @@ object Dependencies {
   lazy val scalajpa               = "org.scala-libs"             % "scalajpa"           % "1.5"     cross CVMappingAll
   lazy val scalap: ModuleMap      = "org.scala-lang"             % "scalap"             % _
   lazy val scala_compiler: ModuleMap = "org.scala-lang"          % "scala-compiler"     % _
-  lazy val scalaz_core: ModuleMap = sv => scalazGroup(sv)        % "scalaz-core"        % scalazVersion(sv) cross CVMappingAll
-  lazy val scalaz7_core: ModuleMap = sv => scalazGroup(sv)       % "scalaz-core"        % scalaz7Version(sv) cross CVMappingAll
-  lazy val slf4j_api              = "org.slf4j"                  % "slf4j-api"          % slf4jVersion
+  lazy val scalaz7_core           = "org.scalaz"                 % "scalaz-core"        % "7.0.6"   cross CVMappingAll
   lazy val squeryl                = "org.squeryl"                % "squeryl"            % "0.9.5-7" cross CVMappingAll
+  lazy val slf4j_api              = "org.slf4j"                  % "slf4j-api"          % slf4jVersion
   lazy val scala_xml              = "org.scala-lang.modules"     %% "scala-xml"         % "1.0.1"
-  lazy val rhino                  = "org.mozilla"                      % "rhino"                 % "1.7R4"
+  lazy val rhino                  = "org.mozilla"                % "rhino"              % "1.7R4"
   lazy val scala_parser           = "org.scala-lang.modules"     %% "scala-parser-combinators" % "1.0.1"
 
   // Aliases
   lazy val mongo_driver = mongo_java_driver
-  lazy val scalaz = scalaz_core
   lazy val scalaz7 = scalaz7_core
 
 
@@ -82,13 +74,13 @@ object Dependencies {
   // Test scope:
   // Scope available only in test classpath, non-transitive by default.
   // TODO: See if something alternative with lesser footprint can be used instead of mega heavy apacheds
-  lazy val apacheds    = "org.apache.directory.server" % "apacheds-server-integ"    % "1.5.5"      % "test" // TODO: 1.5.7
-  lazy val jetty6      = "org.mortbay.jetty"           % "jetty"                    % "6.1.26"     % "test"
-  lazy val jwebunit    = "net.sourceforge.jwebunit"    % "jwebunit-htmlunit-plugin" % "2.5"        % "test"
-  lazy val mockito_all = "org.mockito"                 % "mockito-all"              % "1.9.0"      % "test"
-  lazy val scalacheck  = "org.scalacheck"             %% "scalacheck"               % "1.10.1"     % "test"
-  lazy val specs2: ModuleMap     = sv => "org.specs2"     %% "specs2"     % specs2Version(sv)      % "test"
-  lazy val scalatest: ModuleMap  = sv => "org.scalatest"  %% "scalatest"  % scalatestVersion(sv)   % "test"
-  lazy val junit       = "junit"                          % "junit"       % "4.8.2"                % "test"
+  lazy val apacheds    = "org.apache.directory.server" % "apacheds-server-integ"    % "1.5.5"   % "test" // TODO: 1.5.7
+  lazy val jetty6      = "org.mortbay.jetty"           % "jetty"                    % "6.1.26"  % "test"
+  lazy val jwebunit    = "net.sourceforge.jwebunit"    % "jwebunit-htmlunit-plugin" % "2.5"     % "test"
+  lazy val mockito_all = "org.mockito"                 % "mockito-all"              % "1.9.0"   % "test"
+  lazy val scalacheck  = "org.scalacheck"             %% "scalacheck"               % "1.10.1"  % "test"
+  lazy val specs2      = "org.specs2"                 %% "specs2"                   % "2.3.11"  % "test"
+  lazy val scalatest   = "org.scalatest"              %% "scalatest"                % "2.1.3"   % "test"
+  lazy val junit       = "junit"                       % "junit"                    % "4.8.2"   % "test"
 
 }


### PR DESCRIPTION
- Simpler crossMapped
- Removed scalaz6
- Just use latest versions of specs2, scalatest and scalaz
