### PR TITLE
Fixes LAFuture.collect/collectAll behaviour for empty list parameter

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -221,3 +221,9 @@ Aleksey Izmailov
 
 ### Email: ###
 izmailoff at gmail dot com
+
+### Name: ###
+Arek Burdach
+
+### Email: ###
+arek.burdach at gmail dot com

--- a/core/actor/src/test/scala/net/liftweb/actor/LAFutureSpec.scala
+++ b/core/actor/src/test/scala/net/liftweb/actor/LAFutureSpec.scala
@@ -1,0 +1,37 @@
+package net.liftweb.actor
+
+import org.specs2.mutable.Specification
+
+class LAFutureSpec extends Specification {
+  val timeout = 1000L
+
+  "LAFuture" should {
+
+    "collect one future result" in {
+      val givenOneResult = 123
+      val one = LAFuture(() => givenOneResult)
+      LAFuture.collect(one).get(timeout) shouldEqual List(givenOneResult)
+    }
+
+    "collect more future results in correct order" in {
+      val givenOneResult = 123
+      val givenTwoResult = 234
+      val one = LAFuture(() => givenOneResult)
+      val two = LAFuture(() => givenTwoResult)
+      LAFuture.collect(one, two).get shouldEqual List(givenOneResult, givenTwoResult)
+    }
+
+    "collect empty list immediately" in {
+      val collectResult = LAFuture.collect(Nil: _*)
+      collectResult.isSatisfied shouldEqual true
+      collectResult.get shouldEqual Nil
+    }
+
+    "collectAll empty list immediately" in {
+      val collectResult = LAFuture.collectAll(Nil : _*)
+      collectResult.isSatisfied shouldEqual true
+      collectResult.get shouldEqual Nil
+    }
+  }
+
+}


### PR DESCRIPTION
For empty list parameter, were returned future which never been satisfied.
Now is returned future that is immediately satisfied by empty list.

Fixes #1653