### PR TITLE
Loc loco: Fix behavior of MatchWithoutCurrentValue when stars aren't present in path.

### DIFF
--- a/persistence/proto/src/main/scala/net/liftweb/proto/Crudify.scala
+++ b/persistence/proto/src/main/scala/net/liftweb/proto/Crudify.scala
@@ -239,8 +239,7 @@ trait Crudify {
         override val rewrite: LocRewrite =
         Full(NamedPF(name) {
             case RewriteRequest(pp , _, _) if hasParamFor(pp, viewPath) =>
-              (RewriteResponse(viewPath),
-               findForParam(pp.wholePath.last).openOrThrowException("legacy code, it was open_!"))
+              (RewriteResponse(viewPath), findForParam(pp.wholePath.last))
           })
 
         override def calcTemplate = Full(viewTemplate)
@@ -286,8 +285,7 @@ trait Crudify {
           override val rewrite: LocRewrite =
           Full(NamedPF(name) {
               case RewriteRequest(pp , _, _) if hasParamFor(pp, editPath) =>
-                (RewriteResponse(editPath),
-                 findForParam(pp.wholePath.last).openOrThrowException("legacy code, it was open_!"))
+                (RewriteResponse(editPath), findForParam(pp.wholePath.last))
             })
 
           override def calcTemplate = Full(editTemplate)
@@ -410,8 +408,7 @@ trait Crudify {
           override val rewrite: LocRewrite =
           Full(NamedPF(name) {
             case RewriteRequest(pp , _, _) if hasParamFor(pp, deletePath) =>
-                (RewriteResponse(deletePath),
-                 findForParam(pp.wholePath.last).openOrThrowException("legacy code, it was open_!"))
+                (RewriteResponse(deletePath), findForParam(pp.wholePath.last))
             })
 
           override def calcTemplate = Full(deleteTemplate)

--- a/web/webkit/src/main/scala/net/liftweb/sitemap/Loc.scala
+++ b/web/webkit/src/main/scala/net/liftweb/sitemap/Loc.scala
@@ -166,7 +166,7 @@ trait Loc[T] {
 
   override def toString = "Loc("+name+", "+link+", "+text+", "+params+")"
 
-  type LocRewrite =  Box[PartialFunction[RewriteRequest, (RewriteResponse, T)]]
+  type LocRewrite =  Box[PartialFunction[RewriteRequest, (RewriteResponse, Box[T])]]
 
   def rewrite: LocRewrite = Empty
 
@@ -182,7 +182,7 @@ trait Loc[T] {
 
       def apply(in: RewriteRequest): RewriteResponse = {
         val (ret, param) = rw.apply(in)
-        requestValue.set(Full(param))
+        requestValue.set(param)
         ret
       }
     }

--- a/web/webkit/src/test/scala/net/liftweb/sitemap/LocSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/sitemap/LocSpec.scala
@@ -59,8 +59,22 @@ object LocSpec extends Specification  {
       }
     }
 
-    "should match a Req matching its Link when currentValue is Empty and MatchWithoutCurrentValue is a param" in {
+    "matchs a Req when currentValue is Empty, a * was used, and MatchWithoutCurrentValue is a param" in {
       val testMenu = Menu.param[Param]("Test", "Test", s => Empty, p => "bacon") / "foo" / "bar" / * >> Loc.MatchWithoutCurrentValue
+      val testSiteMap = SiteMap(testMenu)
+
+      val testLoc = testMenu.toLoc
+      val mockReq = new MockHttpServletRequest("http://test/foo/bar/123")
+
+      testS(mockReq) {
+        testReq(mockReq) { req =>
+          testLoc.doesMatch_?(req) mustEqual true
+        }
+      }
+    }
+
+    "matchs a Req when currentValue is Empty, and MatchWithoutCurrentValue is a param" in {
+      val testMenu = Menu.param[Param]("Test", "Test", s => Empty, p => "bacon") / "foo" / "bar" >> Loc.MatchWithoutCurrentValue
       val testSiteMap = SiteMap(testMenu)
 
       val testLoc = testMenu.toLoc

--- a/web/webkit/src/test/scala/net/liftweb/sitemap/LocSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/sitemap/LocSpec.scala
@@ -18,6 +18,7 @@ package net.liftweb
 package sitemap
 
 import common._
+import http._
 import mockweb._
   import MockWeb._
 import mocks._
@@ -82,7 +83,11 @@ object LocSpec extends Specification  {
 
       testS(mockReq) {
         testReq(mockReq) { req =>
-          testLoc.doesMatch_?(req) mustEqual true
+          val rrq = new RewriteRequest(req.path, GetRequest, req.request)
+          val rewriteFn = testLoc.rewrite.openOrThrowException("No rewrite function")
+
+          rewriteFn(rrq) must not(throwA[Exception])
+          rewriteFn(rrq)._2 must_== Empty
         }
       }
     }


### PR DESCRIPTION
This PR closes #1669 as it resolves the issue whereby given a menu declared like so:

```scala
    lazy val product = Menu.param[ProductInfo]("product", "Product Detail Page",
      id   => lookup(id),
      info => info.id.toString
      ) / "product" >> MatchWithoutCurrentValue >> FallbackToSearchPage
```

The `MatchWithoutCurrentValue` would not behave as expected because we hit a different processing pipeline due the absence of the star. Turns out that when we're working with `Menu`'s that lack a star they create a `RewriteResponse` internally. However, the code that creates that `RewriteResponse` is explicitly running the lookup function and failing to issue the rewrite if the function returns anything other than `Full`.

With these changes, we've resolved that issue. Now, `LocRewrite`s can be issued even when `T` can't be resolved, meaning the above code will work as expected.

Hat tip to @d6y for finding the original bug.

Some TODOs:

- [x] Figure out a way to test this thing.
- [x] Figure out what (if anything) we want to do for Lift 2.6. (though I suppose that doesn't block this getting merged into master)