### PR TITLE
Enhanced Support for browser Actor proxies

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2047,8 +2047,8 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * @return a server-side Actor that is a proxy for the client-side Actor/Function call
    *
    */
-  def serverActorForClient(toCall: String, setupFunc: Box[() => Unit] = Empty,
-                            shutdownFunc: Box[() => Unit] = Empty,
+  def serverActorForClient(toCall: String, setupFunc: Box[LiftActor => Unit] = Empty,
+                            shutdownFunc: Box[LiftActor => Unit] = Empty,
                             dataFilter: Any => Any = a => a): LiftActor = {
     testStatefulFeature{
       val ca = new CometActor {

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2077,12 +2077,12 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
 
         override def localSetup(): Unit = {
           super.localSetup()
-          Helpers.tryo(setupFunc.foreach(_()))
+          Helpers.tryo(setupFunc.foreach(_(this)))
         }
 
         override def localShutdown(): Unit = {
           super.localShutdown()
-          Helpers.tryo(shutdownFunc.foreach(_()))
+          Helpers.tryo(shutdownFunc.foreach(_(this)))
         }
 
         override def lifespan = Full(LiftRules.clientActorLifespan.vend.apply(this))


### PR DESCRIPTION
Added support to `serverActorForClient` to register for life cycle events as well as filtering the data before
it's sent to the client.

Opened and documented `serverActorForClient` so folks can add custom CometActors that
are programmatically generated rather than named.