### PR TITLE
Add LiftSession.onFunctionOwnersRemoved.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # Deprecate using build.properties, use -Dsbt.version=... in launcher arg instead
-sbt.version=0.13.5
+sbt.version=0.13.8


### PR DESCRIPTION
These functions are invoked with the set of function owners that had
all of their remaining associated functions evicted from a session in a
given run. A function owner is typically a page’s RenderVersion, though
there are cases (e.g., comets) where this is not necessarily the case.

@andreak have a first look and see what you think!