### PR TITLE
High Wire: Fix appendJs when invoked from inside a toJsCmd def

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
@@ -719,7 +719,7 @@ trait BaseCometActor extends LiftActor with LiftCometActor with CssBindImplicits
                   case e: Exception => reportError("Message dispatch for " + in, e)
                 }
 
-                val updatedJs = S.jsToAppend
+                val updatedJs = S.jsToAppend(clearAfterReading = true)
                 if (updatedJs.nonEmpty) {
                   partialUpdate(updatedJs)
                 }

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -74,7 +74,7 @@ private[http] trait LiftMerge {
       LiftRules.javaScriptSettings.vend().map { settingsFn =>
         LiftJavaScript.initCmd(settingsFn(this))
       }.toList ++
-      S.jsToAppend ++
+      S.jsToAppend() ++
       eventJs
 
     allJs.foldLeft(js.JsCmds.Noop)(_ & _)

--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -937,7 +937,7 @@ trait S extends HasParams with Loggable with UserAgentCalculator {
    *
    * @see appendJs
    */
-  def jsToAppend(): List[JsCmd] = {
+  def jsToAppend(clearAfterReading: Boolean = false): List[JsCmd] = {
     import js.JsCmds._
 
     val globalJs = _globalJsToAppend.is.toList
@@ -948,14 +948,22 @@ trait S extends HasParams with Loggable with UserAgentCalculator {
       }
     val cometJs = commandsForComets
 
-    globalJs ::: {
-      postPageJs ::: cometJs ::: _jsToAppend.is.toList match {
-        case Nil =>
-          Nil
-        case loadJs =>
-          List(OnLoad(loadJs))
+    val allJs =
+      globalJs ::: {
+        postPageJs ::: cometJs ::: _jsToAppend.is.toList match {
+          case Nil =>
+            Nil
+          case loadJs =>
+            List(OnLoad(loadJs))
+        }
       }
+
+    if (clearAfterReading) {
+      _globalJsToAppend(ListBuffer())
+      _jsToAppend(ListBuffer())
     }
+
+    allJs
   }
 
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -31,6 +31,16 @@ object JsCommands {
   def apply(in: JsExp) = new JsCommands(List(in.cmd))
 }
 
+/**
+ * A container for accumulating `[[JsCmd]]`s that need to be sent to the client.
+ * When `[[toResponse]]` is called to finalize the response, in addition to the
+ * JS passed directly to this instance, the commands in `[[S.jsToAppend]]` are
+ * also read and included in the response. Also in this process, all of the
+ * `JsCmd` instances have their `toJsCmd` methods called to convert them to a
+ * string.
+ * 
+ * @note The contents of `jsToAppend` are cleared in this process!
+ */
 class JsCommands(val reverseList: List[JsCmd]) {
   def &(in: JsCmd) = new JsCommands(in :: reverseList)
 


### PR DESCRIPTION
This fixes #1708 specifically.

`appendJs` should append JavaScript to be sent down with the
current request. However, if `appendJs` is called in a `toJsCmd`
method, and that method is defined as a `def`, not a `val`, then
`toJsCmd` will be called *after* the `jsToAppend` is read. This
means that this appended JS won't be sent down.

One place where this manifests is when a `JsCmd`'s `toJsCmd`
method sends down a rendered snippet that contains a Wiring
component (because Wiring uses `appendJs`). In this case, the
`appendJs` that Wiring does is evaluated during the `toJsCmd`
invocation, which means the JsCmd that is sent down misses it.

When we send down JS in bulk for an AJAX or comet response,
we wrap it in a `JsCommands`, which is a collector of `JsCmd`.
We then call its `toResponse` to get a `JavaScriptResponse`.

Before, we passed the `jsToAppend` to `JsCommands`, and then
let `JsCommands` run `toJsCmd` on everyone while constructing
the response. In this PR, let the `toResponse` method call `toJsCmd`
on all the commands that are explicitly being sent down, and then
we read `jsToAppend` and concatenate that on the end of the other
commands inside `toResponse`. In the process, we remove external
invocations of `jsToAppend`.

So as to avoid accidental duplicate send-downs of `jsToAppend`, we
give `jsToAppend` a `clearAfterReading` boolean that, when set to
`true` (it defaults to `false`), will clear the list of `JsCmd`s that need
to be appended. `JsCommands` and the `jsToAppend` reading in
`CometActor`, which sends down additional JS as a partial update,
both set it to `true`. Amongst other things, this ensures the two won't
both try to send down the same JS.

Still pending here: I (or someone else) need to test some of the
scenarios of `appendJs`, like calling it from inside a comet, from
a regular AJAX request, and from a regular screen render.