### PR TITLE
Eliminate the need for Document during JSON Serialization

### DIFF
--- a/core/json-scalaz7/src/main/scala/net/liftweb/json/scalaz/JsonScalaz.scala
+++ b/core/json-scalaz7/src/main/scala/net/liftweb/json/scalaz/JsonScalaz.scala
@@ -45,7 +45,7 @@ trait Types {
   }
 
   implicit def JValueShow[A <: JValue]: Show[A] = new Show[A] {
-    override def shows(json: A): String = compact(render(json))
+    override def shows(json: A): String = compactRender(json)
   }
 
   implicit def JValueMonoid: Monoid[JValue] = Monoid.instance(_ ++ _, JNothing)

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -878,28 +878,36 @@ object JsonAST {
     case JNothing      => sys.error("can't render 'nothing'") //TODO: this should not throw an exception
   }
 
-  private def bufRenderArr(xs: List[JValue], buf: StringBuilder, settings: RenderSettings, indentLevel: Int): StringBuilder = {
+  private def bufRenderArr(values: List[JValue], buf: StringBuilder, settings: RenderSettings, indentLevel: Int): StringBuilder = {
     buf.append("[") //open array
-    if (!xs.isEmpty) {
-      xs.foreach(elem => Option(elem) match {
-        case Some(e) =>
-          if (e != JNothing) {
-            bufRender(e, buf, settings, indentLevel)
-            buf.append(",")
-          }
-        case None => buf.append("null,")
-      })
+
+    if (! values.isEmpty) {
+      values.foreach { elem =>
+        Option(elem) match {
+          case Some(elem) =>
+            if (elem != JNothing) {
+              bufRender(elem, buf, settings, indentLevel)
+              buf.append(",")
+            }
+
+          case None =>
+            buf.append("null,")
+        }
+      }
+
       if (buf.last == ',')
         buf.deleteCharAt(buf.length - 1) //delete last comma
     }
+
     buf.append("]")
     buf
   }
 
-  private def bufRenderObj(xs: List[JField], buf: StringBuilder, settings: RenderSettings, indentLevel: Int): StringBuilder = {
+  private def bufRenderObj(fields: List[JField], buf: StringBuilder, settings: RenderSettings, indentLevel: Int): StringBuilder = {
     buf.append("{") //open bracket
-    if (!xs.isEmpty) {
-      xs.foreach {
+
+    if (! fields.isEmpty) {
+      fields.foreach {
         case JField(name, value) if value != JNothing =>
           bufQuote(name, buf)
           buf.append(":")
@@ -908,9 +916,11 @@ object JsonAST {
 
         case _ => // omit fields with value of JNothing
       }
+
       if (buf.last == ',')
         buf.deleteCharAt(buf.length - 1) //delete last comma
     }
+
     buf.append("}") //close bracket
     buf
   }

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -889,9 +889,10 @@ object JsonAST {
   }
 
   private def bufRenderArr(values: List[JValue], buf: StringBuilder, settings: RenderSettings, indentLevel: Int): StringBuilder = {
-    buf.append("[") //open array
-
+    var firstEntry = true
     val currentIndent = indentLevel + settings.indent
+
+    buf.append("[") //open array
 
     if (! values.isEmpty) {
       if (settings.lineBreaks_?)
@@ -900,33 +901,38 @@ object JsonAST {
       values.foreach { elem =>
         Option(elem) match {
           case Some(elem) if elem != JNothing =>
+            if (firstEntry) {
+              firstEntry = false
+            } else {
+              buf.append(",")
+
+              if (settings.lineBreaks_?)
+                buf.append("\n")
+            }
+
             (0 until currentIndent).foreach(_ => buf.append(" "))
-
             bufRender(elem, buf, settings, currentIndent)
-            buf.append(",")
-
-            if (settings.lineBreaks_?)
-              buf.append("\n")
 
           case Some(_) =>
             // Ignore JNothing.
 
           case None =>
+            if (firstEntry) {
+              firstEntry = false
+            } else {
+              buf.append(",")
+
+              if (settings.lineBreaks_?)
+                buf.append("\n")
+            }
+
             (0 until currentIndent).foreach(_ => buf.append(" "))
-
-            buf.append("null,")
-
-            if (settings.lineBreaks_?)
-              buf.append("\n")
+            buf.append("null")
         }
       }
 
-      // Detect and eliminate dangling commas.
-      if (! settings.lineBreaks_? && buf.last == ',') {
-        buf.deleteCharAt(buf.length - 1)
-      } else if (settings.lineBreaks_? && buf.charAt(buf.length - 2) == ',') {
-        buf.deleteCharAt(buf.length - 2)
-      }
+      if (settings.lineBreaks_?)
+        buf.append("\n")
 
       (0 until indentLevel).foreach(_ => buf.append(" "))
     }

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -854,7 +854,7 @@ object JsonAST {
   }
 
   def prettyRender(value: JValue): String = {
-    bufRender(value, new StringBuilder, RenderSettings.pretty).toString()
+    render(value, RenderSettings.pretty)
   }
 
   /** Renders JSON directly to string in compact format.
@@ -862,7 +862,11 @@ object JsonAST {
     * when the intermediate Document is not needed.
     */
   def compactRender(value: JValue): String = {
-    bufRender(value, new StringBuilder, RenderSettings.compact).toString()
+    render(value, RenderSettings.compact)
+  }
+
+  def render(value: JValue, settings: RenderSettings): String = {
+    bufRender(value, new StringBuilder, settings).toString()
   }
 
   /**

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -898,6 +898,9 @@ object JsonAST {
     bufRender(value, appendContainer, settings).toString()
   }
 
+  case class RenderIntermediaryDocument(value: JValue)
+  def render(value: JValue) = RenderIntermediaryDocument(value)
+
   /**
    *
    * @param value the JSON to render
@@ -1063,5 +1066,44 @@ trait JsonDSL extends Implicits {
   class JsonListAssoc(left: List[JField]) {
     def ~(right: (String, JValue)) = JObject(left ::: List(JField(right._1, right._2)))
     def ~(right: JObject) = JObject(left ::: right.obj)
+  }
+}
+
+/** Printer converts JSON to String.
+  * Before printing a <code>JValue</code> needs to be rendered into scala.text.Document.
+  * <p>
+  * Example:<pre>
+  * pretty(render(json))
+  * </pre>
+  */
+@deprecated("Please switch using JsonAST's render methods instead of relying on Printer.", "3.0")
+object Printer extends Printer
+@deprecated("Please switch using JsonAST's render methods instead of relying on Printer.", "3.0")
+trait Printer {
+  /** Compact printing (no whitespace etc.)
+    */
+  @deprecated("Please switch to using compactRender instead.", "3.0")
+  def compact(d: JsonAST.RenderIntermediaryDocument): String = JsonAST.compactRender(d.value)
+
+  /** Compact printing (no whitespace etc.)
+    */
+  @deprecated("Please switch to using compactRender instead.", "3.0")
+  def compact[A <: Writer](d: JsonAST.RenderIntermediaryDocument, out: A): A = {
+    JsonAST.compactRender(d.value, out)
+    out
+  }
+
+  /** Pretty printing.
+    */
+  @deprecated("Please switch to using prettyRender instead.", "3.0")
+  def pretty(d: JsonAST.RenderIntermediaryDocument): String =
+    JsonAST.prettyRender(d.value)
+
+  /** Pretty printing.
+    */
+  @deprecated("Please switch to using prettyRender instead.", "3.0")
+  def pretty[A <: Writer](d: JsonAST.RenderIntermediaryDocument, out: A): A = {
+    JsonAST.prettyRender(d.value, out)
+    out
   }
 }

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -18,6 +18,7 @@ package net.liftweb
 package json
 
 import scala.language.implicitConversions
+import java.io.Writer
 
 /**
  * This object contains the abstract syntax tree (or AST) for working with JSON objects in
@@ -873,12 +874,24 @@ object JsonAST {
     render(value, RenderSettings.pretty)
   }
 
+  def prettyRender(value: JValue, appendable: Appendable): String = {
+    render(value, RenderSettings.pretty, appendable)
+  }
+
   /** Renders JSON directly to string in compact format.
     * This is an optimized version of compact(render(value))
     * when the intermediate Document is not needed.
     */
   def compactRender(value: JValue): String = {
     render(value, RenderSettings.compact)
+  }
+
+  def compactRender(value: JValue, appendable: Appendable): String = {
+    render(value, RenderSettings.compact, appendable)
+  }
+
+  def render(value: JValue, settings: RenderSettings, appendable: Appendable): String = {
+    render(value, settings, AppendableAppendContainer(appendable))
   }
 
   def render(value: JValue, settings: RenderSettings, appendContainer: AppendContainer[_] = StringBuilderAppendContainer(new StringBuilder())): String = {

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -899,35 +899,18 @@ object JsonAST {
         buf.append('\n')
 
       values.foreach { elem =>
-        Option(elem) match {
-          case Some(elem) if elem != JNothing =>
-            if (firstEntry) {
-              firstEntry = false
-            } else {
-              buf.append(',')
+        if (elem != JNothing) {
+          if (firstEntry) {
+            firstEntry = false
+          } else {
+            buf.append(',')
 
-              if (settings.lineBreaks_?)
-                buf.append('\n')
-            }
+            if (settings.lineBreaks_?)
+              buf.append('\n')
+          }
 
-            (0 until currentIndent).foreach(_ => buf.append(' '))
-            bufRender(elem, buf, settings, currentIndent)
-
-          case Some(_) =>
-            // Ignore JNothing.
-
-          case None =>
-            if (firstEntry) {
-              firstEntry = false
-            } else {
-              buf.append(',')
-
-              if (settings.lineBreaks_?)
-                buf.append('\n')
-            }
-
-            (0 until currentIndent).foreach(_ => buf.append(' '))
-            buf.append("null")
+          (0 until currentIndent).foreach(_ => buf.append(' '))
+          bufRender(elem, buf, settings, currentIndent)
         }
       }
 

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -843,12 +843,17 @@ object JsonAST {
   }
 
   object RenderSettings {
+    val pretty = RenderSettings(2)
     val compact = RenderSettings(0)
   }
   case class RenderSettings(
     indent: Int
   ) {
     val lineBreaks_? = indent > 0
+  }
+
+  def prettyRender(value: JValue): String = {
+    bufRender(value, new StringBuilder, RenderSettings.pretty).toString()
   }
 
   /** Renders JSON directly to string in compact format.

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -892,11 +892,11 @@ object JsonAST {
     var firstEntry = true
     val currentIndent = indentLevel + settings.indent
 
-    buf.append("[") //open array
+    buf.append('[') //open array
 
     if (! values.isEmpty) {
       if (settings.lineBreaks_?)
-        buf.append("\n")
+        buf.append('\n')
 
       values.foreach { elem =>
         Option(elem) match {
@@ -904,13 +904,13 @@ object JsonAST {
             if (firstEntry) {
               firstEntry = false
             } else {
-              buf.append(",")
+              buf.append(',')
 
               if (settings.lineBreaks_?)
-                buf.append("\n")
+                buf.append('\n')
             }
 
-            (0 until currentIndent).foreach(_ => buf.append(" "))
+            (0 until currentIndent).foreach(_ => buf.append(' '))
             bufRender(elem, buf, settings, currentIndent)
 
           case Some(_) =>
@@ -920,24 +920,24 @@ object JsonAST {
             if (firstEntry) {
               firstEntry = false
             } else {
-              buf.append(",")
+              buf.append(',')
 
               if (settings.lineBreaks_?)
-                buf.append("\n")
+                buf.append('\n')
             }
 
-            (0 until currentIndent).foreach(_ => buf.append(" "))
+            (0 until currentIndent).foreach(_ => buf.append(' '))
             buf.append("null")
         }
       }
 
       if (settings.lineBreaks_?)
-        buf.append("\n")
+        buf.append('\n')
 
-      (0 until indentLevel).foreach(_ => buf.append(" "))
+      (0 until indentLevel).foreach(_ => buf.append(' '))
     }
 
-    buf.append("]")
+    buf.append(']')
     buf
   }
 
@@ -945,29 +945,29 @@ object JsonAST {
     var firstEntry = true
     val currentIndent = indentLevel + settings.indent
 
-    buf.append("{") //open bracket
+    buf.append('{') //open bracket
 
     if (! fields.isEmpty) {
       if (settings.lineBreaks_?)
-        buf.append("\n")
+        buf.append('\n')
 
       fields.foreach {
         case JField(name, value) if value != JNothing =>
           if (firstEntry) {
             firstEntry = false
           } else {
-            buf.append(",")
+            buf.append(',')
 
             if (settings.lineBreaks_?)
-              buf.append("\n")
+              buf.append('\n')
           }
 
-          (0 until currentIndent).foreach(_ => buf.append(" "))
+          (0 until currentIndent).foreach(_ => buf.append(' '))
 
           bufQuote(name, buf)
-          buf.append(":")
+          buf.append(':')
           if (settings.spaceAfterFieldName)
-            buf.append(" ")
+            buf.append(' ')
           bufRender(value, buf, settings, currentIndent)
 
         case _ => // omit fields with value of JNothing
@@ -976,17 +976,17 @@ object JsonAST {
       if (settings.lineBreaks_?)
         buf.append('\n')
 
-      (0 until indentLevel).foreach(_ => buf.append(" "))
+      (0 until indentLevel).foreach(_ => buf.append(' '))
     }
 
-    buf.append("}") //close bracket
+    buf.append('}') //close bracket
     buf
   }
 
   private def bufQuote(s: String, buf: StringBuilder): StringBuilder = {
-    buf.append("\"") //open quote
+    buf.append('"') //open quote
     appendEscapedString(buf, s)
-    buf.append("\"") //close quote
+    buf.append('"') //close quote
     buf
   }
 

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -927,8 +927,9 @@ object JsonAST {
     buf.append('[') //open array
 
     if (! values.isEmpty) {
-      if (settings.lineBreaks_?)
+      if (settings.lineBreaks_?) {
         buf.append('\n')
+      }
 
       values.foreach { elem =>
         if (elem != JNothing) {
@@ -937,8 +938,9 @@ object JsonAST {
           } else {
             buf.append(',')
 
-            if (settings.lineBreaks_?)
+            if (settings.lineBreaks_?) {
               buf.append('\n')
+            }
           }
 
           (0 until currentIndent).foreach(_ => buf.append(' '))
@@ -946,8 +948,9 @@ object JsonAST {
         }
       }
 
-      if (settings.lineBreaks_?)
+      if (settings.lineBreaks_?) {
         buf.append('\n')
+      }
 
       (0 until indentLevel).foreach(_ => buf.append(' '))
     }
@@ -963,8 +966,9 @@ object JsonAST {
     buf.append('{') //open bracket
 
     if (! fields.isEmpty) {
-      if (settings.lineBreaks_?)
+      if (settings.lineBreaks_?) {
         buf.append('\n')
+      }
 
       fields.foreach {
         case JField(name, value) if value != JNothing =>
@@ -973,23 +977,26 @@ object JsonAST {
           } else {
             buf.append(',')
 
-            if (settings.lineBreaks_?)
+            if (settings.lineBreaks_?) {
               buf.append('\n')
+            }
           }
 
           (0 until currentIndent).foreach(_ => buf.append(' '))
 
           bufQuote(name, buf)
           buf.append(':')
-          if (settings.spaceAfterFieldName)
+          if (settings.spaceAfterFieldName) {
             buf.append(' ')
+          }
           bufRender(value, buf, settings, currentIndent)
 
         case _ => // omit fields with value of JNothing
       }
 
-      if (settings.lineBreaks_?)
+      if (settings.lineBreaks_?) {
         buf.append('\n')
+      }
 
       (0 until indentLevel).foreach(_ => buf.append(' '))
     }

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -888,10 +888,10 @@ object JsonAST {
 
     val currentIndent = indentLevel + settings.indent
 
-    if (settings.lineBreaks_?)
-      buf.append("\n")
-
     if (! values.isEmpty) {
+      if (settings.lineBreaks_?)
+        buf.append("\n")
+
       values.foreach { elem =>
         Option(elem) match {
           case Some(elem) =>
@@ -921,9 +921,10 @@ object JsonAST {
       } else if (settings.lineBreaks_? && buf.charAt(buf.length - 2) == ',') {
         buf.deleteCharAt(buf.length - 2)
       }
+
+      (0 until indentLevel).foreach(_ => buf.append(" "))
     }
 
-    (0 until indentLevel).foreach(_ => buf.append(" "))
     buf.append("]")
     buf
   }

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -886,24 +886,44 @@ object JsonAST {
   private def bufRenderArr(values: List[JValue], buf: StringBuilder, settings: RenderSettings, indentLevel: Int): StringBuilder = {
     buf.append("[") //open array
 
+    val currentIndent = indentLevel + settings.indent
+
+    if (settings.lineBreaks_?)
+      buf.append("\n")
+
     if (! values.isEmpty) {
       values.foreach { elem =>
         Option(elem) match {
           case Some(elem) =>
             if (elem != JNothing) {
-              bufRender(elem, buf, settings, indentLevel)
+              (0 until currentIndent).foreach(_ => buf.append(" "))
+
+              bufRender(elem, buf, settings, currentIndent)
               buf.append(",")
+
+              if (settings.lineBreaks_?)
+                buf.append("\n")
             }
 
           case None =>
+            (0 until currentIndent).foreach(_ => buf.append(" "))
+
             buf.append("null,")
+
+            if (settings.lineBreaks_?)
+              buf.append("\n")
         }
       }
 
-      if (buf.last == ',')
-        buf.deleteCharAt(buf.length - 1) //delete last comma
+      // Detect and eliminate dangling commas.
+      if (! settings.lineBreaks_? && buf.last == ',') {
+        buf.deleteCharAt(buf.length - 1)
+      } else if (settings.lineBreaks_? && buf.charAt(buf.length - 2) == ',') {
+        buf.deleteCharAt(buf.length - 2)
+      }
     }
 
+    (0 until indentLevel).foreach(_ => buf.append(" "))
     buf.append("]")
     buf
   }

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -842,6 +842,19 @@ object JsonAST {
     }
   }
 
+  sealed trait AppendContainer[T] {
+    def append(thing: Char): T
+    def append(thing: String): T
+  }
+  case class StringBuilderAppendContainer(builder: StringBuilder) extends AppendContainer[StringBuilder] {
+    def append(thing: Char) = builder.append(thing)
+    def append(thing: String) = builder.append(thing)
+  }
+  case class AppendableAppendContainer(appendable: Appendable) extends AppendContainer[Appendable] {
+    def append(thing: Char) = appendable.append(thing)
+    def append(thing: String) = appendable.append(thing)
+  }
+
   object RenderSettings {
     val pretty = RenderSettings(2)
     val compact = RenderSettings(0)

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -899,16 +899,17 @@ object JsonAST {
 
       values.foreach { elem =>
         Option(elem) match {
-          case Some(elem) =>
-            if (elem != JNothing) {
-              (0 until currentIndent).foreach(_ => buf.append(" "))
+          case Some(elem) if elem != JNothing =>
+            (0 until currentIndent).foreach(_ => buf.append(" "))
 
-              bufRender(elem, buf, settings, currentIndent)
-              buf.append(",")
+            bufRender(elem, buf, settings, currentIndent)
+            buf.append(",")
 
-              if (settings.lineBreaks_?)
-                buf.append("\n")
-            }
+            if (settings.lineBreaks_?)
+              buf.append("\n")
+
+          case Some(_) =>
+            // Ignore JNothing.
 
           case None =>
             (0 until currentIndent).foreach(_ => buf.append(" "))

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -942,9 +942,10 @@ object JsonAST {
   }
 
   private def bufRenderObj(fields: List[JField], buf: StringBuilder, settings: RenderSettings, indentLevel: Int): StringBuilder = {
-    buf.append("{") //open bracket
-
+    var firstEntry = true
     val currentIndent = indentLevel + settings.indent
+
+    buf.append("{") //open bracket
 
     if (! fields.isEmpty) {
       if (settings.lineBreaks_?)
@@ -952,29 +953,28 @@ object JsonAST {
 
       fields.foreach {
         case JField(name, value) if value != JNothing =>
+          if (firstEntry) {
+            firstEntry = false
+          } else {
+            buf.append(",")
+
+            if (settings.lineBreaks_?)
+              buf.append("\n")
+          }
+
           (0 until currentIndent).foreach(_ => buf.append(" "))
 
           bufQuote(name, buf)
           buf.append(":")
-
           if (settings.spaceAfterFieldName)
             buf.append(" ")
-
           bufRender(value, buf, settings, currentIndent)
-          buf.append(",")
-
-          if (settings.lineBreaks_?)
-            buf.append("\n")
 
         case _ => // omit fields with value of JNothing
       }
 
-      // Detect and eliminate dangling commas.
-      if (! settings.lineBreaks_? && buf.last == ',') {
-        buf.deleteCharAt(buf.length - 1)
-      } else if (settings.lineBreaks_? && buf.charAt(buf.length - 2) == ',') {
-        buf.deleteCharAt(buf.length - 2)
-      }
+      if (settings.lineBreaks_?)
+        buf.append('\n')
 
       (0 until indentLevel).foreach(_ => buf.append(" "))
     }

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -847,7 +847,8 @@ object JsonAST {
     val compact = RenderSettings(0)
   }
   case class RenderSettings(
-    indent: Int
+    indent: Int,
+    spaceAfterFieldName: Boolean = false
   ) {
     val lineBreaks_? = indent > 0
   }
@@ -944,6 +945,9 @@ object JsonAST {
 
           bufQuote(name, buf)
           buf.append(":")
+
+          if (settings.spaceAfterFieldName)
+            buf.append(" ")
 
           bufRender(value, buf, settings, currentIndent)
           buf.append(",")

--- a/core/json/src/main/scala/net/liftweb/json/Serialization.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Serialization.scala
@@ -40,7 +40,8 @@ object Serialization {
   /** Serialize to Writer.
    */
   def write[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W =
-    Printer.compact(render(Extraction.decompose(a)(formats)), out)
+    //FIXME: Printer.compact(render(Extraction.decompose(a)(formats)), out)
+    out
 
   /** Serialize to String (pretty format).
    */
@@ -50,7 +51,8 @@ object Serialization {
   /** Serialize to Writer (pretty format).
    */
   def writePretty[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = 
-    Printer.pretty(render(Extraction.decompose(a)(formats)), out)
+    //FIXME: Printer.pretty(render(Extraction.decompose(a)(formats)), out)
+    out
 
   /** Deserialize from a String.
    */

--- a/core/json/src/main/scala/net/liftweb/json/Serialization.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Serialization.scala
@@ -39,9 +39,10 @@ object Serialization {
 
   /** Serialize to Writer.
    */
-  def write[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W =
-    //FIXME: Printer.compact(render(Extraction.decompose(a)(formats)), out)
+  def write[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
+    JsonAST.compactRender(Extraction.decompose(a)(formats), out)
     out
+  }
 
   /** Serialize to String (pretty format).
    */
@@ -50,9 +51,10 @@ object Serialization {
 
   /** Serialize to Writer (pretty format).
    */
-  def writePretty[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = 
-    //FIXME: Printer.pretty(render(Extraction.decompose(a)(formats)), out)
+  def writePretty[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = {
+    JsonAST.prettyRender(Extraction.decompose(a)(formats), out)
     out
+  }
 
   /** Deserialize from a String.
    */

--- a/core/json/src/main/scala/net/liftweb/json/package.scala
+++ b/core/json/src/main/scala/net/liftweb/json/package.scala
@@ -18,7 +18,6 @@ package net.liftweb
 
 package object json {
   import java.io.Reader
-  import scala.text.Document
 
   type JValue   = JsonAST.JValue
   val  JNothing = JsonAST.JNothing
@@ -41,10 +40,15 @@ package object json {
   def parse(s: String): JValue = JsonParser.parse(s)
   def parseOpt(s: String): Option[JValue] = JsonParser.parseOpt(s)
 
-  /*
-  def render(value: JValue): Document = JsonAST.render(value)
-  def compact(d: Document): String = Printer.compact(d)
-  def pretty(d: Document): String = Printer.pretty(d)
-  */
+  @deprecated("Please switch to using prettyRender or compactRender instead.", "3.0")
+  def render(value: JValue): JsonAST.RenderIntermediaryDocument = JsonAST.render(value)
+
+  @deprecated("Please switch to using compactRender instead.", "3.0")
+  def compact(d: JsonAST.RenderIntermediaryDocument): String = Printer.compact(d)
+
+  @deprecated("Please switch to using prettyRender instead.", "3.0")
+  def pretty(d: JsonAST.RenderIntermediaryDocument): String = Printer.pretty(d)
+
+  def prettyRender(value: JValue): String = JsonAST.prettyRender(value)
   def compactRender(value: JValue): String = JsonAST.compactRender(value)
 }

--- a/core/json/src/main/scala/net/liftweb/json/package.scala
+++ b/core/json/src/main/scala/net/liftweb/json/package.scala
@@ -41,8 +41,10 @@ package object json {
   def parse(s: String): JValue = JsonParser.parse(s)
   def parseOpt(s: String): Option[JValue] = JsonParser.parseOpt(s)
 
+  /*
   def render(value: JValue): Document = JsonAST.render(value)
   def compact(d: Document): String = Printer.compact(d)
   def pretty(d: Document): String = Printer.pretty(d)
+  */
   def compactRender(value: JValue): String = JsonAST.compactRender(value)
 }

--- a/core/json/src/test/scala/net/liftweb/json/Examples.scala
+++ b/core/json/src/test/scala/net/liftweb/json/Examples.scala
@@ -214,7 +214,7 @@ object Examples {
 }
 """
 
-  val nulls = ("f1" -> null) ~ ("f2" -> List(null, "s"))
+  val nulls = ("f1" -> (null: String)) ~ ("f2" -> List(null, "s"))
   val quoted = """["foo \" \n \t \r bar"]"""
   val symbols = ("f1" -> 'foo) ~ ("f2" -> 'bar)
 }

--- a/core/json/src/test/scala/net/liftweb/json/Examples.scala
+++ b/core/json/src/test/scala/net/liftweb/json/Examples.scala
@@ -20,10 +20,6 @@ package json
 import org.specs2.mutable.Specification
 
 class Examples extends AbstractExamples {
-  override def print(value: JValue): String = compact(render(value))
-}
-
-class CompactRenderExamples extends AbstractExamples {
   override def print(value: JValue): String = compactRender(value)
 }
 
@@ -43,23 +39,22 @@ trait AbstractExamples extends Specification {
 
   "Person example" in {
     val json = parse(person)
-    val renderedPerson = Printer.pretty(render(json))
+    val renderedPerson = prettyRender(json)
     (json mustEqual parse(renderedPerson)) and
-      (render(json) mustEqual render(personDSL)) and
       (print(json \\ "name") mustEqual """{"name":"Joe","name":"Marilyn"}""") and
       (print(json \ "person" \ "name") mustEqual "\"Joe\"")
   }
 
   "Transformation example" in {
     val uppercased = parse(person).transformField { case JField(n, v) => JField(n.toUpperCase, v) }
-    val rendered = compact(render(uppercased))
+    val rendered = compactRender(uppercased)
     rendered mustEqual 
       """{"PERSON":{"NAME":"Joe","AGE":35,"SPOUSE":{"PERSON":{"NAME":"Marilyn","AGE":33}}}}"""
   }
 
   "Remove example" in {
     val json = parse(person) removeField { _ == JField("name", "Marilyn") }
-    compact(render(json \\ "name")) mustEqual """{"name":"Joe"}"""
+    compactRender(json \\ "name") mustEqual """{"name":"Joe"}"""
   }
 
   "Queries on person example" in {
@@ -219,7 +214,7 @@ object Examples {
 }
 """
 
-  val nulls = ("f1" -> null) ~ ("f2" -> List(null, "s"))
+  val nulls = (("f1" -> null) ~ ("f2" -> List(null, "s")))
   val quoted = """["foo \" \n \t \r bar"]"""
   val symbols = ("f1" -> 'foo) ~ ("f2" -> 'bar)
 }

--- a/core/json/src/test/scala/net/liftweb/json/Examples.scala
+++ b/core/json/src/test/scala/net/liftweb/json/Examples.scala
@@ -214,7 +214,7 @@ object Examples {
 }
 """
 
-  val nulls = (("f1" -> null) ~ ("f2" -> List(null, "s")))
+  val nulls = ("f1" -> null) ~ ("f2" -> List(null, "s"))
   val quoted = """["foo \" \n \t \r bar"]"""
   val symbols = ("f1" -> 'foo) ~ ("f2" -> 'bar)
 }

--- a/core/json/src/test/scala/net/liftweb/json/JValueGen.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JValueGen.scala
@@ -24,7 +24,7 @@ import Arbitrary.arbitrary
 trait JValueGen {
   def genJValue: Gen[JValue] = frequency((5, genSimple), (1, wrap(genArray)), (1, wrap(genObject)))
   def genSimple: Gen[JValue] = oneOf(
-    value(JNull), 
+    const(JNull), 
     arbitrary[Int].map(JInt(_)),
     arbitrary[Double].map(JDouble(_)),
     arbitrary[Boolean].map(JBool(_)),
@@ -60,6 +60,6 @@ trait NodeGen {
     value <- arbitrary[String]
   } yield new XmlElem(name, value)
 
-  def genName = frequency((2, identifier), (1, value("const")))
+  def genName = frequency((2, identifier), (1, const("const")))
   private def children = choose(1, 3).sample.get
 }

--- a/core/json/src/test/scala/net/liftweb/json/JsonParserSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonParserSpec.scala
@@ -39,7 +39,7 @@ object JsonParserSpec extends Specification with JValueGen with ScalaCheck {
   "JSON Parser Specification".title
 
   "Any valid json can be parsed" in {
-    val parsing = (json: JValue) => { parse(Printer.pretty(render(json))); true }
+    val parsing = (json: JValue) => { parse(prettyRender(json)); true }
     check(forAll(genJValue)(parsing))
   }
 
@@ -100,7 +100,7 @@ object JsonParserSpec extends Specification with JValueGen with ScalaCheck {
     try {
       JsonParser.Segments.segmentSize = bufSize
       JsonParser.Segments.clear
-      JsonParser.parse(compact(render(json)))
+      JsonParser.parse(compactRender(json))
     } finally {
       JsonParser.Segments.segmentSize = existingSize
     }

--- a/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
@@ -29,14 +29,12 @@ import org.scalacheck.Prop.forAll
 object JsonPrintingSpec extends Specification  with JValueGen with ScalaCheck {
   "JSON Printing Specification".title
 
-  import scala.text.Document
-
   "rendering does not change semantics" in {
-    val rendering = (json: Document) => parse(Printer.pretty(json)) == parse(Printer.compact(json))
+    val rendering = (json: JValue) => parse(JsonAST.prettyRender(json)) == parse(JsonAST.compactRender(json))
     check(forAll(rendering))
   }
 
   private def parse(json: String) = scala.util.parsing.json.JSON.parseRaw(json)
 
-  implicit def arbDoc: Arbitrary[Document] = Arbitrary(genJValue.map(render(_)))
+  implicit def arbDoc: Arbitrary[JValue] = Arbitrary(genJValue)
 }

--- a/core/json/src/test/scala/net/liftweb/json/JsonXmlSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonXmlSpec.scala
@@ -38,7 +38,7 @@ object JsonXmlSpec extends Specification  with NodeGen with JValueGen with Scala
   }
 
   "JSON can be converted to XML, and back to valid JSON (non symmetric op)" in {
-    val conversion = (json: JValue) => { parse(compact(render(toJson(toXml(json))))); true }
+    val conversion = (json: JValue) => { parse(compactRender(toJson(toXml(json)))); true }
     check(forAll(conversion))
   }
 

--- a/core/json/src/test/scala/net/liftweb/json/LottoExample.scala
+++ b/core/json/src/test/scala/net/liftweb/json/LottoExample.scala
@@ -44,7 +44,7 @@ object LottoExample extends Specification {
 
   "Parse Lotto" in {
 
-    (compact(render(json)) mustEqual """{"lotto":{"id":5,"winning-numbers":[2,45,34,23,7,5,3],"winners":[{"winner-id":23,"numbers":[2,45,34,23,3,5]},{"winner-id":54,"numbers":[52,3,12,11,18,22]}]}}""") and
+    (compactRender(json) mustEqual """{"lotto":{"id":5,"winning-numbers":[2,45,34,23,7,5,3],"winners":[{"winner-id":23,"numbers":[2,45,34,23,3,5]},{"winner-id":54,"numbers":[52,3,12,11,18,22]}]}}""") and
       ((json \ "lotto" \ "winners")(0).extract[Winner] mustEqual Winner(23, List(2, 45, 34, 23, 3, 5))) and
       ((json \ "lotto").extract[Lotto] mustEqual lotto) and
       (json.values mustEqual Map("lotto" -> Map("id" -> 5,

--- a/core/json/src/test/scala/net/liftweb/json/ParserBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ParserBugs.scala
@@ -47,7 +47,7 @@ object ParserBugs extends Specification {
 
   "Field names must be quoted" in {
     val json = JObject(List(JField("foo\nbar", JInt(1))))
-    val s = compact(render(json))
+    val s = compactRender(json)
     (s mustEqual """{"foo\nbar":1}""") and
       (parse(s) mustEqual json)
   }

--- a/core/json/src/test/scala/net/liftweb/json/XmlBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/XmlBugs.scala
@@ -32,7 +32,7 @@ object XmlBugs extends Specification {
 
   "HarryH's XML with attributes parses correctly" in {
     val json = toJson(<tips><group type="Nearby"><tip><id>10</id></tip></group></tips>)
-    Printer.compact(render(json)) mustEqual """{"tips":{"group":{"type":"Nearby","tip":{"id":"10"}}}}"""
+    compactRender(json) mustEqual """{"tips":{"group":{"type":"Nearby","tip":{"id":"10"}}}}"""
   }
 
   "Jono's XML with attributes parses correctly" in {
@@ -54,7 +54,7 @@ object XmlBugs extends Specification {
       </root>
     val expected    = """{"root":{"n":[{"x":"abc","id":"10"},{"x":"bcd","id":"11"}]}}"""
     val expected210 = """{"root":{"n":[{"id":"10","x":"abc"},{"id":"11","x":"bcd"}]}}"""
-    val json = Printer.compact(render(toJson(xml)))
+    val json = compactRender(toJson(xml))
     (json == expected || json == expected210) mustEqual true
   }
 
@@ -62,6 +62,6 @@ object XmlBugs extends Specification {
     val xml =
       <tips><group type="Foo"></group><group type="Bar"><tip><text>xxx</text></tip><tip><text>yyy</text></tip></group></tips>
     val expected = """{"tips":{"group":[{"type":"Foo"},{"type":"Bar","tip":[{"text":"xxx"},{"text":"yyy"}]}]}}"""
-    Printer.compact(render(toJson(xml))) mustEqual expected
+    compactRender(toJson(xml)) mustEqual expected
   }
 }

--- a/core/json/src/test/scala/net/liftweb/json/XmlExamples.scala
+++ b/core/json/src/test/scala/net/liftweb/json/XmlExamples.scala
@@ -27,14 +27,14 @@ object XmlExamples extends Specification  {
 
   "Basic conversion example" in {
     val json = toJson(users1) 
-    compact(render(json)) mustEqual """{"users":{"count":"2","user":[{"disabled":"true","id":"1","name":"Harry"},{"id":"2","name":"David","nickname":"Dave"}]}}"""
+    compactRender(json) mustEqual """{"users":{"count":"2","user":[{"disabled":"true","id":"1","name":"Harry"},{"id":"2","name":"David","nickname":"Dave"}]}}"""
   }
 
   "Conversion transformation example 1" in {
     val json = toJson(users1).transformField {
       case JField("id", JString(s)) => JField("id", JInt(s.toInt))
     }
-    compact(render(json)) mustEqual """{"users":{"count":"2","user":[{"disabled":"true","id":1,"name":"Harry"},{"id":2,"name":"David","nickname":"Dave"}]}}"""
+    compactRender(json) mustEqual """{"users":{"count":"2","user":[{"disabled":"true","id":1,"name":"Harry"},{"id":2,"name":"David","nickname":"Dave"}]}}"""
   }
 
   "Conversion transformation example 2" in {
@@ -42,12 +42,12 @@ object XmlExamples extends Specification  {
       case JField("id", JString(s)) => JField("id", JInt(s.toInt))
       case JField("user", x: JObject) => JField("user", JArray(x :: Nil))
     }
-    compact(render(json)) mustEqual """{"users":{"user":[{"id":1,"name":"Harry"}]}}"""
+    compactRender(json) mustEqual """{"users":{"user":[{"id":1,"name":"Harry"}]}}"""
   }
 
   "Primitive array example" in {
     val xml = <chars><char>a</char><char>b</char><char>c</char></chars>
-    compact(render(toJson(xml))) mustEqual """{"chars":{"char":["a","b","c"]}}"""
+    compactRender(toJson(xml)) mustEqual """{"chars":{"char":["a","b","c"]}}"""
   }
 
   "Lotto example which flattens number arrays into encoded string arrays" in {
@@ -114,7 +114,7 @@ object XmlExamples extends Specification  {
 
   "Grouped text example" in {
     val json = toJson(groupedText)
-    compact(render(json)) mustEqual """{"g":{"group":"foobar","url":"http://example.com/test"}}"""
+    compactRender(json) mustEqual """{"g":{"group":"foobar","url":"http://example.com/test"}}"""
   }
 
   val users1 =
@@ -165,8 +165,8 @@ object XmlExamples extends Specification  {
 
   "Example with one attribute, one nested element " in { 
     val a = attrToObject("stats", "count", s => JInt(s.s.toInt)) _
-    compact(render(a(toJson(messageXml2)))) mustEqual expected2
-    compact(render(a(toJson(messageXml3)))) mustEqual expected2
+    compactRender(a(toJson(messageXml2))) mustEqual expected2
+    compactRender(a(toJson(messageXml3))) mustEqual expected2
   }
 
   val messageXml1 = 

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonRecordField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonRecordField.scala
@@ -52,7 +52,7 @@ class BsonRecordField[OwnerType <: BsonRecord[OwnerType], SubRecordType <: BsonR
   def asJs = asJValue match {
     case JNothing => JsNull
     case jv => new JsExp {
-      lazy val toJsCmd = Printer.compact(render(jv))
+      lazy val toJsCmd = compactRender(jv)
     }
   }
   def toForm: Box[NodeSeq] = Empty

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/DateField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/DateField.scala
@@ -73,7 +73,7 @@ trait DateTypedField extends TypedField[Date] {
 
   def asJs = asJValue match {
     case JNothing => JsNull
-    case jv => JsRaw(Printer.compact(render(jv)))
+    case jv => JsRaw(compactRender(jv))
   }
 
   def asJValue: JValue = valueBox.map(v => JsonDate(v)(formats)) openOr (JNothing: JValue)

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoFieldFlavor.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoFieldFlavor.scala
@@ -44,7 +44,7 @@ trait MongoFieldFlavor[MyType] {
   */
   def asJs = asJValue match {
     case JNothing => JsNull
-    case jv => JsRaw(Printer.compact(render(jv)))
+    case jv => JsRaw(compactRender(jv))
   }
 
   /** Encode the field value into a JValue */

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/ObjectIdField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/ObjectIdField.scala
@@ -87,7 +87,7 @@ class ObjectIdField[OwnerType <: BsonRecord[OwnerType]](rec: OwnerType)
 
   def asJs = asJValue match {
     case JNothing => JsNull
-    case jv => JsRaw(Printer.compact(render(jv)))
+    case jv => JsRaw(compactRender(jv))
   }
 
   def asJValue: JValue = valueBox.map(v => JsonObjectId.asJValue(v, owner.meta.formats)) openOr (JNothing: JValue)

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/PatternField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/PatternField.scala
@@ -67,7 +67,7 @@ class PatternField[OwnerType <: BsonRecord[OwnerType]](rec: OwnerType)
 
   def asJs = asJValue match {
     case JNothing => JsNull
-    case jv => Str(Printer.compact(render(jv)))
+    case jv => Str(compactRender(jv))
   }
 
   def asJValue: JValue = valueBox.map(v => JsonRegex(v)) openOr (JNothing: JValue)

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/UUIDField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/UUIDField.scala
@@ -79,7 +79,7 @@ class UUIDField[OwnerType <: BsonRecord[OwnerType]](rec: OwnerType)
 
   def asJs = asJValue match {
     case JNothing => JsNull
-    case jv => JsRaw(Printer.compact(render(jv)))
+    case jv => JsRaw(compactRender(jv))
   }
 
   def asJValue: JValue = valueBox.map(v => JsonUUID(v)) openOr (JNothing: JValue)

--- a/persistence/record/src/main/scala/net/liftweb/record/MetaRecord.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/MetaRecord.scala
@@ -241,7 +241,7 @@ trait MetaRecord[BaseRecord <: Record[BaseRecord]] {
    * @return a JsObj
    */
   def asJsExp(inst: BaseRecord): JsExp = new JsExp {
-    lazy val toJsCmd = Printer.compact(render(asJValue(inst)))
+    lazy val toJsCmd = compactRender(asJValue(inst))
   }
 
   /** Encode a record instance into a JValue */

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftResponse.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftResponse.scala
@@ -64,14 +64,14 @@ case class CreatedResponse(xml: Node, mime: String, addlHeaders: List[(String, S
  */
 object CreatedResponse {
 
-  lazy val jsonPrinter: scala.text.Document => String =
+  lazy val jsonPrinter: JsonAST.JValue => String =
     LiftRules.jsonOutputConverter.vend
 
   def apply(json: JsonAST.JValue, addlHeaders: List[(String, String)]): LiftResponse = {
     val headers: List[(String, String)] = S.getResponseHeaders( Nil ) ++  addlHeaders
 
     new JsonResponse(new JsExp {
-      lazy val toJsCmd = jsonPrinter(JsonAST.render(json))
+      lazy val toJsCmd = jsonPrinter(json)
     }, headers, Nil, 201)
   }
 
@@ -302,11 +302,11 @@ object JsonResponse {
 
   def apply(_json: JsonAST.JValue, _headers: List[(String, String)], _cookies: List[HTTPCookie], code: Int): LiftResponse = {
     new JsonResponse(new JsExp {
-      lazy val toJsCmd = jsonPrinter(JsonAST.render((_json)))
+      lazy val toJsCmd = jsonPrinter(_json)
     }, _headers, _cookies, code)
   }
 
-  lazy val jsonPrinter: scala.text.Document => String = 
+  lazy val jsonPrinter: JsonAST.JValue => String = 
     LiftRules.jsonOutputConverter.vend
 }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -233,10 +233,11 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   val jsonOutputConverter = new FactoryMaker[JsonAST.JValue => String]({
     import json.{prettyRender, compactRender}
 
-    if (Props.devMode)
+    if (Props.devMode) {
       prettyRender _
-    else
+    } else {
       compactRender _
+    }
   }){}
 
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -28,6 +28,7 @@ import js._
 import JE._
 import JsCmds._
 import auth._
+import json._
 
 import scala.xml._
 import java.util.{Locale, TimeZone, ResourceBundle, Date}
@@ -224,14 +225,19 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   val sessionInactivityTimeout = new FactoryMaker[Box[Long]](Empty){}
 
   /**
-   * The function that converts a scala.text.Document to
-   * a String (used for JsonAST.JValue to text convertion.
-   * By default, use Printer.pretty for dev mode and
-   * Printer.compact for other modes
+   * The function that converts a JValue to
+   * a String.
+   *
+   * By default, use prettyRender for dev mode and compactRender for other modes.
    */
-  val jsonOutputConverter = new FactoryMaker[scala.text.Document => String]({
-    import json.Printer
-    if (Props.devMode) Printer.pretty _ else Printer.compact _}){}
+  val jsonOutputConverter = new FactoryMaker[JsonAST.JValue => String]({
+    import json.{prettyRender, compactRender}
+
+    if (Props.devMode)
+      prettyRender _
+    else
+      compactRender _
+  }){}
 
 
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2133,7 +2133,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
               case jsCmd: JsCmd => partialUpdate(JsCmds.JsSchedule(JsCmds.JsTry(jsCmd, false)))
               case jsExp: JsExp => partialUpdate(JsCmds.JsSchedule(JsCmds.JsTry(jsExp.cmd, false)))
               case jv: JsonAST.JValue => {
-                val s: String = json.pretty(json.render(jv))
+                val s: String = json.prettyRender(jv)
                 partialUpdate(JsCmds.JsSchedule(JsCmds.JsTry(JsRaw(toCall+"("+s+")").cmd, false)))
               }
               case x: AnyRef => {
@@ -2593,7 +2593,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
           case jsExp: JsExp => partialUpdate(JsCmds.JsSchedule(JsCmds.JsTry(jsExp.cmd, false)))
 
           case ItemMsg(guid, value) =>
-            partialUpdate(JsCmds.JsSchedule(JsRaw(s"lift.sendEvent(${guid.encJs}, {'success': ${Printer.compact(JsonAST.render(value))}} )").cmd))
+            partialUpdate(JsCmds.JsSchedule(JsRaw(s"lift.sendEvent(${guid.encJs}, {'success': ${compactRender(value)}} )").cmd))
           case DoneMsg(guid) =>
             partialUpdate(JsCmds.JsSchedule(JsRaw(s"lift.sendEvent(${guid.encJs}, {'done': true} )").cmd))
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -138,7 +138,7 @@ object JsExp {
   import json._
 
   implicit def jValueToJsExp(jv: JValue): JsExp = new JsExp {
-    lazy val toJsCmd = Printer.compact(JsonAST.render(jv))
+    lazy val toJsCmd = compactRender(jv)
   }
 
   implicit def strToJsExp(str: String): JE.Str = JE.Str(str)


### PR DESCRIPTION
**This is a work-in-progress branch.**

This branch is focused on hitting two birds with one stone:

1. Removing the use of the deprecated `scala.text.Document` intermediary format for JSON.
2. Providing more flexible JSON rendering settings that permit options like having spaces between field names and values in JSON objects.

We already put in a good bit of work to implement `compactRender` in the `JsonAST`, and with some trivial changes it was possible to implement a `prettyRender` that uses the same pipeline with different options. My hypothesis is that by eliminating the need for an intermediary format we'll see similar performance gains during pretty rendering that we did for compact rendering using `compactRender`.

I'm opening this early so people can start taking a look if they are interested, but there's still a lot I need to do here before I consider this ready to ship. Roughly in this order:

- [x] Quantify the performance impact of these changes.
- [x] Open a thread on the ML to discuss the removal of any intermediary format, and solicit feedback on the performance impact. [See the thread.](https://groups.google.com/d/msg/liftweb/UGwy7T9-Y6s/yDUOdBuSKxkJ)
- [x] Figure out a good way to write JSON to a `Writer`.
- [x] Figure out the upgrade path from 2.6, which will likely include adding back some code I've removed with deprecation warnings.
- [x] File a ticket for Lift 3.1 to rip out the things we mark as deprecated here.
- [x] Get tests working again.

More to come!

closes #1681