### PR TITLE
TimeSpan Deprecation

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -526,22 +526,14 @@ trait TimeHelpers { self: ControlHelpers =>
 
 }
 
-@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
 trait ConvertableToDate {
-  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   def toDate: Date
-  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   def toDateTime: DateTime
-  @deprecated("TimeSpan to Long conversion will be removed for possibility of ambiguous behaviours", "3.0.0")
   def millis: Long
 }
 
-@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
 object ConvertableToDate {
-  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   implicit def toDate(in: ConvertableToDate): Date = in.toDate
-  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   implicit def toDateTime(in: ConvertableToDate): DateTime = in.toDateTime
-  @deprecated("TimeSpan to Long conversion will be removed for possibility of ambiguous behaviours", "3.0.0")
   implicit def toMillis(in: ConvertableToDate): Long = in.millis
 }

--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -22,7 +22,7 @@ import java.util.{TimeZone, Calendar, Date, Locale}
 
 import scala.language.implicitConversions
 
-import org.joda.time.{DateTime, Duration, Period, PeriodType}
+import org.joda.time._
 
 import common._
 
@@ -32,15 +32,12 @@ import common._
 object TimeHelpers extends TimeHelpers with ControlHelpers with ClassHelpers
 
 /**
- * The TimeHelpers trait provide functions to create TimeSpans (an object representing an amount of time), to manage date formats
- * or general utility functions (get the date for today, get year/month/day number,...)
+ * The TimeHelpers trait provide functions to create TimeSpans (an object representing duration in milliseconds),
+ * to manage date formats or general utility functions (get the date for today, get year/month/day number,...)
  */
 trait TimeHelpers { self: ControlHelpers =>
   // Logger must be lazy, since we cannot instantiate until after boot is complete
   private  lazy val logger = Logger(classOf[TimeHelpers])
-
-  /** private variable allowing the access to all TimeHelpers functions from inside the TimeSpan class */
-  private val outer = this
 
   /** transforms a long to a TimeSpanBuilder object. Usage: 3L.seconds returns a TimeSpan of 3000L millis  */
   implicit def longToTimeSpanBuilder(in: Long): TimeSpanBuilder = TimeSpanBuilder(in)
@@ -54,96 +51,86 @@ trait TimeHelpers { self: ControlHelpers =>
   /** transforms an int to a TimeSpan object. Usage: 3000 returns a TimeSpan of 3000L millis  */
   implicit def intToTimeSpan(in: Int): TimeSpan = TimeSpan(in)
 
-  private implicit def durToPeriod(dur: Duration): Period = dur.toPeriod(PeriodType.standard())
-
   /** class building TimeSpans given an amount (len) and a method specify the time unit  */
   case class TimeSpanBuilder(val len: Long) {
-    def seconds = new TimeSpan(Right((new Period).plusSeconds(len.toInt)))
+    def seconds = new TimeSpan(Left(Duration.standardSeconds(len)))
     def second = seconds
-    def minutes = new TimeSpan(Right((new Period).plusMinutes(len.toInt)))
+    def minutes = new TimeSpan(Left(Duration.standardMinutes(len)))
     def minute = minutes
-    def hours = new TimeSpan(Right(Duration.standardHours(len): Period))
+    def hours = new TimeSpan(Left(Duration.standardHours(len)))
     def hour = hours
-    def days = new TimeSpan(Right(Duration.standardDays(len): Period))
+    def days = new TimeSpan(Left(Duration.standardDays(len)))
     def day = days
-    def weeks = new TimeSpan(Right(Duration.standardDays(len * 7L): Period))
+    def weeks = new TimeSpan(Left(Duration.standardDays(len * 7L)))
     def week = weeks
-    def months = new TimeSpan(Right((new Period().plusMonths(len.toInt))))
+    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    def months = new TimeSpan(Right(new Period().plusMonths(len.toInt)))
+    @deprecated("TimeSpan will not support operations on non-millis periods in future")
     def month = months
-    def years = new TimeSpan(Right((new Period().plusYears(len.toInt))))
+    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    def years = new TimeSpan(Right(new Period().plusYears(len.toInt)))
+    @deprecated("TimeSpan will not support operations on non-millis periods in future")
     def year = years
   }
 
-  /*
   /**
-   * transforms a TimeSpan to a date by converting the TimeSpan expressed as millis and creating
-   * a Date lasting that number of millis from the Epoch time (see the documentation for java.util.Date)
+   * The TimeSpan class represents Duration of time in milliseconds.
+   *
+   * For deprecated years and month builders it handle an operations on duration field values. Then it could be
+   * used only in to-period implicit conversion.
    */
-  implicit def timeSpanToDate(in: TimeSpan): Date = in.date
+  class TimeSpan(private val dt: Either[Duration, Period]) extends ConvertableToDate {
 
-  /** transforms a TimeSpan to its long value as millis */
-  implicit def timeSpanToLong(in: TimeSpan): Long = in.millis
-  */
-
-  /**
-   * The TimeSpan class represents an amount of time.
-   * It can be translated to a date with the date method. In that case, the number of millis seconds will be used to create a Date
-   * object starting from the Epoch time (see the documentation for java.util.Date)
-   */
-  class TimeSpan(private val dt: Either[DateTime, Period]) extends ConvertableToDate {
-    /** @return a Date as the amount of time represented by the TimeSpan after the Epoch date */
 
     def this(ms: Long) =
-      this(if (ms < 52L * 7L * 24L * 60L * 60L * 1000L) Right(new Period(ms))
-           else Left(new DateTime(ms)))
-
-    def date: Date = dt match {
-      case Left(datetime) => new Date(datetime.getMillis())
-      case _ => new Date(millis)
-    }
+      this(Left(new Duration(ms)))
 
     /**
-     * Convert to a Date
+     * Convert to a Date. The number of millis seconds will be used to create a Date object starting from the Epoch time.
      */
+    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
+    def date: Date = new Date(millis)
+
+    /**
+     * Convert to a Date. The number of millis seconds will be used to create a Date object starting from the Epoch time.
+     */
+    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
     def toDate: Date = date
 
     /**
-     * Convert to a JodaTime DateTime
+     * Convert to a JodaTime DateTime. The number of millis seconds will be used to create a Date object starting from the Epoch time.
      */
-    def toDateTime = dt match {
-      case Left(datetime) => datetime
-      case _ => new DateTime(millis)
+    @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+    def toDateTime = new DateTime(millis)
+
+    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    private[util] def toPeriod: Period = dt match { // package protected because of view bound usage in tsToPeriod
+      case Left(duration) => duration.toPeriod
+      case Right(period) => period
     }
 
+    /**
+     * @return amount of milliseconds in duration
+     * @throws UnsupportedOperationException if was created by deprecated months/years builder
+     */
     def toMillis = millis
 
+    /**
+     * @return amount of milliseconds in duration
+     * @throws UnsupportedOperationException if was created by deprecated months/years builder
+     */
     def millis = dt match {
-      case Left(datetime) => datetime.getMillis()
-      case Right(duration) => duration.toStandardDuration.getMillis()
+      case Left(duration) => duration.getMillis
+      case Right(period) => period.toStandardDuration.getMillis // will throw exception because it holds month or year
     }
-
-
-    /** @return a Date as the amount of time represented by the TimeSpan after now */
-    def later: TimeSpan = dt match {
-      case Right(duration) => new TimeSpan(Left(new DateTime(outer.millis).plus(duration)))
-      case _ => TimeSpan(millis + outer.millis)
-    }
-
-    /** @return a Date as the amount of time represented by the TimeSpan before now */
-    def ago: TimeSpan = dt match {
-      case Right(duration) => new TimeSpan(Left(new DateTime(outer.millis).minus(duration)))
-      case _ => TimeSpan(outer.millis - millis)
-    }
-
-    def noTime: Date = new DateExtension(this).noTime
 
     /** @return a TimeSpan representing the addition of 2 TimeSpans */
     def +[B](in: B)(implicit f: B => TimeSpan): TimeSpan =
       (this.dt, f(in).dt) match {
-        case (Right(p1), Right(p2)) => p1.plus(p2)
-        case (Left(date), Right(duration)) => date.plus(duration)
-        case (Right(duration), Left(date)) => date.plus(duration)
-        case _ => TimeSpan(this.millis + f(in).millis)
+        case (Right(p1), Right(p2)) => new TimeSpan(Right(p1.plus(p2)))
+        case (Left(duration), Right(period)) => new TimeSpan(Left(duration.plus(period.toStandardDuration)))
+        case (Right(period), Left(duration)) => new TimeSpan(Left(period.toStandardDuration.plus(duration)))
+        case (Left(d1), Left(d2)) => new TimeSpan(Left(d1.plus(d2)))
       }
 
     /** @return a TimeSpan representing the addition of 2 TimeSpans */
@@ -152,10 +139,10 @@ trait TimeHelpers { self: ControlHelpers =>
     /** @return a TimeSpan representing the substraction of 2 TimeSpans */
     def -[B](in: B)(implicit f: B => TimeSpan): TimeSpan =
       (this.dt, f(in).dt) match {
-        case (Right(p1), Right(p2)) => p1.minus(p2)
-        case (Left(date), Right(duration)) => date.minus(duration)
-        case (Right(duration), Left(date)) => date.minus(duration)
-        case _ => TimeSpan(this.millis - f(in).millis)
+        case (Right(p1), Right(p2)) => new TimeSpan(Right(p1.minus(p2)))
+        case (Left(duration), Right(period)) => new TimeSpan(Left(duration.minus(period.toStandardDuration)))
+        case (Right(period), Left(duration)) => new TimeSpan(Left(period.toStandardDuration.minus(duration)))
+        case (Left(d1), Left(d2)) => new TimeSpan(Left(d1.minus(d2)))
       }
 
     /** override the equals method so that TimeSpans can be compared to long, int and TimeSpan */
@@ -164,19 +151,14 @@ trait TimeHelpers { self: ControlHelpers =>
         case lo: Long => lo == this.millis
         case i: Int => i == this.millis
         case ti: TimeSpan => ti.dt == this.dt
-        case d: Date => d.getTime() == this.millis
-        case dt: DateTime => Left(dt) == this.dt
-        case dur: Duration => Right(dur: Period) == this.dt
-        case dur: Period => Right(dur) == this.dt
+        case dur: Duration => Left(dur) == this.dt
+        case period: Period => Right(period) == this.dt
         case _ => false
       }
     }
 
     /** override the toString method to display a readable amount of time */
-    override def toString = dt match {
-      case Left(date) => date.toString
-      case Right(dur) => TimeSpan.format(millis)
-    }
+    override def toString = TimeSpan.format(millis)
   }
 
   /**
@@ -208,26 +190,36 @@ trait TimeHelpers { self: ControlHelpers =>
     /**
      * Convert a Date to a TimeSpan
      */
+    @deprecated("Date to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations")
     implicit def dateToTS(in: Date): TimeSpan =
-      new TimeSpan(Left(new DateTime(in.getTime)))
+      new TimeSpan(Left(new Duration(in.getTime)))
 
-    /**
-     * Convert a DateTime to a TimeSpan
-     */
-    implicit def dateTimeToTS(in: DateTime): TimeSpan =
-      new TimeSpan(Left(in))
 
     /**
      * Convert a Duration to a TimeSpan
      */
     implicit def durationToTS(in: Duration): TimeSpan =
-      new TimeSpan(Right(in: Period))
+      new TimeSpan(Left(in))
 
     /**
      * Convert a Period to a TimeSpan
      */
+    @deprecated("Period to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations")
     implicit def periodToTS(in: Period): TimeSpan =
       new TimeSpan(Right(in))
+
+    /**
+     * Convert a TimeSpan to a Period
+     */
+    @deprecated("TimeSpan to Period conversion will be removed for possibility of mistakes in on-duration operations")
+    implicit def tsToPeriod[TS <% TimeSpan](in: TS): Period = in.toPeriod
+
+    /**
+     * Convert a DateTime to a TimeSpan
+     */
+    @deprecated("DateTime to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations")
+    implicit def dateTimeToTS(in: DateTime): TimeSpan =
+      new TimeSpan(Left(new Duration(in.getMillis)))
   }
 
   /** @return the current System.nanoTime() */
@@ -266,6 +258,11 @@ trait TimeHelpers { self: ControlHelpers =>
       calendar.set(Calendar.MILLISECOND, 0)
       calendar.getTime
     }
+  }
+
+
+  implicit class DateTimeExtension(dateTime: DateTime) {
+    def noTime = dateTime.withTimeAtStartOfDay()
   }
 
   /** implicit def used to add the setXXX methods to the Calendar class */
@@ -427,18 +424,29 @@ trait TimeHelpers { self: ControlHelpers =>
       case e: Exception => logger.debug("Error parsing date "+in, e); Failure("Bad date: "+in, Full(e), Empty)
     }
   }
+
+  implicit class PeriodExtension[P <% Period](period: P) {
+    def later: DateTime = new DateTime(millis).plus(period)
+
+    def ago: DateTime = new DateTime(millis).minus(period)
+  }
+
 }
 
+@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations")
 trait ConvertableToDate {
+  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
   def toDate: Date
+  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations")
   def toDateTime: DateTime
   def millis: Long
 }
 
+@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations")
 object ConvertableToDate {
+  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
   implicit def toDate(in: ConvertableToDate): Date = in.toDate
+  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations")
   implicit def toDateTime(in: ConvertableToDate): DateTime = in.toDateTime
   implicit def toMillis(in: ConvertableToDate): Long = in.millis
-
 }
-

--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -46,9 +46,11 @@ trait TimeHelpers { self: ControlHelpers =>
   implicit def intToTimeSpanBuilder(in: Int): TimeSpanBuilder = TimeSpanBuilder(in)
 
   /** transforms a long to a TimeSpan object. Usage: 3000L returns a TimeSpan of 3000L millis  */
+  @deprecated("Long to TimeSpan conversion will be removed for possibility of ambiguous behaviours", "3.0.0")
   implicit def longToTimeSpan(in: Long): TimeSpan = TimeSpan(in)
 
   /** transforms an int to a TimeSpan object. Usage: 3000 returns a TimeSpan of 3000L millis  */
+  @deprecated("Int to TimeSpan conversion will be removed for possibility of ambiguous behaviours", "3.0.0")
   implicit def intToTimeSpan(in: Int): TimeSpan = TimeSpan(in)
 
   /** class building TimeSpans given an amount (len) and a method specify the time unit  */
@@ -63,13 +65,13 @@ trait TimeHelpers { self: ControlHelpers =>
     def day = days
     def weeks = new TimeSpan(Left(Duration.standardDays(len * 7L)))
     def week = weeks
-    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
     def months = new TimeSpan(Right(new Period().plusMonths(len.toInt)))
-    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
     def month = months
-    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
     def years = new TimeSpan(Right(new Period().plusYears(len.toInt)))
-    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
     def year = years
   }
 
@@ -88,22 +90,22 @@ trait TimeHelpers { self: ControlHelpers =>
     /**
      * Convert to a Date. The number of millis seconds will be used to create a Date object starting from the Epoch time.
      */
-    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     def date: Date = new Date(millis)
 
     /**
      * Convert to a Date. The number of millis seconds will be used to create a Date object starting from the Epoch time.
      */
-    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     def toDate: Date = date
 
     /**
      * Convert to a JodaTime DateTime. The number of millis seconds will be used to create a Date object starting from the Epoch time.
      */
-    @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     def toDateTime = new DateTime(millis)
 
-    @deprecated("TimeSpan will not support operations on non-millis periods in future")
+    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
     private[util] def toPeriod: Period = dt match { // package protected because of view bound usage in tsToPeriod
       case Left(duration) => duration.toPeriod
       case Right(period) => period
@@ -190,7 +192,7 @@ trait TimeHelpers { self: ControlHelpers =>
     /**
      * Convert a Date to a TimeSpan
      */
-    @deprecated("Date to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("Date to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     implicit def dateToTS(in: Date): TimeSpan =
       new TimeSpan(Left(new Duration(in.getTime)))
 
@@ -204,20 +206,20 @@ trait TimeHelpers { self: ControlHelpers =>
     /**
      * Convert a Period to a TimeSpan
      */
-    @deprecated("Period to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("Period to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     implicit def periodToTS(in: Period): TimeSpan =
       new TimeSpan(Right(in))
 
     /**
      * Convert a TimeSpan to a Period
      */
-    @deprecated("TimeSpan to Period conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("TimeSpan to Period conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     implicit def tsToPeriod[TS <% TimeSpan](in: TS): Period = in.toPeriod
 
     /**
      * Convert a DateTime to a TimeSpan
      */
-    @deprecated("DateTime to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations")
+    @deprecated("DateTime to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
     implicit def dateTimeToTS(in: DateTime): TimeSpan =
       new TimeSpan(Left(new Duration(in.getMillis)))
   }
@@ -433,20 +435,22 @@ trait TimeHelpers { self: ControlHelpers =>
 
 }
 
-@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
 trait ConvertableToDate {
-  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
+  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   def toDate: Date
-  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   def toDateTime: DateTime
+  @deprecated("TimeSpan to Long conversion will be removed for possibility of ambiguous behaviours", "3.0.0")
   def millis: Long
 }
 
-@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+@deprecated("TimeSpan to Date/DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
 object ConvertableToDate {
-  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations")
+  @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   implicit def toDate(in: ConvertableToDate): Date = in.toDate
-  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations")
+  @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
   implicit def toDateTime(in: ConvertableToDate): DateTime = in.toDateTime
+  @deprecated("TimeSpan to Long conversion will be removed for possibility of ambiguous behaviours", "3.0.0")
   implicit def toMillis(in: ConvertableToDate): Long = in.millis
 }

--- a/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/TimeHelpers.scala
@@ -65,13 +65,13 @@ trait TimeHelpers { self: ControlHelpers =>
     def day = days
     def weeks = new TimeSpan(Left(Duration.standardDays(len * 7L)))
     def week = weeks
-    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
+    @deprecated("This builder will be removed due to its unclear behavior; use Joda-Time `Period.months` and convert to `TimeSpan` manually instead.", "3.0.0")
     def months = new TimeSpan(Right(new Period().plusMonths(len.toInt)))
-    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
+    @deprecated("This builder will be removed due to its unclear behavior; use Joda-Time `Period.months` and convert to `TimeSpan` manually instead.", "3.0.0")
     def month = months
-    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
+    @deprecated("This builder will be removed due to its unclear behavior; use Joda-Time `Period.years` and convert to `TimeSpan` manually instead.", "3.0.0")
     def years = new TimeSpan(Right(new Period().plusYears(len.toInt)))
-    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
+    @deprecated("This builder will be removed due to its unclear behavior; use Joda-Time `Period.years` and convert to `TimeSpan` manually instead.", "3.0.0")
     def year = years
   }
 
@@ -109,23 +109,23 @@ trait TimeHelpers { self: ControlHelpers =>
      * Convert to a Java `Date`. The number of milliseconds in the `Duration`
      * will be added to the UNIX epoch to create a `Date` object.
      */
-    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
+    @deprecated("This method will be removed due to its unclear behavior; use new Date(timeSpan.millis) instead.", "3.0.0")
     def date: Date = new Date(millis)
 
     /**
      * Convert to a Java `Date`. Synonym of `[[date]]`.
      */
-    @deprecated("TimeSpan to Date conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
+    @deprecated("This method will be removed due to its unclear behavior; use new Date(timeSpan.millis) instead.", "3.0.0")
     def toDate: Date = date
 
     /**
      * Convert to a Joda-Time `DateTime`. The number of milliseconds in the `Duration`
      * will be added to the UNIX epoch to create a `DateTime` object.
      */
-    @deprecated("TimeSpan to DateTime conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
+    @deprecated("This method will be removed due to its unclear behavior; use new DateTime(timeSpan.millis) instead.", "3.0.0")
     def toDateTime = new DateTime(millis)
 
-    @deprecated("TimeSpan will not support operations on non-millis periods in future", "3.0.0")
+    @deprecated("TimeSpan will not support operations on Joda-Time `Period`s in the future; use new Period(timeSpan.millis) instead.", "3.0.0")
     private[util] def toPeriod: Period = dt match { // package protected because of view bound usage in tsToPeriod
       case Left(duration) => duration.toPeriod
       case Right(period) => period
@@ -297,20 +297,20 @@ trait TimeHelpers { self: ControlHelpers =>
     /**
      * Convert a Period to a TimeSpan
      */
-    @deprecated("Period to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
+    @deprecated("Implicit conversion from Period to TimeSpan will be removed due to its unclear behavior; use new Period(timeSpan.millis) instead.", "3.0.0")
     implicit def periodToTS(in: Period): TimeSpan =
       new TimeSpan(Right(in))
 
     /**
      * Convert a TimeSpan to a Period
      */
-    @deprecated("TimeSpan to Period conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
+    @deprecated("Implicit conversion from TimeSpan to Period will be removed due to its unclear behavior; use new TimeSpan(period.toDurationFrom(startDateTime)) instead.", "3.0.0")
     implicit def tsToPeriod[TS <% TimeSpan](in: TS): Period = in.toPeriod
 
     /**
      * Convert a DateTime to a TimeSpan
      */
-    @deprecated("DateTime to TimeSpan conversion will be removed for possibility of mistakes in on-duration operations", "3.0.0")
+    @deprecated("Implicit conversion from DateTime to TimeSpan will be removed due to its unclear behavior; use new TimeSpan(dateTime.getMillis) instead.", "3.0.0")
     implicit def dateTimeToTS(in: DateTime): TimeSpan =
       new TimeSpan(Left(new Duration(in.getMillis)))
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
   lazy val commons_fileupload     = "commons-fileupload"         % "commons-fileupload" % "1.2.2"
   lazy val commons_httpclient     = "commons-httpclient"         % "commons-httpclient" % "3.1"
   lazy val javamail               = "javax.mail"                 % "mail"               % "1.4.4"
-  lazy val joda_time              = "joda-time"                  % "joda-time"          % "2.1"
+  lazy val joda_time              = "joda-time"                  % "joda-time"          % "2.6"
   lazy val joda_convert           = "org.joda"                   % "joda-convert"       % "1.2"
   lazy val htmlparser             = "nu.validator.htmlparser"    % "htmlparser"         % "1.4"
   lazy val mongo_java_driver      = "org.mongodb"                % "mongo-java-driver"  % "2.12.2"


### PR DESCRIPTION
Final version of #1668 .

Dropped deprecation on `ConvertableToDate` pending further discussion.

The current state is also a bit ~ because `5.days.ago` still throws a deprecation
warning… Need to discuss that a bit further.

Final version for M3 though.

Closes #1668.