### PR TITLE
TimeSpan represents duration in milliseconds.

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -22,7 +22,7 @@ import java.util.{TimeZone, Calendar, Date, Locale}
 
 import scala.language.implicitConversions
 
-import org.joda.time.{DateTime, Duration, Period, PeriodType}
+import org.joda.time._
 
 import common._
 
@@ -39,9 +39,6 @@ trait TimeHelpers { self: ControlHelpers =>
   // Logger must be lazy, since we cannot instantiate until after boot is complete
   private  lazy val logger = Logger(classOf[TimeHelpers])
 
-  /** private variable allowing the access to all TimeHelpers functions from inside the TimeSpan class */
-  private val outer = this
-
   /** transforms a long to a TimeSpanBuilder object. Usage: 3L.seconds returns a TimeSpan of 3000L millis  */
   implicit def longToTimeSpanBuilder(in: Long): TimeSpanBuilder = TimeSpanBuilder(in)
 
@@ -54,96 +51,74 @@ trait TimeHelpers { self: ControlHelpers =>
   /** transforms an int to a TimeSpan object. Usage: 3000 returns a TimeSpan of 3000L millis  */
   implicit def intToTimeSpan(in: Int): TimeSpan = TimeSpan(in)
 
-  private implicit def durToPeriod(dur: Duration): Period = dur.toPeriod(PeriodType.standard())
-
   /** class building TimeSpans given an amount (len) and a method specify the time unit  */
   case class TimeSpanBuilder(val len: Long) {
-    def seconds = new TimeSpan(Right((new Period).plusSeconds(len.toInt)))
+    def seconds = new TimeSpan(Left(Duration.standardSeconds(len)))
     def second = seconds
-    def minutes = new TimeSpan(Right((new Period).plusMinutes(len.toInt)))
+    def minutes = new TimeSpan(Left(Duration.standardMinutes(len)))
     def minute = minutes
-    def hours = new TimeSpan(Right(Duration.standardHours(len): Period))
+    def hours = new TimeSpan(Left(Duration.standardHours(len)))
     def hour = hours
-    def days = new TimeSpan(Right(Duration.standardDays(len): Period))
+    def days = new TimeSpan(Left(Duration.standardDays(len)))
     def day = days
-    def weeks = new TimeSpan(Right(Duration.standardDays(len * 7L): Period))
+    def weeks = new TimeSpan(Left(Duration.standardDays(len * 7L)))
     def week = weeks
-    def months = new TimeSpan(Right((new Period().plusMonths(len.toInt))))
+    @deprecated
+    def months = new TimeSpan(Right(new Period().plusMonths(len.toInt)))
+    @deprecated
     def month = months
-    def years = new TimeSpan(Right((new Period().plusYears(len.toInt))))
+    @deprecated
+    def years = new TimeSpan(Right(new Period().plusYears(len.toInt)))
+    @deprecated
     def year = years
   }
-
-  /*
-  /**
-   * transforms a TimeSpan to a date by converting the TimeSpan expressed as millis and creating
-   * a Date lasting that number of millis from the Epoch time (see the documentation for java.util.Date)
-   */
-  implicit def timeSpanToDate(in: TimeSpan): Date = in.date
-
-  /** transforms a TimeSpan to its long value as millis */
-  implicit def timeSpanToLong(in: TimeSpan): Long = in.millis
-  */
 
   /**
    * The TimeSpan class represents an amount of time.
    * It can be translated to a date with the date method. In that case, the number of millis seconds will be used to create a Date
    * object starting from the Epoch time (see the documentation for java.util.Date)
    */
-  class TimeSpan(private val dt: Either[DateTime, Period]) extends ConvertableToDate {
+  class TimeSpan(private val dt: Either[Duration, Period]) extends ConvertableToDate{
     /** @return a Date as the amount of time represented by the TimeSpan after the Epoch date */
 
     def this(ms: Long) =
-      this(if (ms < 52L * 7L * 24L * 60L * 60L * 1000L) Right(new Period(ms))
-           else Left(new DateTime(ms)))
+      this(Left(new Duration(ms)))
 
-    def date: Date = dt match {
-      case Left(datetime) => new Date(datetime.getMillis())
-      case _ => new Date(millis)
-    }
+    @deprecated
+    def date: Date = new Date(millis)
 
     /**
      * Convert to a Date
      */
+    @deprecated
     def toDate: Date = date
 
     /**
      * Convert to a JodaTime DateTime
      */
-    def toDateTime = dt match {
-      case Left(datetime) => datetime
-      case _ => new DateTime(millis)
+    @deprecated
+    def toDateTime = new DateTime(millis)
+
+    @deprecated
+    private[util] def toPeriod: Period = dt match {
+      case Left(duration) => duration.toPeriod
+      case Right(period) => period
     }
 
     def toMillis = millis
 
     def millis = dt match {
-      case Left(datetime) => datetime.getMillis()
-      case Right(duration) => duration.toStandardDuration.getMillis()
+      case Left(duration) => duration.getMillis
+      case Right(period) => period.toStandardDuration.getMillis
     }
-
-
-    /** @return a Date as the amount of time represented by the TimeSpan after now */
-    def later: TimeSpan = dt match {
-      case Right(duration) => new TimeSpan(Left(new DateTime(outer.millis).plus(duration)))
-      case _ => TimeSpan(millis + outer.millis)
-    }
-
-    /** @return a Date as the amount of time represented by the TimeSpan before now */
-    def ago: TimeSpan = dt match {
-      case Right(duration) => new TimeSpan(Left(new DateTime(outer.millis).minus(duration)))
-      case _ => TimeSpan(outer.millis - millis)
-    }
-
-    def noTime: Date = new DateExtension(this).noTime
 
     /** @return a TimeSpan representing the addition of 2 TimeSpans */
     def +[B](in: B)(implicit f: B => TimeSpan): TimeSpan =
       (this.dt, f(in).dt) match {
-        case (Right(p1), Right(p2)) => p1.plus(p2)
-        case (Left(date), Right(duration)) => date.plus(duration)
-        case (Right(duration), Left(date)) => date.plus(duration)
-        case _ => TimeSpan(this.millis + f(in).millis)
+        case (Right(p1), Right(p2)) => new TimeSpan(Right(p1.plus(p2)))
+        case (Left(duration), Right(period)) => new TimeSpan(Left(duration.plus(period.toStandardDuration)))
+        case (Right(period), Left(duration)) => new TimeSpan(Left(period.toStandardDuration.plus(duration)))
+        case (Left(d1), Left(d2)) => new TimeSpan(Left(d1.plus(d2)))
       }
 
     /** @return a TimeSpan representing the addition of 2 TimeSpans */
@@ -152,10 +127,10 @@ trait TimeHelpers { self: ControlHelpers =>
     /** @return a TimeSpan representing the substraction of 2 TimeSpans */
     def -[B](in: B)(implicit f: B => TimeSpan): TimeSpan =
       (this.dt, f(in).dt) match {
-        case (Right(p1), Right(p2)) => p1.minus(p2)
-        case (Left(date), Right(duration)) => date.minus(duration)
-        case (Right(duration), Left(date)) => date.minus(duration)
-        case _ => TimeSpan(this.millis - f(in).millis)
+        case (Right(p1), Right(p2)) => new TimeSpan(Right(p1.minus(p2)))
+        case (Left(duration), Right(period)) => new TimeSpan(Left(duration.minus(period.toStandardDuration)))
+        case (Right(period), Left(duration)) => new TimeSpan(Left(period.toStandardDuration.minus(duration)))
+        case (Left(d1), Left(d2)) => new TimeSpan(Left(d1.minus(d2)))
       }
 
     /** override the equals method so that TimeSpans can be compared to long, int and TimeSpan */
@@ -164,19 +139,14 @@ trait TimeHelpers { self: ControlHelpers =>
         case lo: Long => lo == this.millis
         case i: Int => i == this.millis
         case ti: TimeSpan => ti.dt == this.dt
-        case d: Date => d.getTime() == this.millis
-        case dt: DateTime => Left(dt) == this.dt
-        case dur: Duration => Right(dur: Period) == this.dt
-        case dur: Period => Right(dur) == this.dt
+        case dur: Duration => Left(dur) == this.dt
+        case period: Period => Right(period) == this.dt
         case _ => false
       }
     }
 
     /** override the toString method to display a readable amount of time */
-    override def toString = dt match {
-      case Left(date) => date.toString
-      case Right(dur) => TimeSpan.format(millis)
-    }
+    override def toString = TimeSpan.format(millis)
   }
 
   /**
@@ -208,26 +178,36 @@ trait TimeHelpers { self: ControlHelpers =>
     /**
      * Convert a Date to a TimeSpan
      */
+    @deprecated
     implicit def dateToTS(in: Date): TimeSpan =
-      new TimeSpan(Left(new DateTime(in.getTime)))
+      new TimeSpan(Left(new Duration(in.getTime)))
 
-    /**
-     * Convert a DateTime to a TimeSpan
-     */
-    implicit def dateTimeToTS(in: DateTime): TimeSpan =
-      new TimeSpan(Left(in))
 
     /**
      * Convert a Duration to a TimeSpan
      */
     implicit def durationToTS(in: Duration): TimeSpan =
-      new TimeSpan(Right(in: Period))
+      new TimeSpan(Left(in))
 
     /**
      * Convert a Period to a TimeSpan
      */
+    @deprecated
     implicit def periodToTS(in: Period): TimeSpan =
       new TimeSpan(Right(in))
+
+    /**
+     * Convert a TimeSpan to a Period
+     */
+    @deprecated
+    implicit def tsToPeriod[TS <% TimeSpan](in: TS): Period = in.toPeriod
+
+    /**
+     * Convert a DateTime to a TimeSpan
+     */
+    @deprecated
+    implicit def dateTimeToTS[DT <% DateTime](in: DT): TimeSpan =
+      new TimeSpan(Left(new Duration(in.getMillis)))
   }
 
   /** @return the current System.nanoTime() */
@@ -266,6 +246,11 @@ trait TimeHelpers { self: ControlHelpers =>
       calendar.set(Calendar.MILLISECOND, 0)
       calendar.getTime
     }
+  }
+
+
+  implicit class DateTimeExtension(dateTime: DateTime) {
+    def noTime = dateTime.withTimeAtStartOfDay()
   }
 
   /** implicit def used to add the setXXX methods to the Calendar class */
@@ -427,18 +412,29 @@ trait TimeHelpers { self: ControlHelpers =>
       case e: Exception => logger.debug("Error parsing date "+in, e); Failure("Bad date: "+in, Full(e), Empty)
     }
   }
+
+  implicit class PeriodExtension[P <% Period](period: P) {
+    def later: DateTime = new DateTime(millis).plus(period)
+
+    def ago: DateTime = new DateTime(millis).minus(period)
+  }
+
 }
 
+@deprecated
 trait ConvertableToDate {
+  @deprecated
   def toDate: Date
+  @deprecated
   def toDateTime: DateTime
   def millis: Long
 }
 
+@deprecated
 object ConvertableToDate {
+  @deprecated
   implicit def toDate(in: ConvertableToDate): Date = in.toDate
+  @deprecated
   implicit def toDateTime(in: ConvertableToDate): DateTime = in.toDateTime
   implicit def toMillis(in: ConvertableToDate): Long = in.millis
-
 }
-

--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -46,9 +46,11 @@ trait TimeHelpers { self: ControlHelpers =>
   implicit def intToTimeSpanBuilder(in: Int): TimeSpanBuilder = TimeSpanBuilder(in)
 
   /** transforms a long to a TimeSpan object. Usage: 3000L returns a TimeSpan of 3000L millis  */
+  @deprecated("Long to TimeSpan conversion will be removed for possibility of of ambiguous behaviours", "3.0.0")
   implicit def longToTimeSpan(in: Long): TimeSpan = TimeSpan(in)
 
   /** transforms an int to a TimeSpan object. Usage: 3000 returns a TimeSpan of 3000L millis  */
+  @deprecated("Int to TimeSpan conversion will be removed for possibility of of ambiguous behaviours", "3.0.0")
   implicit def intToTimeSpan(in: Int): TimeSpan = TimeSpan(in)
 
   /** class building TimeSpans given an amount (len) and a method specify the time unit  */
@@ -63,13 +65,13 @@ trait TimeHelpers { self: ControlHelpers =>
     def day = days
     def weeks = new TimeSpan(Left(Duration.standardDays(len * 7L)))
     def week = weeks
-    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
     def months = new TimeSpan(Right(new Period().plusMonths(len.toInt)))
-    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
     def month = months
-    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
     def years = new TimeSpan(Right(new Period().plusYears(len.toInt)))
-    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
     def year = years
   }
 
@@ -88,22 +90,22 @@ trait TimeHelpers { self: ControlHelpers =>
     /**
      * Convert to a Date. The number of millis seconds will be used to create a Date object starting from the Epoch time.
      */
-    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     def date: Date = new Date(millis)
 
     /**
      * Convert to a Date. The number of millis seconds will be used to create a Date object starting from the Epoch time.
      */
-    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     def toDate: Date = date
 
     /**
      * Convert to a JodaTime DateTime. The number of millis seconds will be used to create a Date object starting from the Epoch time.
      */
-    @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     def toDateTime = new DateTime(millis)
 
-    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
     private[util] def toPeriod: Period = dt match { // package protected because of view bound usage in tsToPeriod
       case Left(duration) => duration.toPeriod
       case Right(period) => period
@@ -190,7 +192,7 @@ trait TimeHelpers { self: ControlHelpers =>
     /**
      * Convert a Date to a TimeSpan
      */
-    @deprecated("Date to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("Date to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     implicit def dateToTS(in: Date): TimeSpan =
       new TimeSpan(Left(new Duration(in.getTime)))
 
@@ -204,20 +206,20 @@ trait TimeHelpers { self: ControlHelpers =>
     /**
      * Convert a Period to a TimeSpan
      */
-    @deprecated("Period to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("Period to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     implicit def periodToTS(in: Period): TimeSpan =
       new TimeSpan(Right(in))
 
     /**
      * Convert a TimeSpan to a Period
      */
-    @deprecated("TimeSpan to Period conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("TimeSpan to Period conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     implicit def tsToPeriod[TS <% TimeSpan](in: TS): Period = in.toPeriod
 
     /**
      * Convert a DateTime to a TimeSpan
      */
-    @deprecated("DateTime to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("DateTime to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     implicit def dateTimeToTS(in: DateTime): TimeSpan =
       new TimeSpan(Left(new Duration(in.getMillis)))
   }
@@ -433,20 +435,22 @@ trait TimeHelpers { self: ControlHelpers =>
 
 }
 
-@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
 trait ConvertableToDate {
-  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
+  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   def toDate: Date
-  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   def toDateTime: DateTime
+  @deprecated("TimeSpan to Long conversion will be removed for possibility of of ambiguous behaviours", "3.0.0")
   def millis: Long
 }
 
-@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
 object ConvertableToDate {
-  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
+  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   implicit def toDate(in: ConvertableToDate): Date = in.toDate
-  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   implicit def toDateTime(in: ConvertableToDate): DateTime = in.toDateTime
+  @deprecated("TimeSpan to Long conversion will be removed for possibility of of ambiguous behaviours", "3.0.0")
   implicit def toMillis(in: ConvertableToDate): Long = in.millis
 }

--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -46,11 +46,11 @@ trait TimeHelpers { self: ControlHelpers =>
   implicit def intToTimeSpanBuilder(in: Int): TimeSpanBuilder = TimeSpanBuilder(in)
 
   /** transforms a long to a TimeSpan object. Usage: 3000L returns a TimeSpan of 3000L millis  */
-  @deprecated("Long to TimeSpan conversion will be removed for possibility of of ambiguous behaviours", "3.0.0")
+  @deprecated("Long to TimeSpan conversion will be removed for possibility of ambiguous behaviours", "3.0.0")
   implicit def longToTimeSpan(in: Long): TimeSpan = TimeSpan(in)
 
   /** transforms an int to a TimeSpan object. Usage: 3000 returns a TimeSpan of 3000L millis  */
-  @deprecated("Int to TimeSpan conversion will be removed for possibility of of ambiguous behaviours", "3.0.0")
+  @deprecated("Int to TimeSpan conversion will be removed for possibility of ambiguous behaviours", "3.0.0")
   implicit def intToTimeSpan(in: Int): TimeSpan = TimeSpan(in)
 
   /** class building TimeSpans given an amount (len) and a method specify the time unit  */
@@ -441,7 +441,7 @@ trait ConvertableToDate {
   def toDate: Date
   @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   def toDateTime: DateTime
-  @deprecated("TimeSpan to Long conversion will be removed for possibility of of ambiguous behaviours", "3.0.0")
+  @deprecated("TimeSpan to Long conversion will be removed for possibility of ambiguous behaviours", "3.0.0")
   def millis: Long
 }
 
@@ -451,6 +451,6 @@ object ConvertableToDate {
   implicit def toDate(in: ConvertableToDate): Date = in.toDate
   @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   implicit def toDateTime(in: ConvertableToDate): DateTime = in.toDateTime
-  @deprecated("TimeSpan to Long conversion will be removed for possibility of of ambiguous behaviours", "3.0.0")
+  @deprecated("TimeSpan to Long conversion will be removed for possibility of ambiguous behaviours", "3.0.0")
   implicit def toMillis(in: ConvertableToDate): Long = in.millis
 }

--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -104,7 +104,7 @@ trait TimeHelpers { self: ControlHelpers =>
     def toDateTime = new DateTime(millis)
 
     @deprecated("TimeSpan will not support operations on non-millis periods in future")
-    private[util] def toPeriod: Period = dt match {
+    private[util] def toPeriod: Period = dt match { // package protected because of view bound usage in tsToPeriod
       case Left(duration) => duration.toPeriod
       case Right(period) => period
     }

--- a/core/util/src/test/scala/net/liftweb/util/TimeHelpersSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/TimeHelpersSpec.scala
@@ -91,12 +91,12 @@ object TimeHelpersSpec extends Specification with ScalaCheck with TimeAmountsGen
     "have a later method returning a date relative to now plus the time span" in {
       val expectedTime = new Date().getTime + 3.seconds.millis
 
-      3.seconds.later.getTime must beCloseTo(expectedTime, 1000L)
+      3.seconds.later.getMillis must beCloseTo(expectedTime, 1000L)
     }
     "have an ago method returning a date relative to now minus the time span" in {
       val expectedTime = new Date().getTime - 3.seconds.millis
 
-      3.seconds.ago.getTime must beCloseTo(expectedTime, 1000L)
+      3.seconds.ago.getMillis must beCloseTo(expectedTime, 1000L)
     }
     "have a toString method returning the relevant number of weeks, days, hours, minutes, seconds, millis" in {
       val conversionIsOk = forAll(timeAmounts)((t: TimeAmounts) => { val (timeSpanToString, timeSpanAmounts) = t
@@ -136,8 +136,8 @@ object TimeHelpersSpec extends Specification with ScalaCheck with TimeAmountsGen
     }
 
     "make sure noTime does not change the day" in {
-      dateFormatter.format(0.days.ago.noTime) must_== dateFormatter.format(new Date())
-      dateFormatter.format(3.days.ago.noTime) must_== dateFormatter.format(new Date(millis - (3 * 24 * 60 * 60 * 1000)))
+      dateFormatter.format(0.days.ago.noTime.toDate) must_== dateFormatter.format(new Date())
+      dateFormatter.format(3.days.ago.noTime.toDate) must_== dateFormatter.format(new Date(millis - (3 * 24 * 60 * 60 * 1000)))
     }
 
     "provide a day function returning the day of month corresponding to a given date (relative to UTC)" in {

--- a/core/util/src/test/scala/net/liftweb/util/TimeHelpersSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/TimeHelpersSpec.scala
@@ -236,10 +236,17 @@ object forAllTimeZones extends Around with MatchersImplicits {
     val commonJavaAndJodaTimeZones = (TimeZone.getAvailableIDs.toSet & DateTimeZone.getAvailableIDs.toSet).filter { timeZoneId =>
       TimeZone.getTimeZone(timeZoneId).getOffset(millis) == DateTimeZone.forID(timeZoneId).getOffset(millis)
     }
-    forall(commonJavaAndJodaTimeZones) { timeZoneId =>
-      TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId))
-      DateTimeZone.setDefault(DateTimeZone.forID(timeZoneId))
-      f
+    val tzBefore = TimeZone.getDefault
+    val dtzBefore = DateTimeZone.getDefault
+    try {
+      forall(commonJavaAndJodaTimeZones) { timeZoneId =>
+        TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId))
+        DateTimeZone.setDefault(DateTimeZone.forID(timeZoneId))
+        f
+      }
+    } finally {
+      TimeZone.setDefault(tzBefore)
+      DateTimeZone.setDefault(dtzBefore)
     }
   }
 }

--- a/core/util/src/test/scala/net/liftweb/util/TimeHelpersSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/TimeHelpersSpec.scala
@@ -17,18 +17,18 @@
 package net.liftweb
 package util
 
-import java.util.{Calendar, Date}
+import java.util.{Calendar, Date, TimeZone}
 
-import org.specs2.mutable.Specification
-import org.specs2.ScalaCheck
-import org.specs2.time.NoTimeConversions
+import net.liftweb.common._
+import net.liftweb.util.TimeHelpers._
+import org.joda.time.{DateTimeZone, DateTime}
 import org.scalacheck.Gen._
 import org.scalacheck.Prop._
-
-import common._
-import TimeHelpers._
-
-
+import org.specs2.ScalaCheck
+import org.specs2.execute.AsResult
+import org.specs2.matcher.MatchersImplicits
+import org.specs2.mutable.{Around, Specification}
+import org.specs2.time.NoTimeConversions
 
 /**
  * Systems under specification for TimeHelpers.
@@ -37,68 +37,74 @@ object TimeHelpersSpec extends Specification with ScalaCheck with TimeAmountsGen
   "TimeHelpers Specification".title
 
   "A TimeSpan" can {
-    "be created from a number of milliseconds" in {
+    "be created from a number of milliseconds" in forAllTimeZones {
       TimeSpan(3000) must_== TimeSpan(3 * 1000)
     }
-    "be created from a number of seconds" in {
+    "be created from a number of seconds" in forAllTimeZones {
       3.seconds must_== TimeSpan(3 * 1000)
     }
-    "be created from a number of minutes" in {
+    "be created from a number of minutes" in forAllTimeZones {
       3.minutes must_== TimeSpan(3 * 60 * 1000)
     }
-    "be created from a number of hours" in {
+    "be created from a number of hours" in forAllTimeZones {
       3.hours must_== TimeSpan(3 * 60 * 60 * 1000)
     }
-    "be created from a number of days" in {
+    "be created from a number of days" in forAllTimeZones {
       3.days must_== TimeSpan(3 * 24 * 60 * 60 * 1000)
     }
-    "be created from a number of weeks" in {
+    "be created from a number of weeks" in forAllTimeZones {
       3.weeks must_== TimeSpan(3 * 7 * 24 * 60 * 60 * 1000)
     }
-    "be converted implicitly to a date starting from the epoch time" in {
+    "be created from a number of months" in forAllTimeZones {
+      3.months must_== 3.months
+    }
+    "be created from a number of years" in forAllTimeZones {
+      3.years must_== 3.years
+    }
+    "be converted implicitly to a date starting from the epoch time" in forAllTimeZones {
       3.seconds.after(new Date(0)) must beTrue
     }
-    "be converted to a date starting from the epoch time, using the date method" in {
+    "be converted to a date starting from the epoch time, using the date method" in forAllTimeZones {
       3.seconds.after(new Date(0)) must beTrue
     }
-    "be implicitly converted to a Long" in {
+    "be implicitly converted to a Long" in forAllTimeZones {
       (3.seconds == 3000L) must_== true
     }
-    "be compared to an int" in {
+    "be compared to an int" in forAllTimeZones {
       (3.seconds == 3000) must_== true
       (3.seconds != 2000) must_== true
     }
-    "be compared to a long" in {
+    "be compared to a long" in forAllTimeZones {
       (3.seconds == 3000L) must_== true
       (3.seconds != 2000L) must_== true
     }
-    "be compared to another TimeSpan" in {
+    "be compared to another TimeSpan" in forAllTimeZones {
       3.seconds must_== 3.seconds
       3.seconds must_!= 2.seconds
     }
-    "be compared to another object" in {
+    "be compared to another object" in forAllTimeZones {
       3.seconds must_!= "string"
     }
   }
 
   "A TimeSpan" should {
-    "return a new TimeSpan representing the sum of the 2 times when added with another TimeSpan" in {
+    "return a new TimeSpan representing the sum of the 2 times when added with another TimeSpan" in forAllTimeZones {
       3.seconds + 3.seconds must_== 6.seconds
     }
-    "return a new TimeSpan representing the difference of the 2 times when substracted with another TimeSpan" in {
+    "return a new TimeSpan representing the difference of the 2 times when substracted with another TimeSpan" in forAllTimeZones {
       3.seconds - 4.seconds must_== (-1).seconds
     }
-    "have a later method returning a date relative to now plus the time span" in {
+    "have a later method returning a date relative to now plus the time span" in forAllTimeZones {
       val expectedTime = new Date().getTime + 3.seconds.millis
 
       3.seconds.later.getMillis must beCloseTo(expectedTime, 1000L)
     }
-    "have an ago method returning a date relative to now minus the time span" in {
+    "have an ago method returning a date relative to now minus the time span" in forAllTimeZones {
       val expectedTime = new Date().getTime - 3.seconds.millis
 
       3.seconds.ago.getMillis must beCloseTo(expectedTime, 1000L)
     }
-    "have a toString method returning the relevant number of weeks, days, hours, minutes, seconds, millis" in {
+    "have a toString method returning the relevant number of weeks, days, hours, minutes, seconds, millis" in forAllTimeZones {
       val conversionIsOk = forAll(timeAmounts)((t: TimeAmounts) => { val (timeSpanToString, timeSpanAmounts) = t
         timeSpanAmounts forall { case (amount, unit) =>
           amount >= 1  &&
@@ -116,66 +122,66 @@ object TimeHelpersSpec extends Specification with ScalaCheck with TimeAmountsGen
   }
 
   "the TimeHelpers" should {
-    "provide a 'seconds' function transforming a number of seconds into millis" in {
+    "provide a 'seconds' function transforming a number of seconds into millis" in forAllTimeZones {
       seconds(3) must_== 3 * 1000
     }
-    "provide a 'minutes' function transforming a number of minutes into millis" in {
+    "provide a 'minutes' function transforming a number of minutes into millis" in forAllTimeZones {
       minutes(3) must_== 3 * 60 * 1000
     }
-    "provide a 'hours' function transforming a number of hours into milliss" in {
+    "provide a 'hours' function transforming a number of hours into milliss" in forAllTimeZones {
       hours(3) must_== 3 * 60 * 60 * 1000
     }
-    "provide a 'days' function transforming a number of days into millis" in {
+    "provide a 'days' function transforming a number of days into millis" in forAllTimeZones {
       days(3) must_== 3 * 24 * 60 * 60 * 1000
     }
-    "provide a 'weeks' function transforming a number of weeks into millis" in {
+    "provide a 'weeks' function transforming a number of weeks into millis" in forAllTimeZones {
       weeks(3) must_== 3 * 7 * 24 * 60 * 60 * 1000
     }
-    "provide a noTime function on Date objects to transform a date into a date at the same day but at 00:00" in {
+    "provide a noTime function on Date objects to transform a date into a date at the same day but at 00:00" in forAllTimeZones {
       hourFormat(now.noTime) must_== "00:00:00"
     }
 
-    "make sure noTime does not change the day" in {
-      dateFormatter.format(0.days.ago.noTime.toDate) must_== dateFormatter.format(new Date())
+    "make sure noTime does not change the day" in forAllTimeZones {
+      dateFormatter.format(0.days.ago.noTime.toDate) must_== dateFormatter.format(new DateTime().toDate)
       dateFormatter.format(3.days.ago.noTime.toDate) must_== dateFormatter.format(new Date(millis - (3 * 24 * 60 * 60 * 1000)))
     }
 
-    "provide a day function returning the day of month corresponding to a given date (relative to UTC)" in {
+    "provide a day function returning the day of month corresponding to a given date (relative to UTC)" in forAllTimeZones {
       day(today.setTimezone(utc).setDay(3).getTime) must_== 3
     }
-    "provide a month function returning the month corresponding to a given date" in {
+    "provide a month function returning the month corresponding to a given date" in forAllTimeZones {
       month(today.setTimezone(utc).setMonth(4).getTime) must_== 4
     }
-    "provide a year function returning the year corresponding to a given date" in {
+    "provide a year function returning the year corresponding to a given date" in forAllTimeZones {
       year(today.setTimezone(utc).setYear(2008).getTime) must_== 2008
     }
-    "provide a millisToDays function returning the number of days since the epoch time" in {
+    "provide a millisToDays function returning the number of days since the epoch time" in forAllTimeZones {
       millisToDays(new Date(0).getTime) must_== 0
       millisToDays(today.setYear(1970).setMonth(0).setDay(1).getTime.getTime) must_== 0 // the epoch time
       // on the 3rd day after the epoch time, 2 days are passed
       millisToDays(today.setTimezone(utc).setYear(1970).setMonth(0).setDay(3).getTime.getTime) must_== 2
     }
-    "provide a daysSinceEpoch function returning the number of days since the epoch time" in {
+    "provide a daysSinceEpoch function returning the number of days since the epoch time" in forAllTimeZones {
       daysSinceEpoch must_== millisToDays(now.getTime)
     }
-    "provide a time function creating a new Date object from a number of millis" in {
+    "provide a time function creating a new Date object from a number of millis" in forAllTimeZones {
       time(1000) must_== new Date(1000)
     }
-    "provide a calcTime function returning the time taken to evaluate a block in millis and the block's result" in {
+    "provide a calcTime function returning the time taken to evaluate a block in millis and the block's result" in forAllTimeZones {
       val (time, result) = calcTime((1 to 10).reduceLeft[Int](_ + _))
       time.toInt must beCloseTo(0, 1000)  // it should take less than 1 second!
       result must_== 55
     }
 
-    "provide a hourFormat function to format the time of a date object" in {
+    "provide a hourFormat function to format the time of a date object" in forAllTimeZones {
       hourFormat(Calendar.getInstance(utc).noTime.getTime) must_== "00:00:00"
     }
 
-    "provide a formattedDateNow function to format todays date" in {
+    "provide a formattedDateNow function to format todays date" in forAllTimeZones {
       formattedDateNow must beMatching("\\d\\d\\d\\d/\\d\\d/\\d\\d")
     }
-    "provide a formattedTimeNow function to format now's time with the TimeZone" in {
-      val regex = "\\d\\d:\\d\\d (....?|GMT((\\+|\\-)\\d\\d:00)?)"
+    "provide a formattedTimeNow function to format now's time with the TimeZone" in forAllTimeZones {
+      val regex = "\\d\\d:\\d\\d (....?.?|GMT((\\+|\\-)\\d\\d:\\d\\d)?)"
       "10:00 CEST" must beMatching(regex)
       "10:00 GMT+02:00" must beMatching(regex)
       "10:00 GMT" must beMatching(regex)
@@ -183,16 +189,16 @@ object TimeHelpersSpec extends Specification with ScalaCheck with TimeAmountsGen
       formattedTimeNow must beMatching(regex)
     }
 
-    "provide a parseInternetDate function to parse a string formatted using the internet format" in {
+    "provide a parseInternetDate function to parse a string formatted using the internet format" in forAllTimeZones {
       parseInternetDate(internetDateFormatter.format(now)).getTime.toLong must beCloseTo(now.getTime.toLong, 1000L)
     }
-    "provide a parseInternetDate function returning new Date(0) if the input date cant be parsed" in {
+    "provide a parseInternetDate function returning new Date(0) if the input date cant be parsed" in forAllTimeZones {
       parseInternetDate("unparsable") must_== new Date(0)
     }
-    "provide a toInternetDate function formatting a date to the internet format" in {
+    "provide a toInternetDate function formatting a date to the internet format" in forAllTimeZones {
       toInternetDate(now) must beMatching("..., \\d* ... \\d\\d\\d\\d \\d\\d:\\d\\d:\\d\\d .*")
     }
-    "provide a toDate returning a Full(date) from many kinds of objects" in {
+    "provide a toDate returning a Full(date) from many kinds of objects" in forAllTimeZones {
       val d = now
       List(null, Nil, None, Failure("", Empty, Empty)) forall { toDate(_) must_== Empty }
       List(Full(d), Some(d), List(d)) forall { toDate(_) must_== Full(d) }
@@ -205,20 +211,35 @@ object TimeHelpersSpec extends Specification with ScalaCheck with TimeAmountsGen
   }
 
   "The Calendar class" should {
-    "have a setDay method setting the day of month and returning the updated Calendar" in {
+    "have a setDay method setting the day of month and returning the updated Calendar" in forAllTimeZones {
       day(today.setTimezone(utc).setDay(1).getTime) must_== 1
     }
-    "have a setMonth method setting the month and returning the updated Calendar" in {
+    "have a setMonth method setting the month and returning the updated Calendar" in forAllTimeZones {
       month(today.setTimezone(utc).setMonth(0).getTime) must_== 0
     }
-    "have a setYear method setting the year and returning the updated Calendar" in {
+    "have a setYear method setting the year and returning the updated Calendar" in forAllTimeZones {
       year(today.setTimezone(utc).setYear(2008).getTime) must_== 2008
     }
-    "have a setTimezone method to setting the time zone and returning the updated Calendar" in {
+    "have a setTimezone method to setting the time zone and returning the updated Calendar" in forAllTimeZones {
       today.setTimezone(utc).getTimeZone must_== utc
     }
-    "have a noTime method to setting the time to 00:00:00 and returning the updated Calendar" in {
+    "have a noTime method to setting the time to 00:00:00 and returning the updated Calendar" in forAllTimeZones {
       hourFormat(today.noTime.getTime) must_== "00:00:00"
+    }
+  }
+}
+
+object forAllTimeZones extends Around with MatchersImplicits {
+  override def around[T: AsResult](f: => T) = synchronized { // setDefault is on static context so tests should be sequenced
+    import collection.convert.wrapAsScala._
+    // some timezones for java (used in formatters) and for Joda (other computations) has other offset
+    val commonJavaAndJodaTimeZones = (TimeZone.getAvailableIDs.toSet & DateTimeZone.getAvailableIDs.toSet).filter { timeZoneId =>
+      TimeZone.getTimeZone(timeZoneId).getOffset(millis) == DateTimeZone.forID(timeZoneId).getOffset(millis)
+    }
+    forall(commonJavaAndJodaTimeZones) { timeZoneId =>
+      TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId))
+      DateTimeZone.setDefault(DateTimeZone.forID(timeZoneId))
+      f
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
   lazy val commons_fileupload     = "commons-fileupload"         % "commons-fileupload" % "1.2.2"
   lazy val commons_httpclient     = "commons-httpclient"         % "commons-httpclient" % "3.1"
   lazy val javamail               = "javax.mail"                 % "mail"               % "1.4.4"
-  lazy val joda_time              = "joda-time"                  % "joda-time"          % "2.1"
+  lazy val joda_time              = "joda-time"                  % "joda-time"          % "2.6"
   lazy val joda_convert           = "org.joda"                   % "joda-convert"       % "1.2"
   lazy val htmlparser             = "nu.validator.htmlparser"    % "htmlparser"         % "1.4"
   lazy val mongo_java_driver      = "org.mongodb"                % "mongo-java-driver"  % "2.12.2"


### PR DESCRIPTION
Mailing list discussion: https://groups.google.com/forum/#!topic/liftweb/CgZFVwMEiqU

Before the change TimeSpan has many responsibilities - in equality behave as a joda Period (was checking duration field equality), can represent a Date (using toDate/toDateTime operations) or be used as a simple container for milliseconds. Now is responsible only for operations on milliseconds. Problematic methods have been deprecated (.ago/.later have been moved to implicit PeriodExtension). For backward compatibility there is introduced implicit conversion from Period to TimeSpan.

Period inside TimeSpan is holded now only for puropose of to-period conversion (for months/years builder). There has been used view bounds for purpose of nested conversions usage:
1.second.before
1 -> TimeSpan -> Period

This is WIP branch. Please send me feedback if my english has failed in deprecation descriptions :-)