### PR TITLE
Special case Option intermediary type in extraction.

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -188,16 +188,20 @@ object Extraction {
   private def extract0(json: JValue, clazz: Class[_], typeArgs: Seq[Class[_]])
                       (implicit formats: Formats): Any = {
     def mkMapping(clazz: Class[_], typeArgs: Seq[Class[_]])(implicit formats: Formats): Meta.Mapping = {
-      if (clazz == classOf[List[_]] || clazz == classOf[Set[_]] || clazz.isArray)
+      if (clazz == classOf[Option[_]] || clazz == classOf[List[_]] || clazz == classOf[Set[_]] || clazz.isArray) {
         Col(TypeInfo(clazz, None), mkMapping(typeArgs.head, typeArgs.tail))
-      else if (clazz == classOf[Map[_, _]])
+      } else if (clazz == classOf[Map[_, _]]) {
         Dict(mkMapping(typeArgs.tail.head, typeArgs.tail.tail))
-      else mappingOf(clazz, typeArgs)
+      } else {
+        mappingOf(clazz, typeArgs)
+      }
     }
-    if (clazz == classOf[Option[_]])
+
+    if (clazz == classOf[Option[_]]) {
       json.toOpt.map(extract0(_, mkMapping(typeArgs.head, typeArgs.tail)))
-    else 
+    } else {
       extract0(json, mkMapping(clazz, typeArgs))
+    }
   }
 
   def extract(json: JValue, target: TypeInfo)(implicit formats: Formats): Any = 
@@ -309,6 +313,13 @@ object Extraction {
       constructor(array)
     }
 
+    def newOption(root: JValue, m: Mapping) = {
+      root match {
+        case JNothing | JNull => None
+        case x => Option(build(x, m))
+      }
+    }
+
     def build(root: JValue, mapping: Mapping): Any = mapping match {
       case Value(targetType) => convert(root, targetType, formats)
       case c: Constructor => newInstance(c, root)
@@ -322,6 +333,7 @@ object Extraction {
         else if (c == classOf[Set[_]]) newCollection(root, m, a => Set(a: _*))
         else if (c.isArray) newCollection(root, m, mkTypedArray(c))
         else if (classOf[Seq[_]].isAssignableFrom(c)) newCollection(root, m, a => List(a: _*))
+        else if (c == classOf[Option[_]]) newOption(root, m)
         else fail("Expected collection but got " + m + " for class " + c)
       case Dict(m) => root match {
         case JObject(xs) => Map(xs.map(x => (x.name, build(x.value, m))): _*)

--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -282,11 +282,14 @@ object Extraction {
       }
 
       val custom = formats.customDeserializer(formats)
-      if (custom.isDefinedAt(constructor.targetType, json)) custom(constructor.targetType, json)
-      else json match {
-        case JNull => null
-        case JObject(TypeHint(t, fs)) => mkWithTypeHint(t, fs, constructor.targetType)
-        case _ => instantiate
+      if (custom.isDefinedAt(constructor.targetType, json)) {
+        custom(constructor.targetType, json)
+      } else {
+        json match {
+          case JNull => null
+          case JObject(TypeHint(t, fs)) => mkWithTypeHint(t, fs, constructor.targetType)
+          case _ => instantiate
+        }
       }
     }
 

--- a/core/json/src/main/scala/net/liftweb/json/Meta.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Meta.scala
@@ -163,16 +163,19 @@ private[json] object Meta {
       Arg(name, mapping, optional)
     }
 
-    if (primitive_?(clazz)) Value(rawClassOf(clazz))
-    else {
+    if (primitive_?(clazz)) {
+      Value(rawClassOf(clazz))
+    } else {
       mappings.memoize((clazz, typeArgs), { case (t, _) => 
         val c = rawClassOf(t)
         val (pt, typeInfo) = 
-          if (typeArgs.isEmpty) (t, TypeInfo(c, None))
-          else {
+          if (typeArgs.isEmpty) {
+            (t, TypeInfo(c, None))
+          } else {
             val t = mkParameterizedType(c, typeArgs)
             (t, TypeInfo(c, Some(t)))
           }
+
         Constructor(typeInfo, constructors(pt, Set(), None))         
       })
     }

--- a/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
@@ -59,7 +59,7 @@ object ExtractionBugs extends Specification {
     json.extract[Response] mustEqual Response(List(Map("one" -> 1, "two" -> 2)))
   }
 
-  "Extracting List[Option[String]]" in {
+  "Extraction should handle List[Option[String]]" in {
     val json = JsonParser.parse("""["one", "two", null]""")
     json.extract[List[Option[String]]] mustEqual List(Some("one"), Some("two"), None)
   }

--- a/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
@@ -59,6 +59,11 @@ object ExtractionBugs extends Specification {
     json.extract[Response] mustEqual Response(List(Map("one" -> 1, "two" -> 2)))
   }
 
+  "Extracting List[Option[String]]" in {
+    val json = JsonParser.parse("""["one", "two", null]""")
+    json.extract[List[Option[String]]] mustEqual List(Some("one"), Some("two"), None)
+  }
+
   case class Response(data: List[Map[String, Int]])
 
   case class OptionOfInt(opt: Option[Int])


### PR DESCRIPTION
This PR resolves a long-standing bug where trying to execute extraction when `Option` was an intermediary type on a `List` would cause fireworks and explosions. So, for example if you tried something like the following:

```scala
val json = JsonParser.parse("""["one", "two", null]""")
json.extract[List[Option[String]]]
```

You would get explosions and fireworks because lift-json would try to match up what you've provided to the constructor for `Option`. We now special case `Option` as a type of collection in the generation of the `Meta` ADT, and handle that case when constructing the concrete instance.

I'm not quite familiar enough with this code to know if this is a kludge or a clever hack. Would love some :eyes: from @jonifreeman (if you have time). Either way, I humbly submit this for review.

closes #1071 