### PR TITLE
Signature of asJValue inconsistent

### DIFF
--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonRecordField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonRecordField.scala
@@ -94,7 +94,7 @@ class BsonRecordListField[OwnerType <: BsonRecord[OwnerType], SubRecordType <: B
       valueMeta.fromDBObject(dbo.get(k.toString).asInstanceOf[DBObject])
     })))
 
-  override def asJValue = JArray(value.map(_.asJValue))
+  override def asJValue: JValue = JArray(value.map(_.asJValue))
 
   override def setFromJValue(jvalue: JValue) = jvalue match {
     case JNothing|JNull if optional_? => setBox(Empty)

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/DBRefField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/DBRefField.scala
@@ -58,7 +58,7 @@ class DBRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefT
 
   def asJs = Str(toString)
 
-  def asJValue = (JNothing: JValue) // not implemented
+  def asJValue: JValue = (JNothing: JValue) // not implemented
 
   def setFromJValue(jvalue: JValue) = Empty // not implemented
 

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JObjectField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JObjectField.scala
@@ -36,7 +36,7 @@ with MongoFieldFlavor[JObject] {
 
   def owner = rec
 
-  def asJValue = valueBox openOr (JNothing: JValue)
+  def asJValue: JValue = valueBox openOr (JNothing: JValue)
 
   def setFromJValue(jvalue: JValue): Box[JObject] = jvalue match {
     case JNothing|JNull if optional_? => setBox(Empty)

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoCaseClassField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoCaseClassField.scala
@@ -47,7 +47,7 @@ class MongoCaseClassField[OwnerType <: Record[OwnerType],CaseType](rec: OwnerTyp
   override def defaultValue = null.asInstanceOf[MyType]
   override def optional_? = true
 
-  def asJValue = valueBox.map(v => Extraction.decompose(v)) openOr (JNothing: JValue)
+  def asJValue: JValue = valueBox.map(v => Extraction.decompose(v)) openOr (JNothing: JValue)
 
   def setFromJValue(jvalue: JValue): Box[CaseType] = jvalue match {
     case JNothing|JNull => setBox(Empty)
@@ -94,7 +94,7 @@ class MongoCaseClassListField[OwnerType <: Record[OwnerType],CaseType](rec: Owne
   override def defaultValue: MyType = Nil
   override def optional_? = true
 
-  def asJValue = JArray(value.map(v => Extraction.decompose(v)))
+  def asJValue: JValue = JArray(value.map(v => Extraction.decompose(v)))
 
   def setFromJValue(jvalue: JValue): Box[MyType] = jvalue match {
     case JArray(contents) => setBox(Full(contents.flatMap(s => Helpers.tryo[CaseType]{ s.extract[CaseType] })))

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoListField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoListField.scala
@@ -120,7 +120,7 @@ class MongoListField[OwnerType <: BsonRecord[OwnerType], ListType: Manifest](rec
     if (options.length > 0) Full(elem)
     else Empty
 
-  def asJValue = JArray(value.map(li => li.asInstanceOf[AnyRef] match {
+  def asJValue: JValue = JArray(value.map(li => li.asInstanceOf[AnyRef] match {
     case x if primitive_?(x.getClass) => primitive2jvalue(x)
     case x if mongotype_?(x.getClass) => mongotype2jvalue(x)(owner.meta.formats)
     case x if datetype_?(x.getClass) => datetype2jvalue(x)(owner.meta.formats)
@@ -167,7 +167,7 @@ class MongoJsonObjectListField[OwnerType <: BsonRecord[OwnerType], JObjectType <
       valueMeta.create(JObjectParser.serialize(dbo.get(k.toString))(owner.meta.formats).asInstanceOf[JObject])(owner.meta.formats)
     })))
 
-  override def asJValue = JArray(value.map(_.asJObject()(owner.meta.formats)))
+  override def asJValue: JValue = JArray(value.map(_.asJObject()(owner.meta.formats)))
 
   override def setFromJValue(jvalue: JValue) = jvalue match {
     case JNothing|JNull if optional_? => setBox(Empty)

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoMapField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoMapField.scala
@@ -75,7 +75,7 @@ class MongoMapField[OwnerType <: BsonRecord[OwnerType], MapValueType](rec: Owner
 
   def toForm: Box[NodeSeq] = Empty
 
-  def asJValue = JObject(value.keys.map {
+  def asJValue: JValue = JObject(value.keys.map {
     k =>
       JField(k, value(k).asInstanceOf[AnyRef] match {
         case x if primitive_?(x.getClass) => primitive2jvalue(x)

--- a/persistence/record/src/main/scala/net/liftweb/record/MetaRecord.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/MetaRecord.scala
@@ -245,7 +245,7 @@ trait MetaRecord[BaseRecord <: Record[BaseRecord]] {
   }
 
   /** Encode a record instance into a JValue */
-  def asJValue(rec: BaseRecord): JObject = {
+  def asJValue(rec: BaseRecord): JValue = {
     JObject(fields(rec).map(f => JField(f.name, f.asJValue)))
   }
 

--- a/persistence/record/src/main/scala/net/liftweb/record/Record.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/Record.scala
@@ -91,7 +91,7 @@ trait Record[MyType <: Record[MyType]] extends FieldContainer {
   def asJsExp: JsExp = meta.asJsExp(this)
 
   /** Encode this record instance as a JObject */
-  def asJValue: JObject = meta.asJValue(this)
+  def asJValue: JValue = meta.asJValue(this)
 
   /** Set the fields of this record from the given JValue */
   def setFieldsFromJValue(jvalue: JValue): Box[Unit] = meta.setFieldsFromJValue(this, jvalue)

--- a/persistence/record/src/main/scala/net/liftweb/record/field/BinaryField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/BinaryField.scala
@@ -43,7 +43,7 @@ trait BinaryTypedField extends TypedField[Array[Byte]] {
 
   def asJs = valueBox.map(v => Str(hexEncode(v))) openOr JsNull
 
-  def asJValue = asJString(base64Encode _)
+  def asJValue: JValue = asJString(base64Encode _)
   def setFromJValue(jvalue: JValue) = setFromJString(jvalue)(s => tryo(base64Decode(s)))
 }
   

--- a/persistence/record/src/main/scala/net/liftweb/record/field/BooleanField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/BooleanField.scala
@@ -60,7 +60,7 @@ trait BooleanTypedField extends TypedField[Boolean] {
 
   def asJs: JsExp = valueBox.map(boolToJsExp) openOr JsNull
 
-  def asJValue = valueBox.map(JBool) openOr (JNothing: JValue)
+  def asJValue: JValue = valueBox.map(JBool) openOr (JNothing: JValue)
   def setFromJValue(jvalue: JValue) = jvalue match {
     case JNothing|JNull if optional_? => setBox(Empty)
     case JBool(b)                     => setBox(Full(b))

--- a/persistence/record/src/main/scala/net/liftweb/record/field/DateTimeField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/DateTimeField.scala
@@ -64,7 +64,7 @@ trait DateTimeTypedField extends TypedField[Calendar] {
 
   def asJs = valueBox.map(v => Str(formats.dateFormat.format(v.getTime))) openOr JsNull
 
-  def asJValue = asJString(v => formats.dateFormat.format(v.getTime))
+  def asJValue: JValue = asJString(v => formats.dateFormat.format(v.getTime))
   def setFromJValue(jvalue: JValue) = setFromJString(jvalue) {
     v => formats.dateFormat.parse(v).map(d => {
       val cal = Calendar.getInstance

--- a/persistence/record/src/main/scala/net/liftweb/record/field/DecimalField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/DecimalField.scala
@@ -49,7 +49,7 @@ trait DecimalTypedField extends NumericTypedField[BigDecimal] {
 
   def set_!(in: BigDecimal): BigDecimal = new BigDecimal(in.bigDecimal.setScale(scale, context.getRoundingMode))
 
-  def asJValue = asJString(_.toString)
+  def asJValue: JValue = asJString(_.toString)
   def setFromJValue(jvalue: JValue) = setFromJString(jvalue)(s => tryo(BigDecimal(s)))
 }
 

--- a/persistence/record/src/main/scala/net/liftweb/record/field/DoubleField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/DoubleField.scala
@@ -42,7 +42,7 @@ trait DoubleTypedField extends NumericTypedField[Double] {
 
   def defaultValue = 0.0
 
-  def asJValue = valueBox.map(JDouble) openOr (JNothing: JValue)
+  def asJValue: JValue = valueBox.map(JDouble) openOr (JNothing: JValue)
   
   def setFromJValue(jvalue: JValue) = jvalue match {
     case JNothing|JNull if optional_? => setBox(Empty)

--- a/persistence/record/src/main/scala/net/liftweb/record/field/joda/JodaTimeField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/joda/JodaTimeField.scala
@@ -62,7 +62,7 @@ trait JodaTimeTypedField extends TypedField[DateTime] with JodaHelpers {
   protected def asJInt(encode: MyType => BigInt): JValue =
     valueBox.map(v => JInt(encode(v))) openOr (JNothing: JValue)
 
-  def asJValue = asJInt(v => v.getMillis)
+  def asJValue: JValue = asJInt(v => v.getMillis)
   def setFromJValue(jvalue: JValue) = setFromJInt(jvalue) {
     v => toDateTime(v)
   }

--- a/persistence/squeryl-record/src/test/scala/net/liftweb/squerylrecord/Fixtures.scala
+++ b/persistence/squeryl-record/src/test/scala/net/liftweb/squerylrecord/Fixtures.scala
@@ -115,7 +115,7 @@ class SpecialField[OwnerType <: Record[OwnerType]](rec: OwnerType)
     case v => setBox(Full(v.toString))
   }
   override def setFromJValue(jValue: JValue) = setBox(Full(jValue.toString))
-  override def asJValue = JString(get)
+  override def asJValue: JValue = JString(get)
   override def asJs = Str(get)
   override def toForm = Full(scala.xml.Text(get))
 }


### PR DESCRIPTION
I was subclassing BsonRecordListField (Lift 2.5.1, Scala 2.10) to extend it with some specialized methods.
I also wanted to override asJValue to make it return a json object instead of the JArray that this field returns.

The compiler complained because the type signature in this specific case would be "def asJValue: JArray", because the overridden method does not state any return type so its inferred by the compiler.

To correct this, add the proper type signature to all overrides of asJValue in Lift 3.

Discussion in the list: https://groups.google.com/forum/#!topic/liftweb/kTBHlK7xBHM
