### PR TITLE
Test Fixes: Drop some sleeps in LAFutureSpec.

### DIFF
--- a/core/actor/src/test/scala/net/liftweb/actor/LAFutureSpec.scala
+++ b/core/actor/src/test/scala/net/liftweb/actor/LAFutureSpec.scala
@@ -9,7 +9,6 @@ class LAFutureSpec extends Specification {
   "LAFuture" should {
     "map to failing future if transforming function throws an Exception" in {
       val future = LAFuture { () =>
-        Thread.sleep(500)
         1
       }
       def tranformThrowingException(input: Int) = {
@@ -29,7 +28,6 @@ class LAFutureSpec extends Specification {
 
     "flatMap to failing future if transforming function throws an Exception" in {
       val future = LAFuture { () =>
-        Thread.sleep(500)
         1
       }
       def tranformThrowingException(input: Int): LAFuture[Int] = {


### PR DESCRIPTION
A couple of these specs are behaving intermittently in the CI environment, and
the sleeps seem beside the point to these two specs.

There's still an intermittent failure related to the Iran/Persian timezone that I'm
going to try and nail down before merging this, I think.