### PR TITLE
Fix issues with emailRegexPattern.

### DIFF
--- a/persistence/proto/src/main/scala/net/liftweb/proto/ProtoRules.scala
+++ b/persistence/proto/src/main/scala/net/liftweb/proto/ProtoRules.scala
@@ -31,7 +31,7 @@ object ProtoRules extends Factory with LazyLoggable {
   /**
    * The regular expression pattern for matching email addresses.
    */
-  val emailRegexPattern = new FactoryMaker(Pattern.compile("(?i)^[a-z0-9._%\\-+]+@(?:[a-z0-9\\-]+\\.)+[a-z]{2,}$")) {}
+  val emailRegexPattern = new FactoryMaker(Pattern.compile("^[a-z0-9._%\\-+]+@(?:[a-z0-9\\-]+\\.)+[a-z]{2,}$", Pattern.CASE_INSENSITIVE)) {}
   
 }
 


### PR DESCRIPTION
This resolve issues with `emailRegexPattern` not being up to date w.r.t. new TLDs longer than four characters. While I was in there I also made the matcher case insensitive.

fixes #1634 
