### PR TITLE
Squashing the logError JS stackoverflow

### DIFF
--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -581,6 +581,7 @@
           doCycleIn200();
         });
       },
+      defaultLogError: function(msg) { consoleOrAlert(msg) },
       logError: function() { settings.logError.apply(this, arguments) },
       onEvent: function() { settings.onEvent.apply(this, arguments) },
       ajax: appendToQueue,

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -898,7 +898,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    *   LiftRules.jsLogFunc = Full(v => JE.Call("alert",v).cmd)
    */
   @volatile var jsLogFunc: Box[JsVar => JsCmd] =
-    if (Props.devMode) Full(v => JE.Call("lift.logError", v))
+    if (Props.devMode) Full(v => JE.Call("lift.defaultLogError", v))
     else Empty
 
   /**


### PR DESCRIPTION
Resolves #1720.

One other thought I had while under the hood of this one.  [Several other settings-based JS functions log an error that they are to be defined in settings](https://github.com/lift/framework/blob/09fe944fd314ba52447a5e85df25f12d2b130121/web/webkit/src/main/resources/toserve/lift.js#L61-L73).  We could consider doing the same for `logError` to be consistent.  I wasn't convinced this would be the right move, so I didn't bother touching it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/lift/framework/1721)
<!-- Reviewable:end -->
