### PR TITLE
Replace defunct scala-tools.org reference

### DIFF
--- a/core/json/README.md
+++ b/core/json/README.md
@@ -60,7 +60,7 @@ Add dependency to your pom:
 
 Download following jars:
 
-* http://scala-tools.org/repo-releases/net/liftweb/lift-json/XXX/lift-json-XXX.jar
+* https://oss.sonatype.org/content/groups/scala-tools/net/liftweb/lift-json_2.11/2.6.2/lift-json_2.11-2.6.2.jar
 * http://mirrors.ibiblio.org/pub/mirrors/maven2/com/thoughtworks/paranamer/paranamer/2.1/paranamer-2.1.jar
 * scalap (Only for Scala-2.9 compatible versions)
 


### PR DESCRIPTION
scala-tools.org is no longer active. Pointing to sonatype.org for the jar instead.