### PR TITLE
Fix issue with new password verification in ProtoUser.

### DIFF
--- a/persistence/proto/src/main/scala/net/liftweb/proto/ProtoUser.scala
+++ b/persistence/proto/src/main/scala/net/liftweb/proto/ProtoUser.scala
@@ -1033,8 +1033,11 @@ trait ProtoUser {
     }
 
     val bind = {
+      // Use the same password input for both new password fields.
+      val passwordInput = SHtml.password_*("", LFuncHolder(s => newPassword = s))
+
       ".old-password" #> SHtml.password("", s => oldPassword = s) &
-      ".new-password" #> SHtml.password_*("", LFuncHolder(s => newPassword = s)) &
+      ".new-password" #> passwordInput &
       "type=submit" #> changePasswordSubmitButton(S.?("change"), testAndSet _)
     }
 


### PR DESCRIPTION
When we converted from the original bind strategy, I forgot that the old
bind strategy evaluated things eagerly, while CSS selector transforms
call by name. This meant that the old bind strategy, when it bound both
new password fields (the new password and repeat new password fields) to
a single SHtml.password_\* invocation, actually bound both fields to the
same password input with the same GUID.

In the CSS selector transform port, the result was instead two fields
with two different GUIDs, which broke the expected behavior of the
password field (it was supposed to generate a List of two passwords,
which could then be checked for equality).

To fix this, we now create the single field ahead of time and pass that
to the selector transform so that the same field gets used twice instead
of a different field being generated each time.

Fixes #1594 .

@karma4u101 if you can have a look at this branch and see if it fixes
your issue, that'd be supah-cool :)
