### PR TITLE
Implement ParamFailure chaining for ~>

### DIFF
--- a/core/common/src/main/scala/net/liftweb/common/Box.scala
+++ b/core/common/src/main/scala/net/liftweb/common/Box.scala
@@ -1037,6 +1037,9 @@ final class ParamFailure[T](override val msg: String,
       case null => 0
       case x => x.hashCode()
     })
+
+    override def ~>[T](errorCode: => T): ParamFailure[T] =
+      ParamFailure(msg, exception, Full(this), errorCode)
   }
 
 /**

--- a/core/common/src/test/scala/net/liftweb/common/BoxSpec.scala
+++ b/core/common/src/test/scala/net/liftweb/common/BoxSpec.scala
@@ -301,6 +301,9 @@ class BoxSpec extends Specification with ScalaCheck with BoxGenerator {
               Full(new Exception("broken")),
               Full(Failure("nested cause", Empty, Empty))).chain must_== Full(Failure("nested cause", Empty, Empty))
     }
+    "be converted to a ParamFailure" in {
+      Failure("hi mom") ~> 404 must_== ParamFailure("hi mom", Empty, Empty, 404)
+    }
   }
 
   "A Failure is an Empty Box which" should {
@@ -319,6 +322,15 @@ class BoxSpec extends Specification with ScalaCheck with BoxGenerator {
     }
     "return true for forall method" in {
       Failure("error", Empty, Empty) forall {_ => false } must beTrue
+    }
+  }
+
+  "A ParamFailure is a failure which" should {
+    "appear in the chain when ~> is invoked on it" in {
+      Failure("Apple") ~> 404 ~> "apple" must_==
+        ParamFailure("Apple", Empty, Full(
+          ParamFailure("Apple", Empty, Empty, 404)
+        ), "apple")
     }
   }
 


### PR DESCRIPTION
Now, when ~> is invoked in a ParamFailure, the existing ParamFailure
will be chained, thereby preserving the original param that was
attached.

closes #1680 
