### PR TITLE
This is Where the Function Stops: Map function on ajaxOnSubmit invocation.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -1585,9 +1585,14 @@ trait SHtml {
    *  <pre>"type=submit" #> ajaxOnSubmit(() => Alert("Done!"))</pre>
    */
   def ajaxOnSubmit(func: () => JsCmd): (NodeSeq)=>NodeSeq = {
-    val fgSnap = S._formGroup.get
+    val functionId =
+      _formGroup.is match {
+        case Empty =>
+          formGroup(1)(fmapFunc(func)(id => id))
+        case _ => fmapFunc(func)(id => id)
+      }
 
-    (in: NodeSeq) => S._formGroup.doWith(fgSnap) {
+    (in: NodeSeq) => {
       def runNodes(ns: NodeSeq): NodeSeq = {
         def addAttributes(elem: Elem, name: String) = {
           val clickJs = "lift.setUriSuffix('" + name + "=_'); return true;"
@@ -1600,11 +1605,7 @@ trait SHtml {
 
           case e: Elem if (e.label == "button") ||
                           (e.label == "input" && e.attribute("type").map(_.text) == Some("submit")) =>
-            _formGroup.is match {
-              case Empty =>
-                formGroup(1)(fmapFunc(func)(addAttributes(e, _)))
-              case _ => fmapFunc(func)(addAttributes(e, _))
-            }
+            addAttributes(e, functionId)
         }
       }
 


### PR DESCRIPTION
Before, we bound the function when we processed the element. Because this
occurred in NodeSeq=>NodeSeq function, we had no guarantee that it would run in
the correct formGroup, oneShot, callOnce, etc contexts. To deal with the form
group part of this, we were capturing the form group and setting it when we
went to actually run the binding function. However, this left oneShot,
callOnce, and potential future contexts like them out in the dark.

We now run the fmapFunc call as soon as ajaxOnSubmit is called, and the
NodeSeq=>NodeSeq function is used solely to bind the resulting id to the
matching element(s). This means the function mapping happens in the calling
context, and we avoid all of the above issues.

There is a subtle shift in behavior: multiple matching elements will get the
same function id, where before they would get different ones. Realistically,
this shouldn't cause a big problem, since they'll be invoking the same function
anyway.

Fixes #1644 .