### PR TITLE
[WIP] Change LiftRules.funcNameGenerator to a FactoryMaker.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1752,8 +1752,11 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   /** Controls whether or not the service handling timing messages (Service request (GET) ... took ... Milliseconds) are logged. Defaults to true. */
   @volatile var logServiceRequestTiming = true
 
-  /** Provides a function that returns random names for form variables, page ids, callbacks, etc. */
-  @volatile var funcNameGenerator: () => String = defaultFuncNameGenerator(Props.mode)
+  /**
+   * Provides a function that returns random names for form variables, page ids, callbacks, etc.
+   */
+  val funcNameGenerator: FactoryMaker[() => String] =
+    new FactoryMaker[() => String](defaultFuncNameGenerator(Props.mode)) {}
 
   import provider.servlet._
   import containers._

--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -2638,7 +2638,7 @@ trait S extends HasParams with Loggable with UserAgentCalculator {
       f
     }
 
-  def formFuncName: String = LiftRules.funcNameGenerator()
+  def formFuncName: String = LiftRules.funcNameGenerator.vend()
 
   /** Default func-name logic during test-mode. */
   def generateTestFuncName: String =


### PR DESCRIPTION
This changes the funcNameGenerator to a FactoryMaker allowing it to be changed on a per-request and per-session level in addition to the default behavior. Still waiting to hear if I should rip out the disableTestFuncNames stuff while I'm in here.

fixes #1449
