### PR TITLE
Json serialization any

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/Serialization.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Serialization.scala
@@ -34,22 +34,22 @@ object Serialization {
 
   /** Serialize to String.
    */
-  def write[A <: AnyRef](a: A)(implicit formats: Formats): String =
+  def write[A <: Any](a: A)(implicit formats: Formats): String =
     compactRender(Extraction.decompose(a)(formats))
 
   /** Serialize to Writer.
    */
-  def write[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W =
+  def write[A <: Any, W <: Writer](a: A, out: W)(implicit formats: Formats): W =
     Printer.compact(render(Extraction.decompose(a)(formats)), out)
 
   /** Serialize to String (pretty format).
    */
-  def writePretty[A <: AnyRef](a: A)(implicit formats: Formats): String =
+  def writePretty[A <: Any](a: A)(implicit formats: Formats): String =
     (writePretty(a, new StringWriter)(formats)).toString
 
   /** Serialize to Writer (pretty format).
    */
-  def writePretty[A <: AnyRef, W <: Writer](a: A, out: W)(implicit formats: Formats): W = 
+  def writePretty[A <: Any, W <: Writer](a: A, out: W)(implicit formats: Formats): W =
     Printer.pretty(render(Extraction.decompose(a)(formats)), out)
 
   /** Deserialize from a String.

--- a/core/json/src/test/scala/net/liftweb/json/SerializationExamples.scala
+++ b/core/json/src/test/scala/net/liftweb/json/SerializationExamples.scala
@@ -104,6 +104,12 @@ object SerializationExamples extends Specification {
     read[Unit](swrite( () )) mustEqual ()
   }
 
+  case class CharUnit(c:Char, u:Unit)
+  "The CharUnit serialization" in {
+    val obj = CharUnit('j', ())
+    read[CharUnit](swrite(obj)) mustEqual obj
+  }
+
   "Multidimensional list example" in {
     val ints = Ints(List(List(1, 2), List(3), List(4, 5)))
     val ser = swrite(ints)

--- a/core/json/src/test/scala/net/liftweb/json/SerializationExamples.scala
+++ b/core/json/src/test/scala/net/liftweb/json/SerializationExamples.scala
@@ -84,10 +84,6 @@ object SerializationExamples extends Specification {
     read[Symbol](swrite('j)) mustEqual 'j
   }
 
-  "Primitive Char serialization" in {
-    read[Char](swrite('j')) mustEqual 'j'
-  }
-
   "Primitive Short serialization" in {
     read[Short](swrite(88.shortValue)) mustEqual 88.shortValue
   }
@@ -98,6 +94,14 @@ object SerializationExamples extends Specification {
 
   "Primitive Boolean serialization" in {
     read[Boolean](swrite(false)) mustEqual false
+  }
+
+  "Primitive Char serialization" in {
+    read[Char](swrite('j')) mustEqual 'j'
+  }
+
+  "Primitive Unit serialization" in {
+    read[Unit](swrite( () )) mustEqual ()
   }
 
   "Multidimensional list example" in {

--- a/core/json/src/test/scala/net/liftweb/json/SerializationExamples.scala
+++ b/core/json/src/test/scala/net/liftweb/json/SerializationExamples.scala
@@ -53,10 +53,51 @@ object SerializationExamples extends Specification {
     read[Lotto](ser) mustEqual lotto
   }
 
-  "Primitive serialization example" in {
+  "Primitive-wrapping case class serialization example" in {
     val primitives = Primitives(124, 123L, 126.5, 127.5.floatValue, "128", 's, 125, 129.byteValue, true)
     val ser = swrite(primitives)
     read[Primitives](ser) mustEqual primitives
+  }
+
+  "Primitive Int serialization" in {
+    read[Int](swrite(42)) mustEqual 42
+  }
+
+  "Primitive Long serialization" in {
+    read[Long](swrite(42L)) mustEqual 42L
+  }
+
+  "Primitive Double serialization" in {
+    read[Double](swrite(3.14)) mustEqual 3.14
+  }
+
+  "Primitive Float serialization" in {
+    read[Float](swrite(3.14.floatValue)) mustEqual 3.14.floatValue
+  }
+
+  "Primitive String serialization" in {
+    val rt = "Roll Tide, Farmer!!"
+    read[String](swrite(rt)) mustEqual rt
+  }
+
+  "Symbol serialization" in {
+    read[Symbol](swrite('j)) mustEqual 'j
+  }
+
+  "Primitive Char serialization" in {
+    read[Char](swrite('j')) mustEqual 'j'
+  }
+
+  "Primitive Short serialization" in {
+    read[Short](swrite(88.shortValue)) mustEqual 88.shortValue
+  }
+
+  "Primitive Byte serialization" in {
+    read[Byte](swrite(129.byteValue)) mustEqual 129.byteValue
+  }
+
+  "Primitive Boolean serialization" in {
+    read[Boolean](swrite(false)) mustEqual false
   }
 
   "Multidimensional list example" in {

--- a/core/json/src/test/scala/net/liftweb/json/SerializationExamples.scala
+++ b/core/json/src/test/scala/net/liftweb/json/SerializationExamples.scala
@@ -75,15 +75,6 @@ object SerializationExamples extends Specification {
     read[Float](swrite(3.14.floatValue)) mustEqual 3.14.floatValue
   }
 
-  "Primitive String serialization" in {
-    val rt = "Roll Tide, Farmer!!"
-    read[String](swrite(rt)) mustEqual rt
-  }
-
-  "Symbol serialization" in {
-    read[Symbol](swrite('j)) mustEqual 'j
-  }
-
   "Primitive Short serialization" in {
     read[Short](swrite(88.shortValue)) mustEqual 88.shortValue
   }
@@ -96,18 +87,13 @@ object SerializationExamples extends Specification {
     read[Boolean](swrite(false)) mustEqual false
   }
 
-  "Primitive Char serialization" in {
-    read[Char](swrite('j')) mustEqual 'j'
+  "String serialization" in {
+    val rt = "Roll Tide, Farmer!!"
+    read[String](swrite(rt)) mustEqual rt
   }
 
-  "Primitive Unit serialization" in {
-    read[Unit](swrite( () )) mustEqual ()
-  }
-
-  case class CharUnit(c:Char, u:Unit)
-  "The CharUnit serialization" in {
-    val obj = CharUnit('j', ())
-    read[CharUnit](swrite(obj)) mustEqual obj
+  "Symbol serialization" in {
+    read[Symbol](swrite('j)) mustEqual 'j
   }
 
   "Multidimensional list example" in {


### PR DESCRIPTION
This should be an easy code review.  It just opens up the json serialization to take `Any` rather than restricting the input to `AnyRef`.  Relevant ML thread [here](https://groups.google.com/forum/#!topic/liftweb/imOBZ3W6vjM).