### PR TITLE
Air Gap: Distinguish LiftSession uniqueId from underlyingId.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
@@ -653,7 +653,7 @@ class LiftServlet extends Loggable {
               case _ => JsCommands(S.noticesToJsCmd :: JsCmds.Noop :: S.jsToAppend).toResponse
             }
 
-            LiftRules.cometLogger.debug("AJAX Response: " + liftSession.uniqueId + " " + ret)
+            LiftRules.cometLogger.debug("AJAX Response: " + liftSession.underlyingId + " " + ret)
 
             Full(ret)
           } finally {
@@ -684,7 +684,7 @@ class LiftServlet extends Loggable {
   private def handleAjax(liftSession: LiftSession,
                          requestState: Req): Box[LiftResponse] = {
     extractVersions(requestState.path.partPath) { versionInfo =>
-      LiftRules.cometLogger.debug("AJAX Request: " + liftSession.uniqueId + " " + requestState.params)
+      LiftRules.cometLogger.debug("AJAX Request: " + liftSession.underlyingId + " " + requestState.params)
       tryo {
         LiftSession.onBeginServicing.foreach(_(liftSession, requestState))
       }

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPServletSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPServletSession.scala
@@ -28,7 +28,7 @@ class HTTPServletSession(session: HttpSession) extends HTTPSession {
 
   def sessionId: String = session.getId
 
-  def link(liftSession: LiftSession) = session.setAttribute(LiftMagicID, SessionToServletBridge(liftSession.uniqueId))
+  def link(liftSession: LiftSession) = session.setAttribute(LiftMagicID, SessionToServletBridge(liftSession.underlyingId))
 
   def unlink(liftSession: LiftSession) = session.removeAttribute(LiftMagicID)
 


### PR DESCRIPTION
What used to be uniqueId is now called underlyingId, to
indicate the fact that it is tied to the underlying host’s session
id. A new uniqueId is introduced, which is secure and unique,
and is not tied to the host id and cannot be used to look the
session up in the future.

The only place that is currently continuing to use uniqueId is
when we emit the id into the page as data-lift-session-id for
cache-busting purposes. The underlying id used to be
emitted into the page, which triggered some small security
concerns, so we switch to this model to be on the safe side.

See https://groups.google.com/forum/#!topic/liftweb/YwZgXuMOYrk
for the triggering discussion.