### PR TITLE
Locket Down: Add support for Content-Security-Policy and Strict-Transport-Security

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+sudo: false
+cache:
+  directories:
+    - '$HOME/.m2/repository'
 services:
   - mongodb
-
 jdk:
   - oraclejdk7
   - openjdk7

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftResponse.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftResponse.scala
@@ -107,13 +107,13 @@ case class ResetContentResponse() extends LiftResponse with HeaderDefaults {
  * the request appears incorrect. Use the `message` to indicate what was wrong
  * with the request, if that does not leak important information.
  */
-case class BadRequest(message: String = "") extends LiftResponse with HeaderDefaults {
+case class BadRequestResponse(message: String = "") extends LiftResponse with HeaderDefaults {
   def toResponse = InMemoryResponse(message.getBytes("UTF-8"), headers, cookies, 400)
 }
 object BadResponse {
-  @deprecated("Use BadRequest instead, as that is the correct name for this response.", "3.0.0")
+  @deprecated("Use BadRequestResponse instead, as that is the correct name for this response.", "3.0.0")
   def apply() = {
-    BadRequest()
+    BadRequestResponse()
   }
 }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftResponse.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftResponse.scala
@@ -104,10 +104,17 @@ case class ResetContentResponse() extends LiftResponse with HeaderDefaults {
  * 400 Bad Request
  *
  * Your Request was missing an important element. Use this as a last resort if
- * the request appears incorrect.
+ * the request appears incorrect. Use the `message` to indicate what was wrong
+ * with the request, if that does not leak important information.
  */
-case class BadResponse() extends LiftResponse with HeaderDefaults {
-  def toResponse = InMemoryResponse(Array(), headers, cookies, 400)
+case class BadRequest(message: String = "") extends LiftResponse with HeaderDefaults {
+  def toResponse = InMemoryResponse(message.getBytes("UTF-8"), headers, cookies, 400)
+}
+object BadResponse {
+  @deprecated("Use BadRequest instead, as that is the correct name for this response.", "3.0.0")
+  def apply() = {
+    BadRequest()
+  }
 }
 
 /**

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1654,7 +1654,6 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    */
   val supplementalHeaders: FactoryMaker[List[(String, String)]] = new FactoryMaker(() => {
     ("X-Lift-Version", liftVersion) ::
-    ("X-Frame-Options", "SAMEORIGIN") ::
     securityRules().headers
   }) {}
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -264,7 +264,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    */
   val beforeSend = RulesSeq[(BasicResponse, HTTPResponse, List[(String, String)], Box[Req]) => Any]
 
-  private lazy val defaultSecurityRules = SecurityRules()
+  private[this] lazy val defaultSecurityRules = SecurityRules()
   /**
    * The security rules used by Lift to secure this application. These mostly
    * relate to HTTPS handling and HTTP `Content-Security-Policy`. See the

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -269,8 +269,12 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * The security rules used by Lift to secure this application. These mostly
    * relate to HTTPS handling and HTTP `Content-Security-Policy`. See the
    * `[[SecurityRules]]` documentation for more.
+   *
+   * Once the application has started using these, they are locked in, so make
+   * sure to set them early in the boot process.
    */
   @volatile var securityRules: () => SecurityRules = () => defaultSecurityRules
+  private[http] lazy val lockedSecurityRules = securityRules()
 
   /**
    * Defines the resources that are protected by authentication and authorization. If this function
@@ -1654,7 +1658,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    */
   val supplementalHeaders: FactoryMaker[List[(String, String)]] = new FactoryMaker(() => {
     ("X-Lift-Version", liftVersion) ::
-    securityRules().headers
+    lockedSecurityRules.headers
   }) {}
 
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
@@ -140,6 +140,17 @@ class LiftServlet extends Loggable {
   def service(req: Req, resp: HTTPResponse): Boolean = {
     try {
       def doIt: Boolean = {
+        if (LiftRules.lockedSecurityRules.logInDevMode &&
+              Props.devMode &&
+              LiftRules.lockedSecurityRules.https.isDefined &&
+              ! req.hostAndPath.startsWith("https")) {
+          logger.warn(s"""
+            |Security rules require HTTPS, but request was for ${req.hostAndPath};
+            |in non-dev mode, this will result in the browser forcing
+            |HTTPS.""".stripMargin
+          )
+        }
+
         if (LiftRules.logServiceRequestTiming) {
           logTime {
             val ret = doService(req, resp)

--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -272,13 +272,13 @@ final case class ContentSecurityPolicy(
     }
   }
 
-  private lazy val reportOnlyHeaders = {
+  private[this] lazy val reportOnlyHeaders = {
     List(
       "Content-Security-Policy-Report-Only" -> contentSecurityPolicyString,
       "X-Content-Security-Policy-Report-Only" -> contentSecurityPolicyString
     )
   }
-  private lazy val enforcedHeaders = {
+  private[this] lazy val enforcedHeaders = {
     List(
       "Content-Security-Policy" -> contentSecurityPolicyString,
       "X-Content-Security-Policy" -> contentSecurityPolicyString
@@ -333,7 +333,7 @@ case class ContentSecurityPolicyViolation(
   originalPolicy: String
 )
 object ContentSecurityPolicyViolation extends LazyLoggable {
-  private implicit val formats = DefaultFormats
+  private[this] implicit val formats = DefaultFormats
 
   def defaultViolationHandler: DispatchPF = {
     case request @ Req(start :: "content-security-policy-report" :: Nil, _, _) if start == LiftRules.liftContextRelativePath =>

--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -413,6 +413,8 @@ object FrameRestrictions {
  * Specifies security rules for a Lift application. By default, HTTPS is not
  * required and `Content-Security-Policy` is restricted to the current domain
  * for everything except images, which are accepted from any domain.
+ * Additionally, served pages can only be embedded in other frames from
+ * the current domain.
  *
  * You can use `[[SecurityRules.secure]]` to enable more restrictive, but
  * also more secure, defaults.
@@ -421,7 +423,7 @@ object FrameRestrictions {
  *        enforced in dev mode in addition to staging/pilot/production/etc.
  * @param logInDevMode If true, dev mode violations of security policies are
  *        logged by default. Note that if you override
- *        [[`LiftRules.contentSecurityPolicyViolationReport`]] or otherwise
+ *        `[[LiftRules.contentSecurityPolicyViolationReport]]` or otherwise
  *        change the default Lift policy violation handling behavior, it will
  *        be up to you to handle this property as desired.
  */

--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -32,8 +32,8 @@ import LiftRules._
 /**
  * Rules for HTTPS usage by a Lift application.
  *
- * Currently corresponds directly to the [[HTTP `Strict-Transport-Security`
- * header http://tools.ietf.org/html/rfc6797]].
+ * Currently corresponds directly to the [[http://tools.ietf.org/html/rfc6797
+ * HTTP `Strict-Transport-Security` header]].
  */
 final case class HttpsRules(
   /**
@@ -111,8 +111,8 @@ object ContentSourceRestriction {
   }
   /**
    * Indicates content from the given host path is allowed. See the
-   * `Content-Security-Policy` spec's [[matching rules for `host-source`
-   * http://www.w3.org/TR/CSP/#matching]] for more about what this can look
+   * `Content-Security-Policy` spec's [[http://www.w3.org/TR/CSP/#matching
+   * matching rules for `host-source`]] for more about what this can look
    * like.
    *
    * Example:
@@ -190,60 +190,47 @@ object ContentSourceRestriction {
  * Note that the `X-Webkit-CSP` header is NOT specified, due to
  * potentially-broken behavior in iOS 5 and 5.1. This means iOS 6/6.1 will not
  * receive a content security policy that it can
- * understand. See the [[caniuse page on content security policy
- * http://caniuse.com/#feat=contentsecuritypolicy]] for more.
+ * understand. See the [[http://caniuse.com/#feat=contentsecuritypolicy caniuse
+ * page on content security policy]] for more.
+ *
+ * @param defaultSources A list of default source restrictions; if one of the
+ *        other sources parameters is empty, the default sources will apply
+ *        instead.
+ * @param connectSources A list of source restrictions for `XmlHttpRequest`
+ *        (AJAX) connections.
+ * @param fontSources A list of source restrictions for loading fonts (e.g.,
+ *        from CSS `font-face` declarations).
+ * @param frameSources A list of source restrictions for loading frames and
+ *        iframes.
+ * @param imageSources A list of source restrictions for loading images.
+ * @param mediaSources A list of source restrictions for loading media (audio
+ *        and video).
+ * @param objectSources A list of source restrictions for loading `object`,
+ *        `embed`, `applet`, and related elements.
+ * @param scriptSources A list of source restrictions for loading scripts. Also
+ *        accepts the `[[ContentSourceRestriction.UnsafeInline UnsafeInline]]`
+ *        and `[[ContentSourceRestriction.UnsafeEval UnsafeEval]]` source
+ *        restrictions, though these are strongly discouraged.
+ * @param styleSources A list of source restrictions for loading styles. Also
+ *        accepts the `[[ContentSourceRestriction.UnsafeInline UnsafeInline]]`
+ *        source, though it is strongly discouraged.
+ * @param reportUri The URI where any violation of the security policy will be
+ *        reported. You can set the function that handles these violations in
+ *        `[[LiftRules.contentSecurityPolicyViolationReport]]`. By default,
+ *        reported to `[[ContentSecurityPolicy.defaultReportUri]]`.
+ *
+ *        If this is `None`, violations will not be reported.
  */
 final case class ContentSecurityPolicy(
-  /**
-   * A list of default source restrictions; if one of the other sources
-   * parameters is empty, the default sources will apply instead.
-   */
   defaultSources: List[ContentSourceRestriction] = List(ContentSourceRestriction.Self),
-  /**
-   * A list of source restrictions for `XmlHttpRequest` (AJAX) connections.
-   */
   connectSources: List[ContentSourceRestriction] = Nil,
-  /**
-   * A list of source restrictions for loading fonts (e.g., from CSS `font-face`
-   * declarations).
-   */
   fontSources: List[ContentSourceRestriction] = Nil,
-  /**
-   * A list of source restrictions for loading frames and iframes.
-   */
   frameSources: List[ContentSourceRestriction] = Nil,
-  /**
-   * A list of source restrictions for loading images.
-   */
   imageSources: List[ContentSourceRestriction] = List(ContentSourceRestriction.All),
-  /**
-   * A list of source restrictions for loading media (audio and video).
-   */
   mediaSources: List[ContentSourceRestriction] = Nil,
-  /**
-   * A list of source restrictions for loading `object`, `embed`, `applet`, and
-   * related elements.
-   */
   objectSources: List[ContentSourceRestriction] = Nil,
-  /**
-   * A list of source restrictions for loading scripts. Also accepts the
-   * `UnsafeInline` and `UnsafeEval` sources, though these are strongly
-   * discouraged.
-   */
   scriptSources: List[JavaScriptSourceRestriction] = Nil,
-  /**
-   * A list of source restrictions for loading styles. Also accepts the
-   * `UnsafeInline` source, though it is strongly discouraged.
-   */
   styleSources: List[StylesheetSourceRestriction] = Nil,
-  /**
-   * The URI where any violation of the security policy will be reported. You
-   * can set the function that handles these violations in
-   * `LiftRules.contentSecurityPolicyViolationReport`. By default, reported to
-   * `[[ContentSecurityPolicy.defaultReportUri]]`.
-   *
-   * If this is `None`, violations will not be reported.
-   */
   reportUri: Option[URI] = Some(ContentSecurityPolicy.defaultReportUri)
 ) {
   /**
@@ -390,7 +377,7 @@ object ContentSecurityPolicyViolation extends LazyLoggable {
  * required and `Content-Security-Policy` is restricted to the current domain
  * for everything except images, which are accepted from any domain.
  *
- * You can use `[[SecurityRules$.secure]]` to enable more restrictive, but
+ * You can use `[[SecurityRules.secure]]` to enable more restrictive, but
  * also more secure, defaults.
  */
 final case class SecurityRules(

--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -28,7 +28,6 @@ import util.Helpers.tryo
 
 import LiftRules._
 
-// TODO Set it up so we can redirect HTTP->HTTPS but not send Strict-Transport-Security.
 /**
  * Rules for HTTPS usage by a Lift application.
  *

--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -101,12 +101,13 @@ sealed trait JavaScriptSourceRestriction extends ContentSourceRestriction
  * Marker trait for restrictions that only apply to stylesheets.
  */
 sealed trait StylesheetSourceRestriction extends ContentSourceRestriction
+sealed trait GeneralSourceRestriction extends JavaScriptSourceRestriction with StylesheetSourceRestriction
 
 object ContentSourceRestriction {
   /**
    * Indicates content from all sources is allowed.
    */
-  case object All extends ContentSourceRestriction {
+  case object All extends GeneralSourceRestriction {
     val sourceRestrictionString = "*"
   }
   /**
@@ -120,7 +121,7 @@ object ContentSourceRestriction {
    * Host("https://base.*.example.com")
    * }}}
    */
-  case class Host(hostAndPath: String) extends ContentSourceRestriction {
+  case class Host(hostAndPath: String) extends GeneralSourceRestriction {
     val sourceRestrictionString = hostAndPath
   }
   /**
@@ -132,19 +133,19 @@ object ContentSourceRestriction {
    * Scheme("data")
    * }}}
    */
-  case class Scheme(scheme: String) extends ContentSourceRestriction {
+  case class Scheme(scheme: String) extends GeneralSourceRestriction {
     val sourceRestrictionString = scheme + ":"
   }
   /**
    * Indicates content from no sources is allowed.
    */
-  case object None extends ContentSourceRestriction {
+  case object None extends GeneralSourceRestriction {
     val sourceRestrictionString = "'none'"
   }
   /**
    * Indicates content from the same origin as the content is allowed.
    */
-  case object Self extends ContentSourceRestriction {
+  case object Self extends GeneralSourceRestriction {
     val sourceRestrictionString = "'self'"
   }
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -321,10 +321,9 @@ object ContentSecurityPolicy {
    * to the same origin, but allows images from any source; the secure one only
    * differs because it adds restrictions to the image sources.
    */
-  def secure(reportUri: Option[URI]): ContentSecurityPolicy = {
-    ContentSecurityPolicy(imageSources = Nil, reportUri = reportUri)
+  def secure: ContentSecurityPolicy = {
+    ContentSecurityPolicy(imageSources = Nil)
   }
-  def secure: ContentSecurityPolicy = secure(Some(defaultReportUri))
 }
 
 /**

--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2007-2015 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package http
+
+import java.net.URI
+
+import scala.concurrent.duration._
+
+import util.Props
+
+// TODO Set it up so we can redirect HTTP->HTTPS but not send Strict-Transport-Security.
+/**
+ * Rules for HTTPS usage by a Lift application.
+ *
+ * Currently corresponds directly to the [[HTTP `Strict-Transport-Security`
+ * header http://tools.ietf.org/html/rfc6797]].
+ */
+final case class HttpsRules(
+  /**
+   * When set, the duration of the requirement that HTTPS be used for this
+   * site. It's usually a good idea for this to be a high number. If unset,
+   * HTTPS is not required when interacting with this site.
+   */
+  requiredTime: Option[Duration] = None,
+  /**
+   * When set to true, the required time above includes subdomains.
+   */
+  includeSubDomains: Boolean = false
+) {
+  lazy val headers: List[(String, String)] = {
+    requiredTime.toList.map { duration =>
+      val age = s"max-age=${duration.toSeconds}"
+
+      val header =
+        if (includeSubDomains) {
+          s"$age ; includeSubDomains"
+        } else {
+          age
+        }
+
+      ("Strict-Transport-Security" -> header)
+    }
+  }
+
+  /**
+   * Returns the headers implied by this set of HTTPS rules. If
+   * `enforceInDevMode` is false and we are in dev mode, returns nothing.
+   */
+  def headers(enforceInDevMode: Boolean = false): List[(String, String)] = {
+    if (! enforceInDevMode && Props.devMode) {
+      Nil
+    } else  {
+      headers
+    }
+  }
+}
+object HttpsRules {
+  /**
+   * Creates a restrictive set of HTTPS rules requiring HTTPS for 365 days and
+   * including subdomains in the requirement.
+   */
+  def secure = apply(Some(365.days), true)
+}
+
+/**
+ * Base trait for content source restrictions. These are different ways of
+ * restricting where contents of various types are allowed to come from, in
+ * conjunction with `ContentSecurityPolicy` categories.
+ */
+sealed trait ContentSourceRestriction {
+  /**
+   * The `Content-Security-Policy` string that represents this restriction.
+   */
+  def sourceRestrictionString: String
+}
+/**
+ * Marker trait for restrictions that only apply to JavaScript.
+ */
+sealed trait JavaScriptSourceRestriction extends ContentSourceRestriction
+/**
+ * Marker trait for restrictions that only apply to stylesheets.
+ */
+sealed trait StylesheetSourceRestriction extends ContentSourceRestriction
+
+object ContentSourceRestriction {
+  /**
+   * Indicates content from all sources is allowed.
+   */
+  case object All extends ContentSourceRestriction {
+    val sourceRestrictionString = "*"
+  }
+  /**
+   * Indicates content from the given host path is allowed. See the
+   * `Content-Security-Policy` spec's [[matching rules for `host-source`
+   * http://www.w3.org/TR/CSP/#matching]] for more about what this can look
+   * like.
+   *
+   * Example:
+   * {{{
+   * Host("https://base.*.example.com")
+   * }}}
+   */
+  case class Host(hostAndPath: String) extends ContentSourceRestriction {
+    val sourceRestrictionString = hostAndPath
+  }
+  /**
+   * Indicates content from the given scheme is allowed. The scheme should not
+   * include the trailing `:`.
+   *
+   * Example:
+   * {{{
+   * Scheme("data")
+   * }}}
+   */
+  case class Scheme(scheme: String) extends ContentSourceRestriction {
+    val sourceRestrictionString = scheme + ":"
+  }
+  /**
+   * Indicates content from no sources is allowed.
+   */
+  case object None extends ContentSourceRestriction {
+    val sourceRestrictionString = "'none'"
+  }
+  /**
+   * Indicates content from the same origin as the content is allowed.
+   */
+  case object Self extends ContentSourceRestriction {
+    val sourceRestrictionString = "'self'"
+  }
+  /**
+   * Indicates inline content on the page is allowed to be interpreted.  It is
+   * highly recommended that this not be used, as it exposes your application to
+   * cross-site scripting and other vulnerabilities.
+   *
+   * If not specified for JavaScript, JavaScript `on*` event handler attributes,
+   * `<script>` elements, and `javascript:` URIs will not be executed by a
+   * browser that supports content security policies.
+   *
+   * If not specified for stylesheets, `<style>` elements and inline `style`
+   * attributes will not be read by a browser that supports content security
+   * policies.
+   */
+  case object UnsafeInline extends JavaScriptSourceRestriction with StylesheetSourceRestriction {
+    val sourceRestrictionString = "'unsafe-inline'"
+  }
+  /**
+   * Indicates `eval` and related functionality can be used. It is highly
+   * recommended that this not be used, as it exposes your application to code
+   * injection attacks.
+   *
+   * If not specified for JavaScript, invoking `eval`, the `Function`
+   * constructor, or `setTimeout`/`setInterval` with a string parameter will
+   * all throw security exceptions in a browser that supports content security
+   * policies.
+   */
+  case object UnsafeEval extends JavaScriptSourceRestriction {
+    val sourceRestrictionString = "'unsafe-eval'"
+  }
+}
+
+/**
+ * Specifies a `[[https://developer.mozilla.org/en-US/docs/Web/Security/CSP Content-Security-Policy]] `
+ * for this site. This will be sent to the client in a `Content-Security-Policy`
+ * header when responses are returned from Lift.
+ *
+ * In development mode, content security policy violations are only reported if
+ * the browser supports them, not enforced. In all other modes, content security
+ * policy violations are enforced if the browser supports them.
+ *
+ * Note that the `X-Webkit-CSP` header is NOT specified, due to
+ * potentially-broken behavior in iOS 5 and 5.1. This means iOS 6/6.1 will not
+ * receive a content security policy that it can
+ * understand. See the [[caniuse page on content security policy
+ * http://caniuse.com/#feat=contentsecuritypolicy]] for more.
+ */
+final case class ContentSecurityPolicy(
+  /**
+   * A list of default source restrictions; if one of the other sources
+   * parameters is empty, the default sources will apply instead.
+   */
+  defaultSources: List[ContentSourceRestriction] = List(ContentSourceRestriction.Self),
+  /**
+   * A list of source restrictions for `XmlHttpRequest` (AJAX) connections.
+   */
+  connectSources: List[ContentSourceRestriction] = Nil,
+  /**
+   * A list of source restrictions for loading fonts (e.g., from CSS `font-face`
+   * declarations).
+   */
+  fontSources: List[ContentSourceRestriction] = Nil,
+  /**
+   * A list of source restrictions for loading frames and iframes.
+   */
+  frameSources: List[ContentSourceRestriction] = Nil,
+  /**
+   * A list of source restrictions for loading images.
+   */
+  imageSources: List[ContentSourceRestriction] = List(ContentSourceRestriction.All),
+  /**
+   * A list of source restrictions for loading media (audio and video).
+   */
+  mediaSources: List[ContentSourceRestriction] = Nil,
+  /**
+   * A list of source restrictions for loading `object`, `embed`, `applet`, and
+   * related elements.
+   */
+  objectSources: List[ContentSourceRestriction] = Nil,
+  /**
+   * A list of source restrictions for loading scripts. Also accepts the
+   * `UnsafeInline` and `UnsafeEval` sources, though these are strongly
+   * discouraged.
+   */
+  scriptSources: List[JavaScriptSourceRestriction] = Nil,
+  /**
+   * A list of source restrictions for loading styles. Also accepts the
+   * `UnsafeInline` source, though it is strongly discouraged.
+   */
+  styleSources: List[StylesheetSourceRestriction] = Nil,
+  /**
+   * The URI where any violation of the security policy will be reported. You
+   * can set the function that handles these violations in
+   * `LiftRules.contentSecurityPolicyViolationReport`. By default, reported to
+   * `[[ContentSecurityPolicy.defaultReportUri]]`.
+   *
+   * If this is `None`, violations will not be reported.
+   */
+  reportUri: Option[URI] = Some(ContentSecurityPolicy.defaultReportUri)
+) {
+  /**
+   * The string that describes this content security policy in the syntax
+   * expected by the `Content-Security-Policy` header.
+   */
+  def contentSecurityPolicyString = {
+    val allRestrictions =
+      Map(
+        "default-src" -> defaultSources,
+        "connect-src" -> connectSources,
+        "font-src" -> fontSources,
+        "frame-src" -> frameSources,
+        "img-src" -> imageSources,
+        "media-src" -> mediaSources,
+        "object-src" -> objectSources,
+        "script-src" -> scriptSources,
+        "style-src" -> styleSources
+      )
+
+    val restrictionString =
+      allRestrictions
+        .collect {
+          case (category, restrictions) if restrictions.nonEmpty =>
+            category +
+              " " +
+              restrictions.map(_.sourceRestrictionString).mkString(" ")
+        }
+        .mkString("; ")
+
+    reportUri.map { uri =>
+      s"$restrictionString; report-uri $uri"
+    } getOrElse {
+      restrictionString
+    }
+  }
+
+  private lazy val reportOnlyHeaders = {
+    List(
+      "Content-Security-Policy-Report-Only" -> contentSecurityPolicyString,
+      "X-Content-Security-Policy-Report-Only" -> contentSecurityPolicyString
+    )
+  }
+  private lazy val enforcedHeaders = {
+    List(
+      "Content-Security-Policy" -> contentSecurityPolicyString,
+      "X-Content-Security-Policy" -> contentSecurityPolicyString
+    )
+  }
+  /**
+   * Returns the headers implied by this content security policy.
+   */
+  def headers(reportOnlyInDev: Boolean = true): List[(String, String)] = {
+    if (reportOnlyInDev && Props.devMode) {
+      reportOnlyHeaders
+    } else {
+      enforcedHeaders
+    }
+  }
+}
+object ContentSecurityPolicy {
+  /**
+   * The default URI where security policy violations will be reported. This
+   * URI is under Lift's URI namespace, at `[[LiftRules.liftPath]]`.
+   */
+  def defaultReportUri = {
+    new URI(LiftRules.liftPath + "/content-security-policy-report")
+  }
+
+  /**
+   * Creates a restrictive content security policy that disallows images from
+   * all sources except the page's origin.
+   *
+   * Note that the default content security policy restricts all other resources
+   * to the same origin, but allows images from any source; the secure one only
+   * differs because it adds restrictions to the image sources.
+   */
+  def secure(reportUri: Option[URI]): ContentSecurityPolicy = {
+    ContentSecurityPolicy(imageSources = Nil, reportUri = reportUri)
+  }
+  def secure: ContentSecurityPolicy = secure(Some(defaultReportUri))
+}
+
+/**
+ * Specifies security rules for a Lift application. By default, HTTPS is not
+ * required and `Content-Security-Policy` is restricted to the current domain
+ * for everything except images, which are accepted from any domain.
+ *
+ * You can use `[[SecurityRules$.secure]]` to enable more restrictive, but
+ * also more secure, defaults.
+ */
+final case class SecurityRules(
+  https: Option[HttpsRules] = None,
+  content: Option[ContentSecurityPolicy] = Some(ContentSecurityPolicy()),
+  /**
+   * If true, security policies and HTTPS rules are enforced in dev mode in
+   * addition to staging/pilot/production/etc.
+   */
+  enforceInDevMode: Boolean = false,
+  /**
+   * If true, dev mode violations of security policies are logged by
+   * default. Note that if you override
+   * [[`LiftRules.contentSecurityPolicyViolationReport`]] or otherwise change
+   * the default Lift policy violation handling behavior, it will be up to you
+   * to handle this property as desired.
+   */
+  logInDevMode: Boolean = true
+) {
+  /**
+   * Returns the headers implied by this set of security rules.
+   */
+  lazy val headers: List[(String, String)] = {
+    https.toList.flatMap(_.headers(enforceInDevMode)) :::
+      content.toList.flatMap(_.headers(enforceInDevMode))
+  }
+}
+object SecurityRules {
+  /**
+   * Creates a restrictive set of security rules, including required HTTPS,
+   * [[HttpsRules$.secure secure HTTPS rules]], and
+   * [[ContentSecurityPolicy$.secure secure `Content-Security-Policy` rules]].
+   *
+   * To tweak any of these settings, use the `SecurityRules` constructor
+   * directly.
+   */
+  def secure = {
+    apply(
+      Some(HttpsRules.secure),
+      Some(ContentSecurityPolicy.secure)
+    )
+  }
+}

--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -288,9 +288,11 @@ final case class ContentSecurityPolicy(
   /**
    * Returns the headers implied by this content security policy.
    */
-  def headers(enforceInDevMode: Boolean = true): List[(String, String)] = {
-    if (! enforceInDevMode && Props.devMode) {
+  def headers(enforceInDevMode: Boolean = true, logInDevMode: Boolean = true): List[(String, String)] = {
+    if (! enforceInDevMode && logInDevMode && Props.devMode) {
       reportOnlyHeaders
+    } else if (! enforceInDevMode && Props.devMode) {
+      Nil
     } else {
       enforcedHeaders
     }
@@ -436,7 +438,7 @@ final case class SecurityRules(
    */
   lazy val headers: List[(String, String)] = {
     https.toList.flatMap(_.headers(enforceInDevMode)) :::
-      content.toList.flatMap(_.headers(enforceInDevMode)) :::
+      content.toList.flatMap(_.headers(enforceInDevMode, logInDevMode)) :::
       frameRestrictions.toList.flatMap(_.headers(enforceInDevMode))
   }
 }

--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -291,8 +291,8 @@ final case class ContentSecurityPolicy(
   /**
    * Returns the headers implied by this content security policy.
    */
-  def headers(reportOnlyInDev: Boolean = true): List[(String, String)] = {
-    if (reportOnlyInDev && Props.devMode) {
+  def headers(enforceInDevMode: Boolean = true): List[(String, String)] = {
+    if (! enforceInDevMode && Props.devMode) {
       reportOnlyHeaders
     } else {
       enforcedHeaders

--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -367,7 +367,7 @@ object ContentSecurityPolicyViolation extends LazyLoggable {
               s"Got a content security violation report we couldn't interpret: '${request.body.map(new String(_, "UTF-8"))}'."
             )
 
-            Full(BadRequest("Unrecognized format for content security policy report."))
+            Full(BadRequestResponse("Unrecognized format for content security policy report."))
         }
       }
   }


### PR DESCRIPTION
`SecurityRules` provides a way to set security rules like HTTPS
requirements and a content security policy, which are in turn
served with resources from Lift via headers. Right now, we support
`Content-Security-Policy` and `Strict-Transport-Security` headers.

Content security policy violations are by default reported to a URI
under the lift path, parsed into a case class, and passed to a `LiftRules`
function for handling. The default handler simply logs the violation and
returns a 200. If we get a violation report that doesn’t follow the expected
JSON format, we log an issue and return a 400 bad request.

Along the way, also renamed `BadResponse` to `BadRequest`, since
the previous name was wrong, and deprecated `BadResponse`, as
well as adding the ability to pass `BadRequest` a custom message.

Looking for some feedback here; the default `Content-Security-Policy`
isn’t quite loose enough for default Lift behavior. In particular, we’ll
probably need to allow `unsafe-eval` by default, due to the fact that Lift’s
JS responses need to be run through `eval` on the client.

This is, however, the initial API I have in mind. Let me know what you
think!