### PR TITLE
replaced TimeSpan with scala.concurrent.duration.Duration

### DIFF
--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -18,6 +18,7 @@ package net.liftweb
 package actor 
 
 import common._
+import scala.concurrent.duration._
 
 
 /**
@@ -126,6 +127,10 @@ class LAFuture[T](val scheduler: LAScheduler) {
   }
 
   def withFilter(f: T => Boolean): LAFuture[T] = filter(f)
+
+  def get(timeout: Duration): Box[T] = {
+    get(timeout.toMillis)
+  }
 
   /**
    * Get the future value or if the value is not

--- a/core/util/src/main/scala/net/liftweb/util/Helpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Helpers.scala
@@ -17,6 +17,7 @@
 package net.liftweb
 package util
 
+import scala.concurrent.duration.{TimeUnit, Duration, FiniteDuration, DurationConversions}
 import scala.xml._
 
 /**

--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package net.liftweb
 package util
 
@@ -21,8 +20,6 @@ import java.text.SimpleDateFormat
 import java.util.{TimeZone, Calendar, Date, Locale}
 
 import scala.language.implicitConversions
-
-import org.joda.time.{DateTime, Duration, Period, PeriodType}
 
 import common._
 
@@ -32,203 +29,12 @@ import common._
 object TimeHelpers extends TimeHelpers with ControlHelpers with ClassHelpers
 
 /**
- * The TimeHelpers trait provide functions to create TimeSpans (an object representing an amount of time), to manage date formats
- * or general utility functions (get the date for today, get year/month/day number,...)
+ * The TimeHelpers trait provide functions to manage date formats or general utility functions
+ * (get the date for today, get year/month/day number,...)
  */
 trait TimeHelpers { self: ControlHelpers =>
   // Logger must be lazy, since we cannot instantiate until after boot is complete
   private  lazy val logger = Logger(classOf[TimeHelpers])
-
-  /** private variable allowing the access to all TimeHelpers functions from inside the TimeSpan class */
-  private val outer = this
-
-  /** transforms a long to a TimeSpanBuilder object. Usage: 3L.seconds returns a TimeSpan of 3000L millis  */
-  implicit def longToTimeSpanBuilder(in: Long): TimeSpanBuilder = TimeSpanBuilder(in)
-
-  /** transforms an int to a TimeSpanBuilder object. Usage: 3.seconds returns a TimeSpan of 3000L millis  */
-  implicit def intToTimeSpanBuilder(in: Int): TimeSpanBuilder = TimeSpanBuilder(in)
-
-  /** transforms a long to a TimeSpan object. Usage: 3000L returns a TimeSpan of 3000L millis  */
-  implicit def longToTimeSpan(in: Long): TimeSpan = TimeSpan(in)
-
-  /** transforms an int to a TimeSpan object. Usage: 3000 returns a TimeSpan of 3000L millis  */
-  implicit def intToTimeSpan(in: Int): TimeSpan = TimeSpan(in)
-
-  private implicit def durToPeriod(dur: Duration): Period = dur.toPeriod(PeriodType.standard())
-
-  /** class building TimeSpans given an amount (len) and a method specify the time unit  */
-  case class TimeSpanBuilder(val len: Long) {
-    def seconds = new TimeSpan(Right((new Period).plusSeconds(len.toInt)))
-    def second = seconds
-    def minutes = new TimeSpan(Right((new Period).plusMinutes(len.toInt)))
-    def minute = minutes
-    def hours = new TimeSpan(Right(Duration.standardHours(len): Period))
-    def hour = hours
-    def days = new TimeSpan(Right(Duration.standardDays(len): Period))
-    def day = days
-    def weeks = new TimeSpan(Right(Duration.standardDays(len * 7L): Period))
-    def week = weeks
-    def months = new TimeSpan(Right((new Period().plusMonths(len.toInt))))
-    def month = months
-    def years = new TimeSpan(Right((new Period().plusYears(len.toInt))))
-    def year = years
-  }
-
-  /*
-  /**
-   * transforms a TimeSpan to a date by converting the TimeSpan expressed as millis and creating
-   * a Date lasting that number of millis from the Epoch time (see the documentation for java.util.Date)
-   */
-  implicit def timeSpanToDate(in: TimeSpan): Date = in.date
-
-  /** transforms a TimeSpan to its long value as millis */
-  implicit def timeSpanToLong(in: TimeSpan): Long = in.millis
-  */
-
-  /**
-   * The TimeSpan class represents an amount of time.
-   * It can be translated to a date with the date method. In that case, the number of millis seconds will be used to create a Date
-   * object starting from the Epoch time (see the documentation for java.util.Date)
-   */
-  class TimeSpan(private val dt: Either[DateTime, Period]) extends ConvertableToDate {
-    /** @return a Date as the amount of time represented by the TimeSpan after the Epoch date */
-
-    def this(ms: Long) =
-      this(if (ms < 52L * 7L * 24L * 60L * 60L * 1000L) Right(new Period(ms))
-           else Left(new DateTime(ms)))
-
-    def date: Date = dt match {
-      case Left(datetime) => new Date(datetime.getMillis())
-      case _ => new Date(millis)
-    }
-
-    /**
-     * Convert to a Date
-     */
-    def toDate: Date = date
-
-    /**
-     * Convert to a JodaTime DateTime
-     */
-    def toDateTime = dt match {
-      case Left(datetime) => datetime
-      case _ => new DateTime(millis)
-    }
-
-    def toMillis = millis
-
-    def millis = dt match {
-      case Left(datetime) => datetime.getMillis()
-      case Right(duration) => duration.toStandardDuration.getMillis()
-    }
-
-
-    /** @return a Date as the amount of time represented by the TimeSpan after now */
-    def later: TimeSpan = dt match {
-      case Right(duration) => new TimeSpan(Left(new DateTime(outer.millis).plus(duration)))
-      case _ => TimeSpan(millis + outer.millis)
-    }
-
-    /** @return a Date as the amount of time represented by the TimeSpan before now */
-    def ago: TimeSpan = dt match {
-      case Right(duration) => new TimeSpan(Left(new DateTime(outer.millis).minus(duration)))
-      case _ => TimeSpan(outer.millis - millis)
-    }
-
-    def noTime: Date = new DateExtension(this).noTime
-
-    /** @return a TimeSpan representing the addition of 2 TimeSpans */
-    def +[B](in: B)(implicit f: B => TimeSpan): TimeSpan =
-      (this.dt, f(in).dt) match {
-        case (Right(p1), Right(p2)) => p1.plus(p2)
-        case (Left(date), Right(duration)) => date.plus(duration)
-        case (Right(duration), Left(date)) => date.plus(duration)
-        case _ => TimeSpan(this.millis + f(in).millis)
-      }
-
-    /** @return a TimeSpan representing the addition of 2 TimeSpans */
-    def plus[B](in: B)(implicit f: B => TimeSpan): TimeSpan = this.+(in)(f)
-
-    /** @return a TimeSpan representing the substraction of 2 TimeSpans */
-    def -[B](in: B)(implicit f: B => TimeSpan): TimeSpan =
-      (this.dt, f(in).dt) match {
-        case (Right(p1), Right(p2)) => p1.minus(p2)
-        case (Left(date), Right(duration)) => date.minus(duration)
-        case (Right(duration), Left(date)) => date.minus(duration)
-        case _ => TimeSpan(this.millis - f(in).millis)
-      }
-
-    /** override the equals method so that TimeSpans can be compared to long, int and TimeSpan */
-    override def equals(cmp: Any) = {
-      cmp match {
-        case lo: Long => lo == this.millis
-        case i: Int => i == this.millis
-        case ti: TimeSpan => ti.dt == this.dt
-        case d: Date => d.getTime() == this.millis
-        case dt: DateTime => Left(dt) == this.dt
-        case dur: Duration => Right(dur: Period) == this.dt
-        case dur: Period => Right(dur) == this.dt
-        case _ => false
-      }
-    }
-
-    /** override the toString method to display a readable amount of time */
-    override def toString = dt match {
-      case Left(date) => date.toString
-      case Right(dur) => TimeSpan.format(millis)
-    }
-  }
-
-  /**
-   * The TimeSpan object provides class represents an amount of time.
-   * It can be translated to a date with the date method. In that case, the number of millis seconds will be used to create a Date
-   * object starting from the Epoch time (see the documentation for java.util.Date)
-   */
-  object TimeSpan {
-    /** time units and values used when converting a total number of millis to those units (see the format function)  */
-    val scales = List((1000L, "milli"), (60L, "second"), (60L, "minute"), (24L, "hour"), (7L, "day"), (10000L, "week"))
-
-    /** explicit constructor for a TimeSpan  */
-    def apply(in: Long) = new TimeSpan(in)
-
-    /**
-     * Formats a number of millis to a string representing the number of weeks, days, hours, minutes, seconds, millis
-     */
-    def format(millis: Long): String = {
-      def divideInUnits(millis: Long) = scales.foldLeft[(Long, List[(Long, String)])]((millis, Nil)){ (total, div) =>
-        (total._1 / div._1, (total._1 % div._1, div._2) :: total._2)
-      }._2
-      def formatAmount(amountUnit: (Long, String)) = amountUnit match {
-        case (amount, unit) if (amount == 1) => amount + " " + unit
-        case (amount, unit) => amount + " " + unit + "s"
-      }
-      divideInUnits(millis).filter(_._1 > 0).map(formatAmount(_)).mkString(", ")
-    }
-
-    /**
-     * Convert a Date to a TimeSpan
-     */
-    implicit def dateToTS(in: Date): TimeSpan =
-      new TimeSpan(Left(new DateTime(in.getTime)))
-
-    /**
-     * Convert a DateTime to a TimeSpan
-     */
-    implicit def dateTimeToTS(in: DateTime): TimeSpan =
-      new TimeSpan(Left(in))
-
-    /**
-     * Convert a Duration to a TimeSpan
-     */
-    implicit def durationToTS(in: Duration): TimeSpan =
-      new TimeSpan(Right(in: Period))
-
-    /**
-     * Convert a Period to a TimeSpan
-     */
-    implicit def periodToTS(in: Period): TimeSpan =
-      new TimeSpan(Right(in))
-  }
 
   /** @return the current System.nanoTime() */
   def nano = System.nanoTime()
@@ -427,18 +233,5 @@ trait TimeHelpers { self: ControlHelpers =>
       case e: Exception => logger.debug("Error parsing date "+in, e); Failure("Bad date: "+in, Full(e), Empty)
     }
   }
-}
-
-trait ConvertableToDate {
-  def toDate: Date
-  def toDateTime: DateTime
-  def millis: Long
-}
-
-object ConvertableToDate {
-  implicit def toDate(in: ConvertableToDate): Date = in.toDate
-  implicit def toDateTime(in: ConvertableToDate): DateTime = in.toDateTime
-  implicit def toMillis(in: ConvertableToDate): Long = in.millis
-
 }
 

--- a/core/util/src/main/scala/net/liftweb/util/TimeSpanHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeSpanHelpers.scala
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2006-2015 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.liftweb.util
+
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+import org.joda.time.{DateTime, PeriodType, Period, Duration}
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * The TimeSpanHelpers object extends the TimeSpanHelpers. It can be imported to access all of the trait functions.
+ *
+ * @see net.liftweb.util.TimeSpanHelpers.TimeSpan for deprecation notice
+ */
+@deprecated("Use scala.concurrent.duration.Duration instead of TimeSpan")
+object TimeSpanHelpers extends TimeSpanHelpers with ControlHelpers with ClassHelpers
+
+/**
+ * The TimeSpanHelpers trait provide functions to create TimeSpans (an object representing an amount of time), to manage date formats
+ * or general utility functions (get the date for today, get year/month/day number,...)
+ *
+ * @see net.liftweb.util.TimeSpanHelpers.TimeSpan for deprecation notice
+ */
+@deprecated("Use scala.concurrent.duration.Duration instead of TimeSpan")
+trait TimeSpanHelpers extends TimeHelpers { self: ControlHelpers =>
+
+  /** private variable allowing the access to all TimeSpanHelpers functions from inside the TimeSpan class */
+  private val outer = this
+
+  /** transforms a long to a TimeSpanBuilder object. Usage: 3L.seconds returns a TimeSpan of 3000L millis  */
+  implicit def longToTimeSpanBuilder(in: Long): TimeSpanBuilder = TimeSpanBuilder(in)
+
+  /** transforms an int to a TimeSpanBuilder object. Usage: 3.seconds returns a TimeSpan of 3000L millis  */
+  implicit def intToTimeSpanBuilder(in: Int): TimeSpanBuilder = TimeSpanBuilder(in)
+
+  /** transforms a long to a TimeSpan object. Usage: 3000L returns a TimeSpan of 3000L millis  */
+  implicit def longToTimeSpan(in: Long): TimeSpan = TimeSpan(in)
+
+  /** transforms an int to a TimeSpan object. Usage: 3000 returns a TimeSpan of 3000L millis  */
+  implicit def intToTimeSpan(in: Int): TimeSpan = TimeSpan(in)
+
+  private implicit def durToPeriod(dur: Duration): Period = dur.toPeriod(PeriodType.standard())
+
+  /** class building TimeSpans given an amount (len) and a method specify the time unit  */
+  case class TimeSpanBuilder(val len: Long) {
+    def seconds = new TimeSpan(Right((new Period).plusSeconds(len.toInt)))
+    def second = seconds
+    def minutes = new TimeSpan(Right((new Period).plusMinutes(len.toInt)))
+    def minute = minutes
+    def hours = new TimeSpan(Right(Duration.standardHours(len): Period))
+    def hour = hours
+    def days = new TimeSpan(Right(Duration.standardDays(len): Period))
+    def day = days
+    def weeks = new TimeSpan(Right(Duration.standardDays(len * 7L): Period))
+    def week = weeks
+    def months = new TimeSpan(Right((new Period().plusMonths(len.toInt))))
+    def month = months
+    def years = new TimeSpan(Right((new Period().plusYears(len.toInt))))
+    def year = years
+  }
+
+  /**
+   * The TimeSpan class represents an amount of time.
+   * It can be translated to a date with the date method. In that case, the number of millis seconds will be used to create a Date
+   * object starting from the Epoch time (see the documentation for java.util.Date)
+   *
+   * @deprecated In most cases in concurrent programming the intend of developer is to use duration represented as milliseconds.
+   *            However TimeSpan hold period representation as a changes in each date field. It could cause ambiguous situation
+   *            because it could be used in plus/minus/ago/later/equals operation context where it take care about time switch etc.
+   *            or millis could be taken. So please use scala.concurrent.duration.Duration instead of this class.
+   */
+  @deprecated("Use scala.concurrent.duration.Duration instead of TimeSpan")
+  class TimeSpan(private val dt: Either[DateTime, Period]) extends ConvertableToDate {
+    /** @return a Date as the amount of time represented by the TimeSpan after the Epoch date */
+
+    def this(ms: Long) =
+      this(if (ms < 52L * 7L * 24L * 60L * 60L * 1000L) Right(new Period(ms))
+      else Left(new DateTime(ms)))
+
+    def date: Date = dt match {
+      case Left(datetime) => new Date(datetime.getMillis())
+      case _ => new Date(millis)
+    }
+
+    /**
+     * Convert to a Date
+     */
+    def toDate: Date = date
+
+    /**
+     * Convert to a JodaTime DateTime
+     */
+    def toDateTime = dt match {
+      case Left(datetime) => datetime
+      case _ => new DateTime(millis)
+    }
+
+    def toMillis = millis
+
+    def millis = dt match {
+      case Left(datetime) => datetime.getMillis()
+      case Right(duration) => duration.toStandardDuration.getMillis()
+    }
+
+
+    /** @return a Date as the amount of time represented by the TimeSpan after now */
+    def later: TimeSpan = dt match {
+      case Right(duration) => new TimeSpan(Left(new DateTime(outer.millis).plus(duration)))
+      case _ => TimeSpan(millis + outer.millis)
+    }
+
+    /** @return a Date as the amount of time represented by the TimeSpan before now */
+    def ago: TimeSpan = dt match {
+      case Right(duration) => new TimeSpan(Left(new DateTime(outer.millis).minus(duration)))
+      case _ => TimeSpan(outer.millis - millis)
+    }
+
+    def noTime: Date = new DateExtension(this).noTime
+
+    /** @return a TimeSpan representing the addition of 2 TimeSpans */
+    def +[B](in: B)(implicit f: B => TimeSpan): TimeSpan =
+      (this.dt, f(in).dt) match {
+        case (Right(p1), Right(p2)) => p1.plus(p2)
+        case (Left(date), Right(duration)) => date.plus(duration)
+        case (Right(duration), Left(date)) => date.plus(duration)
+        case _ => TimeSpan(this.millis + f(in).millis)
+      }
+
+    /** @return a TimeSpan representing the addition of 2 TimeSpans */
+    def plus[B](in: B)(implicit f: B => TimeSpan): TimeSpan = this.+(in)(f)
+
+    /** @return a TimeSpan representing the substraction of 2 TimeSpans */
+    def -[B](in: B)(implicit f: B => TimeSpan): TimeSpan =
+      (this.dt, f(in).dt) match {
+        case (Right(p1), Right(p2)) => p1.minus(p2)
+        case (Left(date), Right(duration)) => date.minus(duration)
+        case (Right(duration), Left(date)) => date.minus(duration)
+        case _ => TimeSpan(this.millis - f(in).millis)
+      }
+
+    /** override the equals method so that TimeSpans can be compared to long, int and TimeSpan */
+    override def equals(cmp: Any) = {
+      cmp match {
+        case lo: Long => lo == this.millis
+        case i: Int => i == this.millis
+        case ti: TimeSpan => ti.dt == this.dt
+        case d: Date => d.getTime() == this.millis
+        case dt: DateTime => Left(dt) == this.dt
+        case dur: Duration => Right(dur: Period) == this.dt
+        case dur: Period => Right(dur) == this.dt
+        case _ => false
+      }
+    }
+
+    /** override the toString method to display a readable amount of time */
+    override def toString = dt match {
+      case Left(date) => date.toString
+      case Right(dur) => TimeSpan.format(millis)
+    }
+
+    def toScalaDuration: concurrent.duration.Duration = {
+      FiniteDuration(millis, TimeUnit.MILLISECONDS)
+    }
+  }
+
+  /**
+   * The TimeSpan object provides class represents an amount of time.
+   * It can be translated to a date with the date method. In that case, the number of millis seconds will be used to create a Date
+   * object starting from the Epoch time (see the documentation for java.util.Date)
+   */
+  object TimeSpan {
+    /** time units and values used when converting a total number of millis to those units (see the format function)  */
+    val scales = List((1000L, "milli"), (60L, "second"), (60L, "minute"), (24L, "hour"), (7L, "day"), (10000L, "week"))
+
+    /** explicit constructor for a TimeSpan  */
+    def apply(in: Long) = new TimeSpan(in)
+
+    /**
+     * Formats a number of millis to a string representing the number of weeks, days, hours, minutes, seconds, millis
+     */
+    def format(millis: Long): String = {
+      def divideInUnits(millis: Long) = scales.foldLeft[(Long, List[(Long, String)])]((millis, Nil)){ (total, div) =>
+        (total._1 / div._1, (total._1 % div._1, div._2) :: total._2)
+      }._2
+      def formatAmount(amountUnit: (Long, String)) = amountUnit match {
+        case (amount, unit) if (amount == 1) => amount + " " + unit
+        case (amount, unit) => amount + " " + unit + "s"
+      }
+      divideInUnits(millis).filter(_._1 > 0).map(formatAmount(_)).mkString(", ")
+    }
+
+    /**
+     * Convert a Date to a TimeSpan
+     */
+    implicit def dateToTS(in: Date): TimeSpan =
+      new TimeSpan(Left(new DateTime(in.getTime)))
+
+    /**
+     * Convert a DateTime to a TimeSpan
+     */
+    implicit def dateTimeToTS(in: DateTime): TimeSpan =
+      new TimeSpan(Left(in))
+
+    /**
+     * Convert a Duration to a TimeSpan
+     */
+    implicit def durationToTS(in: Duration): TimeSpan =
+      new TimeSpan(Right(in: Period))
+
+    /**
+     * Convert a Period to a TimeSpan
+     */
+    implicit def periodToTS(in: Period): TimeSpan =
+      new TimeSpan(Right(in))
+  }
+
+}
+
+trait ConvertableToDate {
+  def toDate: Date
+  def toDateTime: DateTime
+  def millis: Long
+}
+
+object ConvertableToDate {
+  implicit def toDate(in: ConvertableToDate): Date = in.toDate
+  implicit def toDateTime(in: ConvertableToDate): DateTime = in.toDateTime
+  implicit def toMillis(in: ConvertableToDate): Long = in.millis
+
+}

--- a/core/util/src/test/scala/net/liftweb/util/ScheduleSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/ScheduleSpec.scala
@@ -22,7 +22,7 @@ import org.specs2.specification.BeforeExample
 import org.specs2.execute.PendingUntilFixed
 
 import actor._
-import Helpers._
+import scala.concurrent.duration._
 
 
 /**
@@ -35,20 +35,20 @@ object ScheduleSpec extends Specification with PendingUntilFixed with PingedServ
 
   "The Schedule object" should {
     "provide a schedule method to ping an actor regularly" in {
-      Schedule.schedule(service, Alive, TimeSpan(10))
+      Schedule.schedule(service, Alive, 10.milli)
       service.pinged must eventually(beTrue)
     }
     "honor multiple restarts" in {
       Schedule.restart
       Schedule.restart
       Schedule.restart
-      Schedule.schedule(service, Alive, TimeSpan(10))
+      Schedule.schedule(service, Alive, 10.milli)
       service.pinged must eventually(beTrue)
     }
     "honor shutdown followed by restart" in {
       Schedule.shutdown
       Schedule.restart
-      Schedule.schedule(service, Alive, TimeSpan(10))
+      Schedule.schedule(service, Alive, 10.milli)
       service.pinged must eventually(beTrue)
     }
     "not honor multiple shutdowns" in {

--- a/core/util/src/test/scala/net/liftweb/util/TimeSpanHelpersSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/TimeSpanHelpersSpec.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2006-2015 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.liftweb.util
+
+import java.util.Date
+
+import net.liftweb.util.TimeSpanHelpers._
+import org.scalacheck.Gen._
+import org.scalacheck.Prop._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+import org.specs2.time.NoTimeConversions
+
+
+
+/**
+ * Systems under specification for TimeHelpers.
+ */
+class TimeSpanHelpersSpec extends Specification with ScalaCheck with TimeAmountsGen with NoTimeConversions {
+  "TimeSpanHelpers Specification".title
+
+  "A TimeSpan" can {
+    "be converted implicitly to a date starting from the epoch time" in {
+      3.seconds.after(new Date(0)) must beTrue
+    }
+    "be converted to a date starting from the epoch time, using the date method" in {
+      3.seconds.after(new Date(0)) must beTrue
+    }
+    "be implicitly converted to a Long" in {
+      (3.seconds == 3000L) must_== true
+    }
+    "be compared to an int" in {
+      (3.seconds == 3000) must_== true
+      (3.seconds != 2000) must_== true
+    }
+    "be compared to a long" in {
+      (3.seconds == 3000L) must_== true
+      (3.seconds != 2000L) must_== true
+    }
+    "be compared to another TimeSpan" in {
+      3.seconds must_== 3.seconds
+      3.seconds must_!= 2.seconds
+    }
+    "be compared to another object" in {
+      3.seconds must_!= "string"
+    }
+  }
+
+  "A TimeSpan" should {
+    "return a new TimeSpan representing the sum of the 2 times when added with another TimeSpan" in {
+      3.seconds + 3.seconds must_== 6.seconds
+    }
+    "return a new TimeSpan representing the difference of the 2 times when substracted with another TimeSpan" in {
+      3.seconds - 4.seconds must_== (-1).seconds
+    }
+    "have a later method returning a date relative to now plus the time span" in {
+      val expectedTime = new Date().getTime + 3.seconds.millis
+
+      3.seconds.later.getTime must beCloseTo(expectedTime, 1000L)
+    }
+    "have an ago method returning a date relative to now minus the time span" in {
+      val expectedTime = new Date().getTime - 3.seconds.millis
+
+      3.seconds.ago.getTime must beCloseTo(expectedTime, 1000L)
+    }
+    "have a toString method returning the relevant number of weeks, days, hours, minutes, seconds, millis" in {
+      val conversionIsOk = forAll(timeAmounts)((t: TimeAmounts) => { val (timeSpanToString, timeSpanAmounts) = t
+        timeSpanAmounts forall { case (amount, unit) =>
+          amount >= 1  &&
+            timeSpanToString.contains(amount.toString) || true }
+      })
+      val timeSpanStringIsPluralized = forAll(timeAmounts)((t: TimeAmounts) => { val (timeSpanToString, timeSpanAmounts) = t
+        timeSpanAmounts forall { case (amount, unit) =>
+          amount > 1  && timeSpanToString.contains(unit + "s") ||
+            amount == 1 && timeSpanToString.contains(unit) ||
+            amount == 0 && !timeSpanToString.contains(unit)
+        }
+      })
+      check(conversionIsOk && timeSpanStringIsPluralized)
+    }
+  }
+}
+
+trait TimeAmountsGen {
+
+  type TimeAmounts = (String, List[(Int, String)])
+
+  val timeAmounts =
+    for {
+      w <- choose(0, 2)
+      d <- choose(0, 6)
+      h <- choose(0, 23)
+      m <- choose(0, 59)
+      s <- choose(0, 59)
+      ml <- choose(0, 999)
+    }
+    yield (
+      TimeSpan(weeks(w) + days(d) + hours(h) + minutes(m) + seconds(s) + ml).toString,
+      (w, "week") :: (d, "day") :: (h, "hour") :: (m, "minute") :: (s, "second") :: (ml, "milli") :: Nil
+    )
+}

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
@@ -23,6 +23,7 @@ import common._
 import util._
 import http._
 import Helpers._
+import scala.concurrent.duration._
 
 
 trait ProtoExtendedSession[T <: ProtoExtendedSession[T]] extends
@@ -52,7 +53,7 @@ KeyedMapper[Long, T] {
    */
   protected def expirationColumnName = "expiration"
 
-  def expirationTime: Long = millis + 180.days
+  def expirationTime: Long = millis + 180.days.toMillis
 }
 
 trait UserIdAsString {

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
@@ -33,8 +33,7 @@ import json._
 import mongodb.BsonDSL._
 import util.Helpers.randomString
 import http.{LiftSession, S}
-import http.js.JE._
-import http.js.JsExp
+import http.js._
 import net.liftweb.record._
 import common.Box._
 import xml.{Elem, NodeSeq, Text}
@@ -230,7 +229,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
     passConversionTests(
       now,
       rec.mandatoryDateField,
-      JsObj(("$dt", Str(nowStr))),
+      JE.JsObj(("$dt", JE.Str(nowStr))),
       JObject(List(JField("$dt", JString(nowStr)))),
       Full(<input name=".*" type="text" tabindex="1" value={nowStr} id="mandatoryDateField_id"></input>)
     )
@@ -263,7 +262,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         oid,
         rec.mandatoryObjectIdField,
-        JsObj(("$oid", oid.toString)),
+        JE.JsObj(("$oid", oid.toString)),
         JObject(List(JField("$oid", JString(oid.toString)))),
         Full(<input name=".*" type="text" tabindex="1" value={oid.toString} id="mandatoryObjectIdField_id"></input>)
       )
@@ -281,7 +280,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
     passConversionTests(
       ptrn,
       rec.mandatoryPatternField,
-      JsObj(("$regex", Str(ptrn.toString)), ("$flags", Num(2))),
+      JE.JsObj(("$regex", JE.Str(ptrn.toString)), ("$flags", JE.Num(2))),
       JObject(List(JField("$regex", JString(ptrn.toString)), JField("$flags", JInt(2)))),
       Empty,
       false
@@ -296,7 +295,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
     passConversionTests(
       uuid,
       rec.mandatoryUUIDField,
-      JsObj(("$uuid", Str(uuid.toString))),
+      JE.JsObj(("$uuid", JE.Str(uuid.toString))),
       JObject(List(JField("$uuid", JString(uuid.toString)))),
       Full(<input name=".*" type="text" tabindex="1" value={uuid.toString} id="mandatoryUUIDField_id"></input>)
     )
@@ -331,7 +330,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         lst,
         rec.mandatoryStringListField,
-        JsArray(Str("abc"), Str("def"), Str("ghi")),
+        JE.JsArray(JE.Str("abc"), JE.Str("def"), JE.Str("ghi")),
         JArray(List(JString("abc"), JString("def"), JString("ghi"))),
         Empty
       )
@@ -347,7 +346,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         lst,
         rec.mandatoryIntListField,
-        JsArray(Num(4), Num(5), Num(6)),
+        JE.JsArray(JE.Num(4), JE.Num(5), JE.Num(6)),
         JArray(List(JInt(4), JInt(5), JInt(6))),
         Empty
       )
@@ -369,7 +368,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         lst,
         rec.objectIdRefListField,
-        JsArray(Str(oid1.toString), Str(oid2.toString), Str(oid3.toString)),
+        JE.JsArray(JE.Str(oid1.toString), JE.Str(oid2.toString), JE.Str(oid3.toString)),
         JArray(List(
           JObject(List(JField("$oid", JString(oid1.toString)))),
           JObject(List(JField("$oid", JString(oid2.toString)))),
@@ -393,7 +392,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         lst1,
         rec.patternListField,
-        JsArray(Str(ptrn1.toString), Str(ptrn2.toString)),
+        JE.JsArray(JE.Str(ptrn1.toString), JE.Str(ptrn2.toString)),
         JArray(List(
           JsonRegex(ptrn1),
           JsonRegex(ptrn2)
@@ -419,7 +418,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         lst,
         rec.dateListField,
-        JsArray(Str(dt1.toString), Str(dt2.toString), Str(dt3.toString)),
+        JE.JsArray(JE.Str(dt1.toString), JE.Str(dt2.toString), JE.Str(dt3.toString)),
         JArray(List(
           JsonDate(dt1)(MongoListTestRecord.formats),
           JsonDate(dt2)(MongoListTestRecord.formats),
@@ -445,7 +444,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         lst,
         rec.uuidListField,
-        JsArray(Str(uuid1.toString), Str(uuid2.toString), Str(uuid3.toString)),
+        JE.JsArray(JE.Str(uuid1.toString), JE.Str(uuid2.toString), JE.Str(uuid3.toString)),
         JArray(List(
           JsonUUID(uuid1),
           JsonUUID(uuid2),
@@ -471,7 +470,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         lst,
         rec.dateTimeListField,
-        JsArray(Str(dt1.toString), Str(dt2.toString), Str(dt3.toString)),
+        JE.JsArray(JE.Str(dt1.toString), JE.Str(dt2.toString), JE.Str(dt3.toString)),
         JArray(List(
           JsonDate(dt1.toDate)(MongoListTestRecord.formats),
           JsonDate(dt2.toDate)(MongoListTestRecord.formats),
@@ -522,7 +521,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         map,
         rec.mandatoryStringMapField,
-        JsObj(("a", Str("abc")), ("b", Str("def")), ("c", Str("ghi"))),
+        JE.JsObj(("a", JE.Str("abc")), ("b", JE.Str("def")), ("c", JE.Str("ghi"))),
         JObject(List(
           JField("a", JString("abc")),
           JField("b", JString("def")),
@@ -542,7 +541,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         map,
         rec.mandatoryIntMapField,
-        JsObj(("a", Num(4)), ("b", Num(5)), ("c", Num(6))),
+        JE.JsObj(("a", JE.Num(4)), ("b", JE.Num(5)), ("c", JE.Num(6))),
         JObject(List(
           JField("a", JInt(4)),
           JField("b", JInt(5)),
@@ -634,7 +633,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       passConversionTests(
         lst,
         rec.mandatoryBsonRecordListField,
-        JsArray(sr1JsExp, sr2JsExp),
+        JE.JsArray(sr1JsExp, sr2JsExp),
         JArray(List(sr1Json, sr2Json)),
         Empty
       )

--- a/persistence/record/src/test/scala/net/liftweb/record/RecordSpec.scala
+++ b/persistence/record/src/test/scala/net/liftweb/record/RecordSpec.scala
@@ -26,14 +26,13 @@ import org.joda.time._
 import http.js.JE._
 import common._
 import http.{S, LiftSession}
-import json._
 import util._
 import util.Helpers._
 
 import field.Countries
 import fixtures._
 
-import JsonDSL._
+import json.JsonDSL._
 
 
 /**
@@ -174,7 +173,7 @@ object RecordSpec extends Specification {
   "Record" should {
     val session = new LiftSession("", randomString(20), Empty)
     S.initIfUninitted(session){
-      val gu: Array[Byte] = Array(18, 19, 20)
+      val gu = Array[Byte](18, 19, 20)
       val cal = Calendar.getInstance
       val dt: DateTime = DateTime.now
 
@@ -196,7 +195,7 @@ object RecordSpec extends Specification {
         .mandatoryTimeZoneField("America/Chicago")
         .mandatoryJodaTimeField(dt)
 
-      val fttrJValue: JValue =
+      val fttrJValue: json.JValue =
         ("mandatoryBooleanField" -> false) ~
         ("mandatoryCountryField" -> 1) ~
         ("mandatoryDateTimeField" -> Helpers.toInternetDate(cal.getTime)) ~
@@ -214,7 +213,7 @@ object RecordSpec extends Specification {
         ("mandatoryBinaryField" -> "EhMU") ~
         ("mandatoryJodaTimeField" -> dt.getMillis)
 
-      val fttrJson: String = compact(render(fttrJValue))
+      val fttrJson: String = json.compact(json.render(fttrJValue))
 
       val fttrAsJsObj = JsObj(
         ("mandatoryBooleanField", JsFalse),
@@ -279,6 +278,8 @@ object RecordSpec extends Specification {
       }*/
 
       "convert to JValue" in {
+        import json._
+
         fttr.asJValue mustEqual JObject(List(
           JField("mandatoryBooleanField", JBool(false)),
           JField("legacyOptionalBooleanField", JNothing),

--- a/web/webkit/src/main/scala/net/liftweb/builtin/comet/AsyncRenderComet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/comet/AsyncRenderComet.scala
@@ -2,13 +2,13 @@ package net.liftweb
 package builtin
 package comet
 
+import scala.concurrent.duration._
 import scala.xml.NodeSeq
 
 import common._
 import http._
   import js._
 import util._
-  import Helpers._
 
 case class Compute(js: () => JsCmd)
 private case class Render(js: JsCmd)
@@ -37,7 +37,7 @@ private case class Render(js: JsCmd)
  */
 class AsyncRenderComet extends CometActor {
 
-  override def lifespan: Box[TimeSpan] = Full(90.seconds)
+  override def lifespan: Box[Duration] = Full(90.seconds)
 
   def render = NodeSeq.Empty
 

--- a/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
@@ -22,6 +22,7 @@ import net.liftweb.actor._
 import net.liftweb.util.Helpers._
 import net.liftweb.util._
 import net.liftweb.json._
+import scala.concurrent.duration.Duration
 import scala.xml.{NodeSeq, Text, Elem, Node, Group, Null, PrefixedAttribute, UnprefixedAttribute}
 import scala.collection.mutable.ListBuffer
 import net.liftweb.http.js._
@@ -550,7 +551,7 @@ trait CometActor extends LiftActor with LiftCometActor with CssBindImplicits {
    * isn't visible on any page for some period after its lifespan
    * the CometActor will be shut down.
    */
-  def lifespan: Box[TimeSpan] = Empty
+  def lifespan: Box[Duration] = Empty
 
   private var _running = true
 
@@ -910,7 +911,7 @@ trait CometActor extends LiftActor with LiftCometActor with CssBindImplicits {
 
     case ShutdownIfPastLifespan =>
       for {
-        ls <- lifespan if listeners.isEmpty && (lastListenTime + ls.millis + 1000l) < millis
+        ls <- lifespan if listeners.isEmpty && (lastListenTime + ls.toMillis + 1000l) < millis
       } {
         this ! ShutDown
       }

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -53,7 +53,7 @@ private[http] trait LiftMerge {
    */
   def merge(xhtml: NodeSeq, req: Req): Node = {
     val snippetHashs: HashMap[String, Box[NodeSeq]] = this.deferredSnippets.is
-    val waitUntil = millis + LiftRules.lazySnippetTimeout.vend.millis
+    val waitUntil = millis + LiftRules.lazySnippetTimeout.vend.toMillis
     val stripComments: Boolean = LiftRules.stripComments.vend
 
     def waitUntilSnippetsDone() {

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -29,6 +29,7 @@ import JE._
 import JsCmds._
 import auth._
 
+import scala.concurrent.duration._
 import scala.xml._
 import java.util.{Locale, TimeZone, ResourceBundle, Date}
 import java.io.{InputStream, ByteArrayOutputStream, BufferedReader, StringReader}
@@ -240,7 +241,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * for general notices (not associated with id-s) regardless if they are set for the page rendering, ajax
    * response or Comet response.
    */
-  val noticesAutoFadeOut = new FactoryMaker[(NoticeType.Value) => Box[(TimeSpan, TimeSpan)]]((notice : NoticeType.Value) => Empty){}
+  val noticesAutoFadeOut = new FactoryMaker[(NoticeType.Value) => Box[(Duration, Duration)]]((notice : NoticeType.Value) => Empty){}
 
   /**
    * Use this to apply various effects to the notices. The user function receives the NoticeType
@@ -687,7 +688,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * the long polling connection
    */
   val clientActorLifespan = new FactoryMaker[LiftActor => Long](
-    () => (actor: LiftActor) => (30.minutes): Long
+    () => (actor: LiftActor) => 30.minutes.toMillis
   ){}
 
   /**
@@ -710,17 +711,17 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   /**
    * If a Comet request fails timeout for this period of time. Default value is 10 seconds
    */
-  @volatile var cometFailureRetryTimeout: Long = 10.seconds
+  @volatile var cometFailureRetryTimeout: Long = 10.seconds.toMillis
 
   /**
    * The timeout in milliseconds of a comet ajax-request. Defaults to 5000 ms.
    */
-  @volatile var cometProcessingTimeout: Long = 5.seconds
+  @volatile var cometProcessingTimeout: Long = 5.seconds.toMillis
 
   /**
    * The timeout in milliseconds of a comet render-request. Defaults to 30000 ms.
    */
-  @volatile var cometRenderTimeout: Long = 30.seconds
+  @volatile var cometRenderTimeout: Long = 30.seconds.toMillis
 
   /**
    * The dispatcher that takes a Snippet and converts it to a
@@ -1042,7 +1043,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   /**
    * How long should we wait for all the lazy snippets to render
    */
-  val lazySnippetTimeout: FactoryMaker[TimeSpan] = new FactoryMaker(() => 30.seconds) {}
+  val lazySnippetTimeout: FactoryMaker[Duration] = new FactoryMaker(() => 30.seconds: Duration) {}
 
   /**
    * Does the current context support parallel snippet execution
@@ -1616,13 +1617,13 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * (given in milliseconds) will be discarded, hence eligible for garbage collection.
    * The default value is 10 minutes.
    */
-  @volatile var unusedFunctionsLifeTime: Long = 10.minutes
+  @volatile var unusedFunctionsLifeTime: Long = 10.minutes.toMillis
 
   /**
    * The polling interval for background Ajax requests to prevent functions of being garbage collected.
    * Default value is set to 75 seconds.
    */
-  @volatile var liftGCPollingInterval: Long = 75.seconds
+  @volatile var liftGCPollingInterval: Long = 75.seconds.toMillis
 
   /**
    * Put a test for being logged in into this function
@@ -1633,7 +1634,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * The polling interval for background Ajax requests to keep functions to not be garbage collected.
    * This will be applied if the Ajax request will fail. Default value is set to 15 seconds.
    */
-  @volatile var liftGCFailureRetryTimeout: Long = 15.seconds
+  @volatile var liftGCFailureRetryTimeout: Long = 15.seconds.toMillis
 
   /**
    * If this is Full, comet updates (partialUpdates or reRenders) are

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
@@ -27,6 +27,7 @@ import js._
 import auth._
 import provider._
 import json.JsonAST.JValue
+import scala.concurrent.duration._
 
 /**
  * Wrap a LiftResponse and cache the result to avoid computing the actual response
@@ -812,7 +813,7 @@ class LiftServlet extends Loggable {
 
       case ar: AnswerRender =>
         answers = ar :: answers
-        LAPinger.schedule(this, BreakOut(), 5.millis)
+        LAPinger.schedule(this, BreakOut(), 5L)
 
       case BreakOut() if !done =>
         done = true
@@ -844,7 +845,7 @@ class LiftServlet extends Loggable {
     try {
       session.enterComet(cont -> request)
 
-      LAPinger.schedule(cont, BreakOut(), TimeSpan(cometTimeout))
+      LAPinger.schedule(cont, BreakOut(), cometTimeout)
 
       request.request.suspend(cometTimeout + 2000L)
     } finally {
@@ -918,7 +919,7 @@ class LiftServlet extends Loggable {
 
       session.enterComet(cont -> request)
 
-      LAPinger.schedule(cont, BreakOut(), TimeSpan(cometTimeout))
+      LAPinger.schedule(cont, BreakOut(), cometTimeout)
 
       val ret2 = f.get(cometTimeout) openOr Nil
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -21,6 +21,7 @@ import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.mutable.{HashMap, ListBuffer}
+import scala.concurrent.duration._
 import collection.JavaConversions
 
 import collection.mutable.{HashMap, ListBuffer}
@@ -396,7 +397,7 @@ object SessionMaster extends LiftActor with Loggable {
       import scala.collection.JavaConversions._
 
     /* remove dead sessions that are more than 45 minutes old */
-    val now = Helpers.millis - 45.minutes
+    val now = Helpers.millis - 45.minutes.toMillis
 
     val removeKeys: Iterable[String] = killedSessions.filter(_._2 < now).map(_._1)
     removeKeys.foreach(s => killedSessions.remove(s))
@@ -677,7 +678,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
 
   @volatile
   private[http] var inactivityLength: Long =
-    LiftRules.sessionInactivityTimeout.vend openOr ((30.minutes): Long)
+    LiftRules.sessionInactivityTimeout.vend openOr (30.minutes.toMillis)
 
   private[http] var highLevelSessionDispatcher = new HashMap[String, LiftRules.DispatchPF]()
   private[http] var sessionRewriter = new HashMap[String, LiftRules.RewritePF]()
@@ -2342,7 +2343,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
 
 
 
-        override def lifespan = Full(LiftRules.clientActorLifespan.vend.apply(this))
+        override def lifespan = Full(LiftRules.clientActorLifespan.vend.apply(this).millis)
 
         override def hasOuter = false
 
@@ -2808,7 +2809,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
 
 
 
-        override def lifespan = Full(LiftRules.clientActorLifespan.vend.apply(this))
+        override def lifespan = Full(LiftRules.clientActorLifespan.vend.apply(this).millis)
 
         override def hasOuter = false
 

--- a/web/webkit/src/main/scala/net/liftweb/http/NamedCometActorTrait.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/NamedCometActorTrait.scala
@@ -17,7 +17,7 @@
 package net.liftweb
 package http
 
-import util.Helpers._
+import scala.concurrent.duration._
 import common.{Loggable, Full}
 
 

--- a/web/webkit/src/main/scala/net/liftweb/http/ResourceServer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/ResourceServer.scala
@@ -22,6 +22,7 @@ import net.liftweb.util._
 import Helpers._
 import java.net.{URL, URLConnection, JarURLConnection}
 import java.util.concurrent.{ConcurrentHashMap => CHash}
+import scala.concurrent.duration._
 
 object ResourceServer {
   var allowedPaths: PartialFunction[List[String], Boolean] = {
@@ -93,13 +94,13 @@ object ResourceServer {
       url <- LiftRules.getResource(path)
       lastModified = calcLastModified(url)
     } yield
-      request.testFor304(lastModified, "Expires" -> toInternetDate(millis + 30.days)) openOr {
+      request.testFor304(lastModified, "Expires" -> toInternetDate(millis + 30.days.toMillis)) openOr {
         val stream = url.openStream
         val uc = url.openConnection
         StreamingResponse(stream, () => stream.close, uc.getContentLength,
           (if (lastModified == 0L) Nil else
             List("Last-Modified" -> toInternetDate(lastModified))) :::
-                  List("Expires" -> toInternetDate(millis + 30.days),
+                  List("Expires" -> toInternetDate(millis + 30.days.toMillis),
                        "Date" -> Helpers.nowAsInternetDate,
                        "Pragma" -> "",
                        "Cache-Control" -> "",

--- a/web/webkit/src/main/scala/net/liftweb/http/auth/HttpAuthentication.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/auth/HttpAuthentication.scala
@@ -25,6 +25,7 @@ import net.liftweb.util.Helpers._
 import net.liftweb.http._
 import org.apache.commons.codec.binary._
 import scala.collection.mutable.{HashMap}
+import scala.concurrent.duration._
 
 /**
  * All http authentication methods must implement these methods.
@@ -140,7 +141,7 @@ case class HttpDigestAuthentication(realmName: String)(func: PartialFunction[(St
    * The default value returned is 30 seconds.
    *
    */
-  def nonceValidityPeriod: Long = 30.seconds
+  def nonceValidityPeriod: Long = 30.seconds.toMillis
 
   override def realm = realmName
 

--- a/web/webkit/src/main/scala/net/liftweb/http/jquery/JqSHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/jquery/JqSHtml.scala
@@ -18,25 +18,42 @@ package net.liftweb
 package http
 package jquery
 
-import net.liftweb.util.Helpers._
 import net.liftweb.http.js._
 import net.liftweb.http.js.jquery._
 import JqJsCmds._
+import net.liftweb.util.TimeSpanHelpers.TimeSpan
+
+import scala.concurrent.duration.Duration
 
 /**
  * This contains Html artifacts that are heavily relying on JQuery
  */
 @deprecated("This contains Html artifacts that are heavily relying on JQuery", "2.3")
 object JqSHtml {
+  @deprecated("Use scala.concurrent.duration.Duration instead of TimeSpan")
   def fadeOutErrors(duration: TimeSpan, fadeTime: TimeSpan): JsCmd = {
+    fadeOutErrors(duration.toScalaDuration, fadeTime.toScalaDuration)
+  }
+
+  @deprecated("Use scala.concurrent.duration.Duration instead of TimeSpan")
+  def fadeOutWarnings(duration: TimeSpan, fadeTime: TimeSpan): JsCmd = {
+    fadeOutWarnings(duration.toScalaDuration, fadeTime.toScalaDuration)
+  }
+
+  @deprecated("Use scala.concurrent.duration.Duration instead of TimeSpan")
+  def fadeOutNotices(duration: TimeSpan, fadeTime: TimeSpan): JsCmd = {
+    fadeOutNotices(duration.toScalaDuration, fadeTime.toScalaDuration)
+  }
+
+  def fadeOutErrors(duration: Duration, fadeTime: Duration): JsCmd = {
     FadeOut(LiftRules.noticesContainerId + "_error", duration, fadeTime)
   }
 
-  def fadeOutWarnings(duration: TimeSpan, fadeTime: TimeSpan): JsCmd = {
+  def fadeOutWarnings(duration: Duration, fadeTime: Duration): JsCmd = {
     FadeOut(LiftRules.noticesContainerId + "_warn", duration, fadeTime)
   }
 
-  def fadeOutNotices(duration: TimeSpan, fadeTime: TimeSpan): JsCmd = {
+  def fadeOutNotices(duration: Duration, fadeTime: Duration): JsCmd = {
     FadeOut(LiftRules.noticesContainerId + "_notice", duration, fadeTime)
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JSArtifacts.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JSArtifacts.scala
@@ -19,8 +19,9 @@ package http
 package js
 
 import net.liftweb.common.{Box, Full, Empty}
+import net.liftweb.util.TimeSpanHelpers.TimeSpan
+import scala.concurrent.duration._
 import scala.xml.NodeSeq
-import net.liftweb.util.Helpers._
 
 /**
  * Abstracted JavaScript artifacts used by lift core.
@@ -73,7 +74,16 @@ trait JSArtifacts {
    * Fades out the element denominated by id, by waiting
    * for duration milliseconds and fading out for fadeTime milliseconds
    */
-  def fadeOut(id: String, duration: TimeSpan, fadeTime: TimeSpan): JsCmd
+  @deprecated("Use scala.concurrent.duration.Duration instead of TimeSpan")
+  def fadeOut(id: String, duration: TimeSpan, fadeTime: TimeSpan): JsCmd = {
+    fadeOut(id, duration.toScalaDuration, fadeTime.toScalaDuration)
+  }
+
+  /**
+   * Fades out the element denominated by id, by waiting
+   * for duration milliseconds and fading out for fadeTime milliseconds
+   */
+  def fadeOut(id: String, duration: Duration, fadeTime: Duration): JsCmd
 
   /**
    * Transforms a JSON object into its string representation

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -17,6 +17,9 @@ package net.liftweb
 package http
 package js
 
+import net.liftweb.util.TimeSpanHelpers.TimeSpan
+
+import scala.concurrent.duration._
 import scala.xml.{NodeSeq, Group, Unparsed, Elem}
 import net.liftweb.util.Helpers._
 import net.liftweb.common._
@@ -790,13 +793,20 @@ object JsCmds {
   }
 
   trait HasTime {
-    def time: Box[TimeSpan]
+    def time: Box[Duration]
 
-    def timeStr = time.map(_.millis.toString) openOr ""
+    def timeStr = time.map(_.toMillis.toString) openOr ""
   }
 
-  case class After(time: TimeSpan, toDo: JsCmd) extends JsCmd {
-    def toJsCmd = "setTimeout(function() {" + toDo.toJsCmd + "}, " + time.millis + ");"
+  object After {
+    @deprecated("Use scala.concurrent.duration.Duration instead of TimeSpan")
+    def apply(time: TimeSpan, toDo: JsCmd): After = {
+      new After(time.toScalaDuration, toDo)
+    }
+  }
+
+  case class After(time: Duration, toDo: JsCmd) extends JsCmd {
+    def toJsCmd = "setTimeout(function() {" + toDo.toJsCmd + "}, " + time.toMillis + ");"
   }
 
   case class Alert(text: String) extends JsCmd {
@@ -954,13 +964,13 @@ object JsRules {
   * messages.
   */
   //@deprecated
-  @volatile var prefadeDuration: Helpers.TimeSpan = 5.seconds
+  @volatile var prefadeDuration: Duration = 5.seconds
 
   /**
   * The default fade time for fading FadeOut and FadeIn
   * messages.
   */
   //@deprecated
-  @volatile var fadeTime: Helpers.TimeSpan = 1.second
+  @volatile var fadeTime: Duration = 1.second
 }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/extcore/ExtCoreArtifacts.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/extcore/ExtCoreArtifacts.scala
@@ -19,6 +19,7 @@ package http
 package js
 package extcore
 
+import scala.concurrent.duration.Duration
 import scala.xml.NodeSeq
 
 import net.liftweb.http.S
@@ -113,7 +114,7 @@ object ExtCoreArtifacts extends JSArtifacts {
    * Fades out the element having the provided id, by waiting
    * for the given duration and fades out during fadeTime
    */
-  def fadeOut(id: String, duration: TimeSpan, fadeTime: TimeSpan) = Noop
+  def fadeOut(id: String, duration: Duration, fadeTime: Duration) = Noop
 
   /**
    * Trabsforms a JSON object intoits string representation

--- a/web/webkit/src/main/scala/net/liftweb/http/js/jquery/JQueryArtifacts.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/jquery/JQueryArtifacts.scala
@@ -29,6 +29,7 @@ import JqJE._
 import JqJsCmds._
 import util.Helpers._
 import util.Props
+import scala.concurrent.duration._
 
 trait JQueryArtifacts extends JSArtifacts {
   /**
@@ -87,7 +88,7 @@ trait JQueryArtifacts extends JSArtifacts {
    * Fades out the element having the provided id, by waiting
    * for the given duration and fades out during fadeTime
    */
-  def fadeOut(id: String, duration: TimeSpan, fadeTime: TimeSpan) =
+  def fadeOut(id: String, duration: Duration, fadeTime: Duration) =
     FadeOut(id, duration, fadeTime)
 
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/js/yui/YUIArtifacts.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/yui/YUIArtifacts.scala
@@ -17,8 +17,9 @@
 package net.liftweb 
 package http 
 package js 
-package yui 
+package yui
 
+import scala.concurrent.duration.Duration
 import scala.xml.{Elem, NodeSeq}
 
 import net.liftweb.http.S
@@ -119,7 +120,7 @@ object YUIArtifacts extends JSArtifacts {
    * Fades out the element having the provided id, by waiting
    * for the given duration and fades out during fadeTime
    */
-  def fadeOut(id: String, duration: TimeSpan, fadeTime: TimeSpan) = Noop
+  def fadeOut(id: String, duration: Duration, fadeTime: Duration) = Noop
 
   /**
    * Trabsforms a JSON object intoits string representation


### PR DESCRIPTION
Mailing list discussion: https://groups.google.com/forum/#!topic/liftweb/CgZFVwMEiqU

`TimeSpan` has ambiguous definition. It can behave like a joda `Period` (e.g. take care about timeshift)
but for most cases it should by only a wrapper for in-milliseconds duration. It breaks SRP. This change replace `TimeSpan` with `scala.concurrent.duration.Duration` deprecating the first one.

For most cases old code should work without changes - only import of `TimeSpanHelpers` will be neede and deprecation notice will appear. Change should be painless If user will want to clear it because of similar DSL for `Duration` building as in `TimeSpan`. The all what will be needed is to replace import with  `scala.concurrent.duration._.`

For a few places code will not compile until user make a migration because `TimeSpan` was used in abstract method e.g. `CometActor.lifespan: Box[TimeSpan]`

There is a little walk-around in `Schedule.schedule(f: () => Any, delay: Duration): ScheduledFuture[Unit]`. It takes now `f: () => Any` istead of `f: () => Unit`. Because of backward compatibility there is overloaded method with TimeSpan and it causes ambiguity if smb pass a function returning other thing than `Unit`.