### PR TITLE
Comet fixes

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2372,19 +2372,9 @@ class LiftSession(private[http] val _contextPath: String, val uniqueId: String,
 
       S.addComet(ca)
 
-      ca ! SetDeltaPruner(lastWhenDeltaPruner)
-
       ca
     }
   }
-
-
-  private def lastWhenDeltaPruner: (LiftCometActor, List[Delta]) => List[Delta] =
-    (ca, dl) => {
-      val when = ca.lastListenerTime
-      dl.filter(d => when <= d.timestamp)
-    }
-
 
   /**
    * Processes the surround tag and other lift tags
@@ -2830,8 +2820,6 @@ class LiftSession(private[http] val _contextPath: String, val uniqueId: String,
       implicit val defaultFormats = DefaultFormats
 
       ca ! PerformSetupComet2(Empty)
-
-      ca ! SetDeltaPruner(lastWhenDeltaPruner)
 
       S.addComet(ca)
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2382,7 +2382,7 @@ class LiftSession(private[http] val _contextPath: String, val uniqueId: String,
   private def lastWhenDeltaPruner: (LiftCometActor, List[Delta]) => List[Delta] =
     (ca, dl) => {
       val when = ca.lastListenerTime
-      dl.filter(d => when <= d.when)
+      dl.filter(d => when <= d.timestamp)
     }
 
 

--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -808,7 +808,7 @@ trait S extends HasParams with Loggable with UserAgentCalculator {
    */
   def addComet(cometActor: LiftCometActor): Unit = {
     requestCometVersions.set(
-      requestCometVersions.is + CVP(cometActor.uniqueId, cometActor.lastListenerTime)
+      requestCometVersions.is + CVP(cometActor.uniqueId, cometActor.lastRenderTime)
     )
   }
 


### PR DESCRIPTION
This fixes a handful of bugs that when taken together kept things mostly working!

  - Unify lastListenerTime (which was previously always zero) with
    lastListenTime
  - Make lastRenderTime, delta timestamps, and lastListenerTime
    consistent with each other as they are directly compared
  - More accurately track whether any deltas have been sent
  - Pretend initial render happened at creation time to prevent a second
    render call from running on the initial Listen message
  - Rename devMode to alwaysReRenderOnPageLoad