### PR TITLE
Midair Collision: Fix issue where binding an `href` and an `onclick` together could fail.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -178,7 +178,7 @@ private[http] trait LiftMerge {
           fixAttrs(original, toFix, remainingAttributes, fixURL, updatedEventAttributes)
 
         case u: UnprefixedAttribute if u.key == toFix =>
-          val (id, fixedAttributes, updatedEventAttributes) = fixAttrs(original, toFix, attrs.next, fixURL)
+          val (id, fixedAttributes, updatedEventAttributes) = fixAttrs(original, toFix, attrs.next, fixURL, eventAttributes)
 
           (id, new UnprefixedAttribute(toFix, fixHref(contextPath, attrs.value, fixURL, rewrite), fixedAttributes), updatedEventAttributes)
 


### PR DESCRIPTION
This only manifested when the `onclick` came before the `href` on an
`a` element, and probably also manifested if you bound an `onsubmit`
on a form that had an `action` attribute. The cause was just that I had
forgotten to properly pass on already-seen event attributes when
processing the href attributes, so we lost them.

Fixes #1691 .