### PR TITLE
Beautiful and Unique Snowflake: Try to ensure uniqueness of comet requests

### DIFF
--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -293,7 +293,9 @@
     ///// Comet ////////////////////////////////////
     ////////////////////////////////////////////////
 
-    var currentCometRequest = null;
+    var currentCometRequest = null,
+        // Used to ensure that we can only fire one comet request at a time.
+        cometRequestCount = 0;
 
     // http://stackoverflow.com/questions/4994201/is-object-empty
     function is_empty(obj) {
@@ -320,11 +322,13 @@
     }
 
     function cometFailureFunc() {
-      setTimeout(cometEntry, settings.cometFailureRetryTimeout);
+      var requestCount = cometRequestCount;
+      setTimeout(function() { cometEntry(requestCount) }, settings.cometFailureRetryTimeout);
     }
 
     function cometSuccessFunc() {
-      setTimeout(cometEntry, 100);
+      var requestCount = cometRequestCount;
+      setTimeout(function() { cometEntry(requestCount); }, 100);
     }
 
     function calcCometPath() {
@@ -345,11 +349,12 @@
       cometSuccessFunc();
     }
 
-    function cometEntry() {
+    function cometEntry(requestedCount) {
       var isEmpty = is_empty(toWatch);
 
-      if (!isEmpty) {
+      if (!isEmpty && requestedCount == cometRequestCount) {
         uriSuffix = undefined;
+        cometRequestCount++;
         currentCometRequest =
           settings.ajaxGet(
             calcCometPath(),

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -378,7 +378,7 @@
     // Called to register a comet. Sets the comet with guid `cometGuid`
     // to have the version `cometVersion`. If `startComet` is set to
     // `true`, restarts the comet request cycle.
-    function registerComet(cometGuid, cometVersion, restartComet) {
+    function registerComet(cometGuid, cometVersion, startComet) {
       toWatch[cometGuid] = cometVersion;
 
       if (startComet) {

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -352,7 +352,7 @@
     function cometEntry(requestedCount) {
       var isEmpty = is_empty(toWatch);
 
-      if (!isEmpty && requestedCount == cometRequestCount) {
+      if (!isEmpty && requestedCount === cometRequestCount) {
         uriSuffix = undefined;
         cometRequestCount++;
         currentCometRequest =

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -375,17 +375,6 @@
       toWatch = ret;
     }
 
-    // Called to register a comet. Sets the comet with guid `cometGuid`
-    // to have the version `cometVersion`. If `startComet` is set to
-    // `true`, restarts the comet request cycle.
-    function registerComet(cometGuid, cometVersion, startComet) {
-      toWatch[cometGuid] = cometVersion;
-
-      if (startComet) {
-        restartComet();
-      }
-    }
-
     // Called to register comets in bulk. `cometInfo` should be
     // an object of comet ids associated with comet versions.
     //


### PR DESCRIPTION
> ["You are not a beautiful or unique snowflake. You are the same decaying organic matter as everyone else, and we are all a part of the same compost pile."](http://en.wikiquote.org/wiki/Fight_Club_(novel))

(^ for the positive thought of the day :p)

We already did some work to make sure comet requests were unique;
this adds one more layer of checking around that. When we schedule a
new comet request, we include the current "comet request count". That
count is incremented when the request is actually fired off. This means
that scheduling a new request multiple times before the request is fired
will only result in one request, rather than multiple requests that will walk
all over each other.

Should fix issues from the ML threads at https://groups.google.com/forum/#!topic/liftweb/cREIVSEpDzQ
and https://groups.google.com/forum/#!topic/liftweb/vTUL2RW0SVc,
hopefully.