### PR TITLE
Handle incorrect types wrapped in the Option.

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -360,15 +360,7 @@ object Extraction {
       } else {
         try {
           val x = build(root, mapping)
-          if (optional) {
-            if (x == null) {
-              None
-            } else {
-              Some(x)
-            }
-          } else {
-            x
-          }
+          if (optional) Option(x) else x 
         } catch { 
           case e @ MappingException(msg, _) =>
             if (optional && (root == JNothing || root == JNull)) {

--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -371,7 +371,7 @@ object Extraction {
           }
         } catch { 
           case e @ MappingException(msg, _) =>
-            if (optional) {
+            if (optional && (root == JNothing || root == JNull)) {
               None
             } else {
               fail("No usable value for " + path + "\n" + msg, e)

--- a/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
@@ -66,7 +66,10 @@ object ExtractionBugs extends Specification {
 
   "Extraction should fail if you're attempting to extract an option and you're given data of the wrong type" in {
     val json = JsonParser.parse("""{"opt": "hi"}""")
-    json.extract[OptionOfInt] must throwA[Exception]
+    json.extract[OptionOfInt] must throwA[MappingException]
+
+    val json2 = JString("hi")
+    json2.extract[Option[Int]] must throwA[MappingException]
   }
 
   case class Response(data: List[Map[String, Int]])

--- a/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
@@ -59,6 +59,11 @@ object ExtractionBugs extends Specification {
     json.extract[Response] mustEqual Response(List(Map("one" -> 1, "two" -> 2)))
   }
 
+  "Extraction should fail if you're attempting to extract an option and you're given data of the wrong type" in {
+    val json = JsonParser.parse("""{"opt": "hi"}""")
+    json.extract[OptionOfInt] must throwA[Exception]
+  }
+
   case class Response(data: List[Map[String, Int]])
 
   case class OptionOfInt(opt: Option[Int])

--- a/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
@@ -66,10 +66,14 @@ object ExtractionBugs extends Specification {
 
   "Extraction should fail if you're attempting to extract an option and you're given data of the wrong type" in {
     val json = JsonParser.parse("""{"opt": "hi"}""")
-    json.extract[OptionOfInt] must throwA[MappingException]
+    json.extract[OptionOfInt] must throwA[MappingException].like {
+      case e => e.getMessage mustEqual "No usable value for opt\nDo not know how to convert JString(hi) into int"
+    }
 
     val json2 = JString("hi")
-    json2.extract[Option[Int]] must throwA[MappingException]
+    json2.extract[Option[Int]] must throwA[MappingException].like {
+      case e => e.getMessage mustEqual "Do not know how to convert JString(hi) into int"
+    }
   }
 
   case class Response(data: List[Map[String, Int]])


### PR DESCRIPTION
~~This PR depends on #1717.~~

As described in #1425, previously if we were expecting an `Option[String]` but you provided an integer value for that key in an object, for example, we would just give you a `None` in that field. This isn't exactly desirable, since you probably generated that data somewhere else (maybe not Scala) expecting something to be in that key when you pipe it into Lift and try to deserialize it. So when we give you a `None` there we're not telling you that something has gone wrong.

So, this fixes that issue by checking to see whether or not what we're looking at is a `JNothing` or `JNull`. If it is, then hey - we didn't find anything and you get a `None`. If it's anything other than that you're a silly bear and gave us the wrong thing for what you're trying to instantiate. You get a `MappingException`!

closes #1425 