### PR TITLE
Fix Comet clean-up bug

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2543,7 +2543,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
   private[http] def removeCometActor(act: LiftCometActor): Unit = {
     testStatefulFeature {
       nasyncById.remove(act.uniqueId)
-      nasyncComponents.remove(act.theType -> act.name)
+      act.theType.foreach(t => nasyncComponents.remove(CometId(t, act.name)))
 
       val toCmp = Full(act.uniqueId)
 


### PR DESCRIPTION
Comet actors which defined a life span were being half-cleaned up with correspondingly strange results. 

The cause was java.util.Map#remove taking an Object, not a K with the result that this was missed when migrating from a tuple to CometId. I assume remove(Object key) was for backwards compatibility reasons, but seriously, come on!