### PR TITLE
Add data-lift-fixedeventattribute-<event-name> for each replaced event-attribute

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -203,10 +203,8 @@ private[http] trait LiftMerge {
     def fixElementAndAttributes(element: Elem, attributeToFix: String, fixURL: Boolean, fixedChildren: NodeSeq) = {
       val (id, fixedAttributes, eventAttributes) = fixAttrs(attributeToFix, element.attributes, fixURL)
 
-      val attributesIncludingEventsAsData = if (LiftRules.includeFixedEventAttributesAsDataAttributes_?) {
-        eventAttributes.foldLeft(fixedAttributes) { case (accum, cur) =>
-          new UnprefixedAttribute(s"data-lift-fixedeventattribute-${cur.eventName}", cur.eventName, accum)
-        }
+      val attributesIncludingEventsAsData = if (LiftRules.includeFixedEventAttributesAsDataAttributes_? && eventAttributes.nonEmpty) {
+        new UnprefixedAttribute(s"data-lift-removed-attributes", eventAttributes.map(ea => s"on${ea.eventName}").join(" "), fixedAttributes)
       } else {
         fixedAttributes
       }

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -203,8 +203,8 @@ private[http] trait LiftMerge {
     def fixElementAndAttributes(element: Elem, attributeToFix: String, fixURL: Boolean, fixedChildren: NodeSeq) = {
       val (id, fixedAttributes, eventAttributes) = fixAttrs(attributeToFix, element.attributes, fixURL)
 
-      val attributesIncludingEventsAsData = if (LiftRules.includeFixedEventAttributesAsDataAttributes_? && eventAttributes.nonEmpty) {
-        new UnprefixedAttribute(s"data-lift-removed-attributes", eventAttributes.map(ea => s"on${ea.eventName}").join(" "), fixedAttributes)
+      val attributesIncludingEventsAsData = if (LiftRules.includeRemovedEventAttributesAsDataAttributes_? && eventAttributes.nonEmpty) {
+        new UnprefixedAttribute(LiftRules.removedEventAttributesAttributeName, eventAttributes.map(ea => s"on${ea.eventName}").join(" "), fixedAttributes)
       } else {
         fixedAttributes
       }

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -562,44 +562,63 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   @volatile var displayHelpfulSiteMapMessages_? = true
 
   /**
-   * Set to true if you want to add an attribute of the form data-lift-removed-attributes="removedattribute1 removedattribute2 ..."
-   * for each event-attribute (on*) which is replaced as part of the CSP.
-   * <br/>
-   * Example for the onclick attribute.
+   * The attribute used to expose the names of event attributes that
+   * were removed from a given element for separate processing in JS.
+   * By default, Lift removes event attributes and attaches those
+   * behaviors via a separate JS file, to avoid inline JS invocations so
+   * that a restrictive Content-Security-Policy can be used.
    *
-   * <pre>
-   * An element looking like this
+   * You can set this variable so that the resulting HTML will have
+   * attribute information about the removed attributes, in case you
+   * need them for e.g. CSS selector matching. The attribute will
+   * contain a space-separated list of JS attributes that were removed
+   * by Lift's processing.
    *
-   * &lt;span onclick="someStuff"&gt;
+   * For example, if you needed to match elements with an `onclick`
+   * attribute in CSS, you would usually do:
    *
-   * Will be re-written to:
-   *
-   * &lt;span id="lift-event-js-F827001738725NKMEQNf"&gt;
-   *
-   * by the CSP.
-   *
-   * When setting this value to <strong>true</strong> an extra attribute is added to indicate which events have been replaced
-   *
-   * &lt;span id="lift-event-js-F827001738725NKMEQNf" <strong>data-lift-removed-attributes="onclick"</strong>&gt;
-   *
-   * </pre>
-   *
-   * This makes it possible to replace old CSS matching the onclick:
-   * <pre>
+   * {{{
    * [onclick] {
    *   text-decoration: underline;
    * }
-   * </pre>
-   * with similar matching the data-lift-removed-attributes="onclick":
-   * <pre>
+   * }}}
+   *
+   * And have an element:
+   *
+   * {{{
+   * <span onclick="jsCode()">Do something!</span>
+   * }}}
+   *
+   * In Lift 3, this would not work, as the onclick attribute would be
+   * removed before HTML serialization, so your HTML would be:
+   *
+   * {{{
+   * <span id="lift-event-js-F827001738725NKMEQNF">Do something!</span>
+   * }}}
+   *
+   * Instead, you could set:
+   *
+   * {{{
+   * LiftRules.attributeForRemovedEventAttributes = Some("data-lift-removed-attributes")
+   * }}}
+   *
+   * The HTML Lift emitted would then look like:
+   *
+   * {{{
+   * <span id="lift-event-js-F827001738725NKMEQNF"
+   *       data-lift=removed-attributes="onclick">Do something!</span>
+   * }}}
+   *
+   * This makes it possible to replace the old CSS with with similar
+   * matching for the `data-lift-removed-attributes` attribute:
+   *
+   * {{{
    * [data-lift-removed-attributes~=onclick] {
    *   text-decoration: underline;
    * }
-   * </pre>
+   * }}}
    */
-  @volatile var includeRemovedEventAttributesAsDataAttributes_? = false
-
-  @volatile var removedEventAttributesAttributeName = "data-lift-removed-attributes"
+  @volatile var attributeForRemovedEventAttributes: Option[String] = None
 
   /**
    * The default location to send people if SiteMap access control fails. The path is

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -562,8 +562,8 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   @volatile var displayHelpfulSiteMapMessages_? = true
 
   /**
-   * Set to true if you want to add an attribute of the form data-lift-fixedeventattribute-&lt;eventName&gt;
-   * for each even-attribute (on*) which is replaced as part of the CSP.
+   * Set to true if you want to add an attribute of the form data-lift-removed-attributes="removedattribute1 removedattribute2 ..."
+   * for each event-attribute (on*) which is replaced as part of the CSP.
    * <br/>
    * Example for the onclick attribute.
    *
@@ -580,7 +580,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    *
    * When setting this value to <strong>true</strong> an extra attribute is added to indicate which events have been replaced
    *
-   * &lt;span id="lift-event-js-F827001738725NKMEQNf" <strong>data-lift-fixedeventattribute-click="click"</strong>&gt;
+   * &lt;span id="lift-event-js-F827001738725NKMEQNf" <strong>data-lift-removed-attributes="onclick"</strong>&gt;
    *
    * </pre>
    *
@@ -590,9 +590,9 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    *   text-decoration: underline;
    * }
    * </pre>
-   * with similar matching the data-lift-fixedeventattribute-click:
+   * with similar matching the data-lift-removed-attributes="onclick":
    * <pre>
-   * [data-lift-fixedeventattribute-click] {
+   * [data-lift-removed-attributes~=onclick] {
    *   text-decoration: underline;
    * }
    * </pre>

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -562,6 +562,44 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   @volatile var displayHelpfulSiteMapMessages_? = true
 
   /**
+   * Set to true if you want to add an attribute of the form data-lift-fixedeventattribute-&lt;eventName&gt;
+   * for each even-attribute (on*) which is replaced as part of the CSP.
+   * <br/>
+   * Example for the onclick attribute.
+   *
+   * <pre>
+   * An element looking like this
+   *
+   * &lt;span onclick="someStuff"&gt;
+   *
+   * Will be re-written to:
+   *
+   * &lt;span id="lift-event-js-F827001738725NKMEQNf"&gt;
+   *
+   * by the CSP.
+   *
+   * When setting this value to <strong>true</strong> an extra attribute is added to indicate which events have been replaced
+   *
+   * &lt;span id="lift-event-js-F827001738725NKMEQNf" <strong>data-lift-fixedeventattribute-click="click"</strong>&gt;
+   *
+   * </pre>
+   *
+   * This makes it possible to replace old CSS matching the onclick:
+   * <pre>
+   * [onclick] {
+   *   text-decoration: underline;
+   * }
+   * </pre>
+   * with similar matching the data-lift-fixedeventattribute-click:
+   * <pre>
+   * [data-lift-fixedeventattribute-click] {
+   *   text-decoration: underline;
+   * }
+   * </pre>
+   */
+  @volatile var includeFixedEventAttributesAsDataAttributes_? = false
+
+  /**
    * The default location to send people if SiteMap access control fails. The path is
    * expressed a a List[String]
    */

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -597,7 +597,9 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * }
    * </pre>
    */
-  @volatile var includeFixedEventAttributesAsDataAttributes_? = false
+  @volatile var includeRemovedEventAttributesAsDataAttributes_? = false
+
+  @volatile var removedEventAttributesAttributeName = "data-lift-removed-attributes"
 
   /**
    * The default location to send people if SiteMap access control fails. The path is


### PR DESCRIPTION
Add data-lift-fixedeventattribute-<event-name> for each replaced event-attribute, with settings in LiftRules: LiftRules.includeFixedEventAttributesAsDataAttributes_? (default false)