### PR TITLE
Comet, Comet on the Wall: Fix comets sent down via AJAX from within a comet

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
@@ -865,11 +865,6 @@ trait CometActor extends LiftActor with LiftCometActor with CssBindImplicits {
 
     case ActionMessageSet(msgs, req) =>
       S.doCometParams(req.params) {
-        S.jsToAppend() match {
-          case Nil =>
-          case js => partialUpdate(js)
-        }
-
         val computed: List[Any] =
           msgs.flatMap {
             f => try {
@@ -879,6 +874,11 @@ trait CometActor extends LiftActor with LiftCometActor with CssBindImplicits {
               case e: Exception => reportError("Ajax function dispatch", e); Nil
             }
           }
+
+        S.jsToAppend() match {
+          case Nil =>
+          case js => partialUpdate(js)
+        }
 
         reply(computed ::: List(S.noticesToJsCmd))
       }

--- a/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
@@ -679,6 +679,12 @@ trait CometActor extends LiftActor with LiftCometActor with CssBindImplicits {
                   case e if exceptionHandler.isDefinedAt(e) => exceptionHandler(e)
                   case e: Exception => reportError("Message dispatch for " + in, e)
                 }
+
+                val updatedJs = S.jsToAppend
+                if (updatedJs.nonEmpty) {
+                  partialUpdate(updatedJs)
+                }
+
                 if (S.functionMap.size > 0) {
                   theSession.updateFunctionMap(S.functionMap,
                     uniqueId, lastRenderTime)
@@ -874,11 +880,6 @@ trait CometActor extends LiftActor with LiftCometActor with CssBindImplicits {
               case e: Exception => reportError("Ajax function dispatch", e); Nil
             }
           }
-
-        S.jsToAppend() match {
-          case Nil =>
-          case js => partialUpdate(js)
-        }
 
         reply(computed ::: List(S.noticesToJsCmd))
       }
@@ -1179,15 +1180,16 @@ trait CometActor extends LiftActor with LiftCometActor with CssBindImplicits {
    * is helpful if you use Lift's CSS Selector Transforms to define
    * rendering.
    */
-  protected implicit def nsToNsFuncToRenderOut(f: NodeSeq => NodeSeq) =
-    new RenderOut((Box !! defaultHtml).map(f), internalFixedRender, if (autoIncludeJsonCode) Full(jsonToIncludeInCode & S.jsToAppend())
-    else {
-      S.jsToAppend match {
-        case Nil => Empty
-        case x :: Nil => Full(x)
-        case xs => Full(xs.reduceLeft(_ & _))
+  protected implicit def nsToNsFuncToRenderOut(f: NodeSeq => NodeSeq) = {
+    val additionalJs =
+      if (autoIncludeJsonCode) {
+        Full(jsonToIncludeInCode)
+      } else {
+        Empty
       }
-    }, Empty, false)
+
+    new RenderOut((Box !! defaultHtml).map(f), internalFixedRender, additionalJs, Empty, false)
+  }
 
   /**
    * Convert a Seq[Node] (the superclass of NodeSeq) to a RenderOut.
@@ -1196,16 +1198,27 @@ trait CometActor extends LiftActor with LiftCometActor with CssBindImplicits {
    * (in Java) will convert a NodeSeq to a RenderOut.  This
    * is helpful if you return a NodeSeq from your render method.
    */
-  protected implicit def arrayToRenderOut(in: Seq[Node]): RenderOut = new RenderOut(Full(in: NodeSeq), internalFixedRender, if (autoIncludeJsonCode) Full(jsonToIncludeInCode & S.jsToAppend())
-  else {
-    S.jsToAppend match {
-      case Nil => Empty
-      case x :: Nil => Full(x)
-      case xs => Full(xs.reduceLeft(_ & _))
-    }
-  }, Empty, false)
+  protected implicit def arrayToRenderOut(in: Seq[Node]): RenderOut = {
+    val additionalJs =
+      if (autoIncludeJsonCode) {
+        Full(jsonToIncludeInCode)
+      } else {
+        Empty
+      }
 
-  protected implicit def jsToXmlOrJsCmd(in: JsCmd): RenderOut = new RenderOut(Empty, internalFixedRender, if (autoIncludeJsonCode) Full(in & jsonToIncludeInCode & S.jsToAppend()) else Full(in & S.jsToAppend()), Empty, false)
+      new RenderOut(Full(in: NodeSeq), internalFixedRender, additionalJs, Empty, false)
+  }
+
+  protected implicit def jsToXmlOrJsCmd(in: JsCmd): RenderOut = {
+    val additionalJs =
+      if (autoIncludeJsonCode) {
+        Full(in & jsonToIncludeInCode)
+      } else {
+        Full(in)
+      }
+
+    new RenderOut(Empty, internalFixedRender, additionalJs, Empty, false)
+  }
 
   implicit def pairToPair(in: (String, Any)): (String, NodeSeq) = (in._1, Text(in._2 match {
     case null => "null"

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
@@ -578,29 +578,6 @@ class LiftServlet extends Loggable {
   }
 
   /**
-   * Generates the JsCmd needed to initialize comets in
-   * `S.requestCometVersions` on the client.
-   */
-  private def commandForComets: JsCmd = {
-    val cometVersions = S.requestCometVersions.is
-
-    if (cometVersions.nonEmpty) {
-      js.JE.Call(
-        "lift.registerComets",
-        js.JE.JsObj(
-          S.requestCometVersions.is.toList.map {
-            case CometVersionPair(guid, version) =>
-              (guid, js.JE.Num(version))
-          }: _*
-        ),
-        true
-      ).cmd
-    } else {
-      js.JsCmds.Noop
-    }
-  }
-
-  /**
    * Runs the actual AJAX processing. This includes handling __lift__GC,
    * or running the parameters in the session. It returns once the AJAX
    * request has completed with a response meant for the user. In cases
@@ -642,8 +619,7 @@ class LiftServlet extends Loggable {
                   (js :: (xs.collect {
                     case js: JsCmd => js
                   }).reverse) &
-                  S.jsToAppend &
-                  commandForComets
+                  S.jsToAppend
                 ).toResponse
               }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -922,7 +922,9 @@ trait S extends HasParams with Loggable with UserAgentCalculator {
                 (guid, js.JE.Num(version))
             }: _*
           ),
-          true
+          // Don't kick off a new comet request client-side if we're responding
+          // to a comet request right now.
+          ! currentCometActor.isDefined
         ).cmd
       )
     } else {

--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -950,7 +950,8 @@ trait S extends HasParams with Loggable with UserAgentCalculator {
 
     globalJs ::: {
       postPageJs ::: cometJs ::: _jsToAppend.is.toList match {
-        case Nil => Nil
+        case Nil =>
+          Nil
         case loadJs =>
           List(OnLoad(loadJs))
       }


### PR DESCRIPTION
This fixes a few issues:
 - We centralize comet command generation into `S.jsToAppend`.
 - We fix when we look up `S.jsToAppend` during AJAX processing in comet contexts so we don't miss anything that might be added during the actual AJAX function execution.
 - We make sure not to trigger a second comet request when setting up new comets client-side from within a comet response.

Fixes issue #1645 .