### PR TITLE
Props enhanced

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -89,18 +89,21 @@ object Props extends Logger {
    * @param props Arbitrary map of property key -> property value
    */
   def prepend(props:Map[String, String]):Unit = {}
+  def prepend(props:java.util.Map[Object, Object]):Unit = {}
 
   /**
    * Updates Props to find property values in the argument AFTER first looking in the standard Lift prop files.
    * @param props Arbitrary map of property key -> property value
    */
   def append(props:Map[String, String]):Unit = {}
+  def append(props:java.util.Map[Object, Object]):Unit = {}
 
   /**
    * Updates Props to find interpolated values in the argument.
    * @param props
    */
   def appendInterpolator(props:Map[String, String]):Unit = {}
+  def appendInterpolator(props:java.util.Map[Object, Object]):Unit = {}
 
   /**
    * Enumeration of available run modes.

--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -20,6 +20,7 @@ package util
 import java.net.InetAddress
 import java.util.Properties
 import java.io.InputStream
+import scala.collection.JavaConverters._
 import Helpers._
 import common._
 
@@ -88,21 +89,21 @@ object Props extends Logger {
    * Updates Props to find property values in the argument BEFORE looking in the standard Lift prop files.
    * @param props Arbitrary map of property key -> property value
    */
-  def prepend(props:Map[String, String]):Unit = {}
+  def prepend(props:Map[String, String]):Unit = prepend(props.asJava.asInstanceOf[java.util.Map[Object, Object]])
   def prepend(props:java.util.Map[Object, Object]):Unit = {}
 
   /**
    * Updates Props to find property values in the argument AFTER first looking in the standard Lift prop files.
    * @param props Arbitrary map of property key -> property value
    */
-  def append(props:Map[String, String]):Unit = {}
+  def append(props:Map[String, String]):Unit = append(props.asJava.asInstanceOf[java.util.Map[Object, Object]])
   def append(props:java.util.Map[Object, Object]):Unit = {}
 
   /**
    * Updates Props to find interpolated values in the argument.
    * @param props
    */
-  def appendInterpolator(props:Map[String, String]):Unit = {}
+  def appendInterpolator(props:Map[String, String]):Unit = appendInterpolator(props.asJava.asInstanceOf[java.util.Map[Object, Object]])
   def appendInterpolator(props:java.util.Map[Object, Object]):Unit = {}
 
   /**
@@ -350,11 +351,17 @@ object Props extends Logger {
     }
   }
 
+  private var prepended:List[java.util.Map[Object, Object]] = Nil
+  private var appended:List[java.util.Map[Object, Object]] = Nil
+  private var interpolators:List[java.util.Map[Object, Object]] = Nil
+
   /**
    * Resets the Props stacks to allow for isolated unit tests
    */
   private [util] def testReset() = {
-
+    prepended = Nil
+    appended = Nil
+    interpolators = Nil
   }
 }
 

--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -117,15 +117,15 @@ object Props extends Logger {
    * Updates Props to find property values in the argument BEFORE looking in the standard Lift prop files.
    * @param props Arbitrary map of property key -> property value
    */
-  def prepend(props:Map[String, String]):Unit = prepend(props.asJava.asInstanceOf[java.util.Map[Object, Object]])
-  def prepend(props:java.util.Map[Object, Object]):Unit = prepended = props :: prepended
+  def prependSource(props:Map[String, String]):Unit = prependSource(props.asJava.asInstanceOf[java.util.Map[Object, Object]])
+  def prependSource(props:java.util.Map[Object, Object]):Unit = prepended = props :: prepended
 
   /**
    * Updates Props to find property values in the argument AFTER first looking in the standard Lift prop files.
    * @param props Arbitrary map of property key -> property value
    */
-  def append(props:Map[String, String]):Unit = append(props.asJava.asInstanceOf[java.util.Map[Object, Object]])
-  def append(props:java.util.Map[Object, Object]):Unit = appended = appended :+ props
+  def appendSource(props:Map[String, String]):Unit = appendSource(props.asJava.asInstanceOf[java.util.Map[Object, Object]])
+  def appendSource(props:java.util.Map[Object, Object]):Unit = appended = appended :+ props
 
   /**
    * Updates Props to find interpolated values in the argument.

--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -85,6 +85,24 @@ object Props extends Logger {
   }
 
   /**
+   * Updates Props to find property values in the argument BEFORE looking in the standard Lift prop files.
+   * @param props Arbitrary map of property key -> property value
+   */
+  def prepend(props:Map[String, String]):Unit = {}
+
+  /**
+   * Updates Props to find property values in the argument AFTER first looking in the standard Lift prop files.
+   * @param props Arbitrary map of property key -> property value
+   */
+  def append(props:Map[String, String]):Unit = {}
+
+  /**
+   * Updates Props to find interpolated values in the argument.
+   * @param props
+   */
+  def appendInterpolator(props:Map[String, String]):Unit = {}
+
+  /**
    * Enumeration of available run modes.
    */
   object RunModes extends Enumeration {

--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -41,9 +41,9 @@ private[util] trait Props extends Logger {
       .map(interpolate)
   }
 
-  private val interpolateRegex = """(.*?)\Q${\E(.*?)\Q}\E([^$]*)""".r
+  private[this] val interpolateRegex = """(.*?)\Q${\E(.*?)\Q}\E([^$]*)""".r
 
-  private def interpolate(value: String): String = {
+  private[this] def interpolate(value: String): String = {
     def lookup(key: String) = {
       lockedInterpolationValues
         .flatMap(_.get(key))

--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -349,5 +349,12 @@ object Props extends Logger {
         Map()
     }
   }
+
+  /**
+   * Resets the Props stacks to allow for isolated unit tests
+   */
+  private [util] def testReset() = {
+
+  }
 }
 

--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -54,7 +54,14 @@ object Props extends Logger {
    * @param name key for the property to get
    * @return the value of the property if defined
    */
-  def get(name: String): Box[String] = Box(props.get(name))
+  def get(name: String): Box[String] = {
+    val tries:List[Box[Object]] =
+      prepended.map(m => Box.legacyNullTest(m get name)) ++
+      (props.get(name).toBox ::
+      appended.map(m => Box.legacyNullTest(m get name)))
+
+    tries.find(_.isDefined).getOrElse(Empty).map(_.toString)
+  }
 
   // def apply(name: String): String = props(name)
 
@@ -72,7 +79,7 @@ object Props extends Logger {
    * @return the subset of strings in 'what' that do not correspond to
    * keys for available properties.
    */
-  def require(what: String*) = what.filter(!props.contains(_))
+  def require(what: String*) = what.filter(get(_).isEmpty)
 
   /**
    * Ensure that all of the specified properties exist; throw an exception if

--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -63,14 +63,14 @@ object Props extends Logger {
     tries.find(_.isDefined).getOrElse(Empty).map(interpolate)
   }
 
-  private val INTERPOLATE = """(.*?)\Q${\E(.*?)\Q}\E([^$]*)""".r
+  private val interpolateRegex = """(.*?)\Q${\E(.*?)\Q}\E([^$]*)""".r
   private def interpolate(v:Object):String = {
     def lookup(key:String) = {
       val tries = interpolators.map(m => Box.legacyNullTest(m get key))
       tries.find(_.isDefined).getOrElse(Empty)
     }
     val interpolated = for {
-      m <- INTERPOLATE findAllMatchIn v.toString
+      m <- interpolateRegex findAllMatchIn v.toString
     } yield {
       val before = m group 1
       val key    = m group 2

--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -60,11 +60,11 @@ object Props extends Logger {
 
   def getInt(name: String): Box[Int] = get(name).map(toInt) // toInt(props.get(name))
   def getInt(name: String, defVal: Int): Int = getInt(name) openOr defVal // props.get(name).map(toInt(_)) getOrElse defVal
-  def getLong(name: String): Box[Long] = props.get(name).flatMap(asLong)
+  def getLong(name: String): Box[Long] = get(name).flatMap(asLong)
   def getLong(name: String, defVal: Long): Long = getLong(name) openOr defVal // props.get(name).map(toLong(_)) getOrElse defVal
-  def getBool(name: String): Box[Boolean] = props.get(name).map(toBoolean) // (props.get(name))
+  def getBool(name: String): Box[Boolean] = get(name).map(toBoolean) // (props.get(name))
   def getBool(name: String, defVal: Boolean): Boolean = getBool(name) openOr defVal // props.get(name).map(toBoolean(_)) getOrElse defVal
-  def get(name: String, defVal: String) = props.get(name) getOrElse defVal
+  def get(name: String, defVal: String):String = get(name) getOrElse defVal
 
   /**
    * Determine whether the specified properties exist.
@@ -90,21 +90,21 @@ object Props extends Logger {
    * @param props Arbitrary map of property key -> property value
    */
   def prepend(props:Map[String, String]):Unit = prepend(props.asJava.asInstanceOf[java.util.Map[Object, Object]])
-  def prepend(props:java.util.Map[Object, Object]):Unit = {}
+  def prepend(props:java.util.Map[Object, Object]):Unit = prepended = props :: prepended
 
   /**
    * Updates Props to find property values in the argument AFTER first looking in the standard Lift prop files.
    * @param props Arbitrary map of property key -> property value
    */
   def append(props:Map[String, String]):Unit = append(props.asJava.asInstanceOf[java.util.Map[Object, Object]])
-  def append(props:java.util.Map[Object, Object]):Unit = {}
+  def append(props:java.util.Map[Object, Object]):Unit = appended = appended :+ props
 
   /**
    * Updates Props to find interpolated values in the argument.
    * @param props
    */
   def appendInterpolator(props:Map[String, String]):Unit = appendInterpolator(props.asJava.asInstanceOf[java.util.Map[Object, Object]])
-  def appendInterpolator(props:java.util.Map[Object, Object]):Unit = {}
+  def appendInterpolator(props:java.util.Map[Object, Object]):Unit = interpolators = interpolators :+ props
 
   /**
    * Enumeration of available run modes.

--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -64,23 +64,23 @@ object Props extends Logger {
   }
 
   private val interpolateRegex = """(.*?)\Q${\E(.*?)\Q}\E([^$]*)""".r
-  private def interpolate(v:Object):String = {
+  private def interpolate(value:Object):String = {
     def lookup(key:String) = {
       val tries = interpolators.map(m => Box.legacyNullTest(m get key))
       tries.find(_.isDefined).getOrElse(Empty)
     }
     val interpolated = for {
-      m <- interpolateRegex findAllMatchIn v.toString
+      m <- interpolateRegex findAllMatchIn value.toString
     } yield {
-      val before = m group 1
-      val key    = m group 2
-      val after  = m group 3
-      val value  = lookup(key).openOr(v.toString)
+      val before   = m group 1
+      val key      = m group 2
+      val after    = m group 3
+      val lookedUp = lookup(key).openOr(value.toString)
 
-      before + value + after
+      before + lookedUp + after
     }
 
-    if(interpolated.isEmpty) v.toString
+    if(interpolated.isEmpty) value.toString
     else interpolated.mkString
   }
 

--- a/core/util/src/test/resources/test.default.props
+++ b/core/util/src/test/resources/test.default.props
@@ -4,3 +4,7 @@ default.jndi.name=from_props
 jetty.port=${PORT}
 db.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/MYDB
 omniauth.baseurl=http://liftweb.net/
+
+an.int=42
+a.long=9223372036854775807
+a.boolean=true

--- a/core/util/src/test/resources/test.default.props
+++ b/core/util/src/test/resources/test.default.props
@@ -1,1 +1,5 @@
 default.jndi.name=from_props
+
+# Used in net.liftweb.util.PropsSpecs
+jetty.port=${PORT}
+db.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/MYDB

--- a/core/util/src/test/resources/test.default.props
+++ b/core/util/src/test/resources/test.default.props
@@ -3,3 +3,4 @@ default.jndi.name=from_props
 # Used in net.liftweb.util.PropsSpecs
 jetty.port=${PORT}
 db.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/MYDB
+omniauth.baseurl=http://liftweb.net/

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -71,7 +71,7 @@ object PropsSpec extends Specification {
     "Prefer prepended properties to the test.default.props" in {
       val testProps = TestProps()
 
-      testProps.prependSource(Map("jetty.port" -> "8080"))
+      testProps.prependProvider(Map("jetty.port" -> "8080"))
       val port = testProps.getInt("jetty.port")
 
       port must_== Full(8080)
@@ -82,7 +82,7 @@ object PropsSpec extends Specification {
 
       System.setProperty("omniauth.baseurl", "http://google.com")
 
-      testProps.prependSource(sys.props)
+      testProps.prependProvider(sys.props)
       val baseurl = testProps.get("omniauth.baseurl")
 
       baseurl must_== Full("http://google.com")
@@ -92,7 +92,7 @@ object PropsSpec extends Specification {
       val testProps = TestProps()
 
       System.setProperty("omniauth.baseurl", "http://google.com")
-      testProps.prependSource(sys.props)
+      testProps.prependProvider(sys.props)
       System.setProperty("omniauth.baseurl", "http://ebay.com")
       val baseurl = testProps.get("omniauth.baseurl")
 
@@ -102,7 +102,7 @@ object PropsSpec extends Specification {
     "Find properties in appended maps when not defined in test.default.props" in {
       val testProps = TestProps()
 
-      testProps.appendSource(Map("new.prop" -> "new.value"))
+      testProps.appendProvider(Map("new.prop" -> "new.value"))
       val prop = testProps.get("new.prop")
 
       prop must_== Full("new.value")
@@ -117,7 +117,7 @@ object PropsSpec extends Specification {
     "Interpolate values from the given interpolator" in {
       val testProps = TestProps()
 
-      testProps.appendInterpolator(Map("PORT" -> "8080"))
+      testProps.appendInterpolationValues(Map("PORT" -> "8080"))
       val port = testProps.getInt("jetty.port")
 
       port must_== Full(8080)
@@ -126,7 +126,7 @@ object PropsSpec extends Specification {
     "Interpolate multiple values in a string from the given interpolator" in {
       val testProps = TestProps()
 
-      testProps.appendInterpolator(Map("DB_HOST" -> "localhost", "DB_PORT" -> "3306"))
+      testProps.appendInterpolationValues(Map("DB_HOST" -> "localhost", "DB_PORT" -> "3306"))
       val url = testProps.get("db.url")
 
       url must_== Full("jdbc:mysql://localhost:3306/MYDB")
@@ -135,14 +135,14 @@ object PropsSpec extends Specification {
     "Find properties in append for require()" in {
       val testProps = TestProps()
 
-      testProps.appendSource(Map("new.prop" -> "new.value"))
+      testProps.appendProvider(Map("new.prop" -> "new.value"))
       testProps.require("new.prop") must_== Nil
     }
 
     "Find properties in prepend for require()" in {
       val testProps = TestProps()
 
-      testProps.prependSource(Map("new.prop" -> "new.value"))
+      testProps.prependProvider(Map("new.prop" -> "new.value"))
       testProps.require("new.prop") must_== Nil
     }
   }

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -119,6 +119,14 @@ object PropsSpec extends Specification with AfterEach {
       port must_== Full(8080)
     }
 
+    "Interpolate multiple values in a string from the given interpolator" in {
+      Props.testReset()
+      Props.appendInterpolator(Map("DB_HOST" -> "localhost", "DB_PORT" -> "3306"))
+      val url = Props.get("db.url")
+
+      url must_== Full("jdbc:mysql://localhost:3306/MYDB")
+    }
+
     "Find properties in append for require()" in {
       Props.testReset()
       Props.append(Map("new.prop" -> "new.value"))

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -53,6 +53,18 @@ object PropsSpec extends Specification with After {
       Props.autoDetectRunModeFn.get must_== before
     }
 
+    "Parse and cast to int" in {
+      Props.getInt("an.int") must_== Full(42)
+    }
+
+    "Parse and cast to long" in {
+      Props.getLong("a.long") must_== Full(9223372036854775807L)
+    }
+
+    "Parse and cast to boolean" in {
+      Props.getBool("a.boolean") must_== Full(true)
+    }
+
     "Prefer prepended properties to the test.default.props" in {
       Props.prepend(Map("jetty.port" -> "8080"))
       val port = Props.getInt("jetty.port")

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -71,7 +71,7 @@ object PropsSpec extends Specification with AfterEach {
 
     "Prefer prepended properties to the test.default.props" in {
       Props.testReset()
-      Props.prepend(Map("jetty.port" -> "8080"))
+      Props.prependSource(Map("jetty.port" -> "8080"))
       val port = Props.getInt("jetty.port")
 
       port must_== Full(8080)
@@ -80,7 +80,7 @@ object PropsSpec extends Specification with AfterEach {
     "Prefer prepended System.properties to the test.default.props" in {
       Props.testReset()
       System.setProperty("omniauth.baseurl", "http://google.com")
-      Props.prepend(System.getProperties)
+      Props.prependSource(System.getProperties)
       val baseurl = Props.get("omniauth.baseurl")
 
       baseurl must_== Full("http://google.com")
@@ -89,7 +89,7 @@ object PropsSpec extends Specification with AfterEach {
     "Read through to System.properties, correctly handling mutation" in {
       Props.testReset()
       System.setProperty("omniauth.baseurl", "http://google.com")
-      Props.prepend(System.getProperties)
+      Props.prependSource(System.getProperties)
       System.setProperty("omniauth.baseurl", "http://ebay.com")
       val baseurl = Props.get("omniauth.baseurl")
 
@@ -98,7 +98,7 @@ object PropsSpec extends Specification with AfterEach {
 
     "Find properties in appended maps when not defined in test.default.props" in {
       Props.testReset()
-      Props.append(Map("new.prop" -> "new.value"))
+      Props.appendSource(Map("new.prop" -> "new.value"))
       val prop = Props.get("new.prop")
 
       prop must_== Full("new.value")
@@ -129,13 +129,13 @@ object PropsSpec extends Specification with AfterEach {
 
     "Find properties in append for require()" in {
       Props.testReset()
-      Props.append(Map("new.prop" -> "new.value"))
+      Props.appendSource(Map("new.prop" -> "new.value"))
       Props.require("new.prop") must_== Nil
     }
 
     "Find properties in prepend for require()" in {
       Props.testReset()
-      Props.prepend(Map("new.prop" -> "new.value"))
+      Props.prependSource(Map("new.prop" -> "new.value"))
       Props.require("new.prop") must_== Nil
     }
   }

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -57,6 +57,23 @@ object PropsSpec extends Specification {
       port must_== Full(8080)
     }
 
+    "Prefer prepended System.properties to the test.default.props" in {
+      System.setProperty("omniauth.baseurl", "http://google.com")
+      Props.prepend(System.getProperties)
+      val baseurl = Props.get("omniauth.baseurl")
+
+      baseurl must_== Full("http://google.com")
+    }
+
+    "Read through to System.properties, correctly handling mutation" in {
+      System.setProperty("omniauth.baseurl", "http://google.com")
+      Props.prepend(System.getProperties)
+      System.setProperty("omniauth.baseurl", "http://ebay.com")
+      val baseurl = Props.get("omniauth.baseurl")
+
+      baseurl must_== Full("http://ebay.com")
+    }
+
     "Find properties in appended maps when not defined in test.default.props" in {
       Props.append(Map("new.prop" -> "new.value"))
       val prop = Props.get("new.prop")

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -17,6 +17,7 @@
 package net.liftweb
 package util
 
+import net.liftweb.common.Full
 import org.specs2.mutable.Specification
 import Props.RunModes._
 
@@ -47,6 +48,33 @@ object PropsSpec extends Specification {
       Props.autoDetectRunModeFn.allowModification must_== false
       Props.autoDetectRunModeFn.set(() => Test) must_== false
       Props.autoDetectRunModeFn.get must_== before
+    }
+
+    "Prefer prepended properties to the test.default.props" in {
+      Props.prepend(Map("jetty.port" -> "8080"))
+      val port = Props.getInt("jetty.port")
+
+      port must_== Full(8080)
+    }
+
+    "Find properties in appended maps when not defined in test.default.props" in {
+      Props.append(Map("new.prop" -> "new.value"))
+      val prop = Props.get("new.prop")
+
+      prop must_== Full("new.value")
+    }
+
+    "Not interpolate values when no interpolator is given" in {
+      val port = Props.get("jetty.port")
+
+      port must_== Full("${PORT}")
+    }
+
+    "Interpolate values from the given interpolator" in {
+      Props.appendInterpolator(Map("PORT" -> "8080"))
+      val port = Props.getInt("jetty.port")
+
+      port must_== Full(8080)
     }
   }
 }

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -20,9 +20,6 @@ package util
 import org.specs2.mutable.Specification
 import Props.RunModes._
 
-/**
- * Systems under specification for Lift Mailer.
- */
 object PropsSpec extends Specification {
   "Props Specification".title
   sequential

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -19,13 +19,14 @@ package util
 
 import net.liftweb.common.Full
 import org.specs2.mutable.Specification
+import org.specs2.specification.AfterEach
 import Props.RunModes._
-import org.specs2.specification.After
 
-object PropsSpec extends Specification with After {
+object PropsSpec extends Specification with AfterEach {
   "Props Specification".title
   sequential
 
+  // TODO: Why doesn't this work??
   def after = Props.testReset()
 
   "Props" should {
@@ -54,18 +55,22 @@ object PropsSpec extends Specification with After {
     }
 
     "Parse and cast to int" in {
+      Props.testReset()
       Props.getInt("an.int") must_== Full(42)
     }
 
     "Parse and cast to long" in {
+      Props.testReset()
       Props.getLong("a.long") must_== Full(9223372036854775807L)
     }
 
     "Parse and cast to boolean" in {
+      Props.testReset()
       Props.getBool("a.boolean") must_== Full(true)
     }
 
     "Prefer prepended properties to the test.default.props" in {
+      Props.testReset()
       Props.prepend(Map("jetty.port" -> "8080"))
       val port = Props.getInt("jetty.port")
 
@@ -73,6 +78,7 @@ object PropsSpec extends Specification with After {
     }
 
     "Prefer prepended System.properties to the test.default.props" in {
+      Props.testReset()
       System.setProperty("omniauth.baseurl", "http://google.com")
       Props.prepend(System.getProperties)
       val baseurl = Props.get("omniauth.baseurl")
@@ -81,6 +87,7 @@ object PropsSpec extends Specification with After {
     }
 
     "Read through to System.properties, correctly handling mutation" in {
+      Props.testReset()
       System.setProperty("omniauth.baseurl", "http://google.com")
       Props.prepend(System.getProperties)
       System.setProperty("omniauth.baseurl", "http://ebay.com")
@@ -90,6 +97,7 @@ object PropsSpec extends Specification with After {
     }
 
     "Find properties in appended maps when not defined in test.default.props" in {
+      Props.testReset()
       Props.append(Map("new.prop" -> "new.value"))
       val prop = Props.get("new.prop")
 
@@ -97,12 +105,14 @@ object PropsSpec extends Specification with After {
     }
 
     "Not interpolate values when no interpolator is given" in {
+      Props.testReset()
       val port = Props.get("jetty.port")
 
       port must_== Full("${PORT}")
     }
 
     "Interpolate values from the given interpolator" in {
+      Props.testReset()
       Props.appendInterpolator(Map("PORT" -> "8080"))
       val port = Props.getInt("jetty.port")
 
@@ -110,11 +120,13 @@ object PropsSpec extends Specification with After {
     }
 
     "Find properties in append for require()" in {
+      Props.testReset()
       Props.append(Map("new.prop" -> "new.value"))
       Props.require("new.prop") must_== Nil
     }
 
     "Find properties in prepend for require()" in {
+      Props.testReset()
       Props.prepend(Map("new.prop" -> "new.value"))
       Props.require("new.prop") must_== Nil
     }

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -20,10 +20,13 @@ package util
 import net.liftweb.common.Full
 import org.specs2.mutable.Specification
 import Props.RunModes._
+import org.specs2.specification.After
 
-object PropsSpec extends Specification {
+object PropsSpec extends Specification with After {
   "Props Specification".title
   sequential
+
+  def after = Props.testReset()
 
   "Props" should {
     "Detect test mode correctly" in {

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -80,7 +80,7 @@ object PropsSpec extends Specification with AfterEach {
     "Prefer prepended System.properties to the test.default.props" in {
       Props.testReset()
       System.setProperty("omniauth.baseurl", "http://google.com")
-      Props.prependSource(System.getProperties)
+      Props.prependSource(sys.props)
       val baseurl = Props.get("omniauth.baseurl")
 
       baseurl must_== Full("http://google.com")
@@ -89,7 +89,7 @@ object PropsSpec extends Specification with AfterEach {
     "Read through to System.properties, correctly handling mutation" in {
       Props.testReset()
       System.setProperty("omniauth.baseurl", "http://google.com")
-      Props.prependSource(System.getProperties)
+      Props.prependSource(sys.props)
       System.setProperty("omniauth.baseurl", "http://ebay.com")
       val baseurl = Props.get("omniauth.baseurl")
 

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -108,5 +108,15 @@ object PropsSpec extends Specification with After {
 
       port must_== Full(8080)
     }
+
+    "Find properties in append for require()" in {
+      Props.append(Map("new.prop" -> "new.value"))
+      Props.require("new.prop") must_== Nil
+    }
+
+    "Find properties in prepend for require()" in {
+      Props.prepend(Map("new.prop" -> "new.value"))
+      Props.require("new.prop") must_== Nil
+    }
   }
 }

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -24,111 +24,126 @@ import Props.RunModes._
 
 object PropsSpec extends Specification {
   "Props Specification".title
-  sequential
+
+  case class TestProps() extends Props
 
   "Props" should {
-    "Detect test mode correctly" in new props {
-      Props.testMode must_== true
+    "Detect test mode correctly" in {
+      TestProps().testMode must_== true
     }
 
-    "Allow modification of run-mode properties before the run-mode is set" in new props {
-      val before = Props.autoDetectRunModeFn.get
+    "Allow modification of run-mode properties before the run-mode is set" in {
+      val testProps = TestProps()
+
+      val before = testProps.autoDetectRunModeFn.get
       try {
-        Props.runModeInitialised = false
-        Props.autoDetectRunModeFn.allowModification must_== true
-        Props.autoDetectRunModeFn.set(() => Test) must_== true
-        Props.autoDetectRunModeFn.get must_!= before
+        testProps.runModeInitialised = false
+        testProps.autoDetectRunModeFn.allowModification must_== true
+        testProps.autoDetectRunModeFn.set(() => Test) must_== true
+        testProps.autoDetectRunModeFn.get must_!= before
       } finally {
-        Props.autoDetectRunModeFn.set(before)
-        Props.runModeInitialised = true
+        testProps.autoDetectRunModeFn.set(before)
+        testProps.runModeInitialised = true
       }
     }
 
-    "Prohibit modification of run-mode properties when the run-mode is set" in new props {
-      val before = Props.autoDetectRunModeFn.get
-      Props.autoDetectRunModeFn.allowModification must_== false
-      Props.autoDetectRunModeFn.set(() => Test) must_== false
-      Props.autoDetectRunModeFn.get must_== before
+    "Prohibit modification of run-mode properties when the run-mode is set" in {
+      val testProps = TestProps()
+
+      val before = testProps.autoDetectRunModeFn.get
+      testProps.autoDetectRunModeFn.allowModification must_== false
+      testProps.autoDetectRunModeFn.set(() => Test) must_== false
+      testProps.autoDetectRunModeFn.get must_== before
     }
 
-    "Parse and cast to int" in new props {
-      Props.getInt("an.int") must_== Full(42)
+    "Parse and cast to int" in {
+      TestProps().getInt("an.int") must_== Full(42)
     }
 
-    "Parse and cast to long" in new props {
-      Props.getLong("a.long") must_== Full(9223372036854775807L)
+    "Parse and cast to long" in {
+      TestProps().getLong("a.long") must_== Full(9223372036854775807L)
     }
 
-    "Parse and cast to boolean" in new props {
-      Props.getBool("a.boolean") must_== Full(true)
+    "Parse and cast to boolean" in {
+      TestProps().getBool("a.boolean") must_== Full(true)
     }
 
-    "Prefer prepended properties to the test.default.props" in new props {
-      Props.prependSource(Map("jetty.port" -> "8080"))
-      val port = Props.getInt("jetty.port")
+    "Prefer prepended properties to the test.default.props" in {
+      val testProps = TestProps()
+
+      testProps.prependSource(Map("jetty.port" -> "8080"))
+      val port = testProps.getInt("jetty.port")
 
       port must_== Full(8080)
     }
 
-    "Prefer prepended System.properties to the test.default.props" in new props {
+    "Prefer prepended System.properties to the test.default.props" in {
+      val testProps = TestProps()
+
       System.setProperty("omniauth.baseurl", "http://google.com")
-      Props.prependSource(sys.props)
-      val baseurl = Props.get("omniauth.baseurl")
+
+      testProps.prependSource(sys.props)
+      val baseurl = testProps.get("omniauth.baseurl")
 
       baseurl must_== Full("http://google.com")
     }
 
-    "Read through to System.properties, correctly handling mutation" in new props {
+    "Read through to System.properties, correctly handling mutation" in {
+      val testProps = TestProps()
+
       System.setProperty("omniauth.baseurl", "http://google.com")
-      Props.prependSource(sys.props)
+      testProps.prependSource(sys.props)
       System.setProperty("omniauth.baseurl", "http://ebay.com")
-      val baseurl = Props.get("omniauth.baseurl")
+      val baseurl = testProps.get("omniauth.baseurl")
 
       baseurl must_== Full("http://ebay.com")
     }
 
-    "Find properties in appended maps when not defined in test.default.props" in new props {
-      Props.appendSource(Map("new.prop" -> "new.value"))
-      val prop = Props.get("new.prop")
+    "Find properties in appended maps when not defined in test.default.props" in {
+      val testProps = TestProps()
+
+      testProps.appendSource(Map("new.prop" -> "new.value"))
+      val prop = testProps.get("new.prop")
 
       prop must_== Full("new.value")
     }
 
-    "Not interpolate values when no interpolator is given" in new props {
-      val port = Props.get("jetty.port")
+    "Not interpolate values when no interpolator is given" in {
+      val port = TestProps().get("jetty.port")
 
       port must_== Full("${PORT}")
     }
 
-    "Interpolate values from the given interpolator" in new props {
-      Props.appendInterpolator(Map("PORT" -> "8080"))
-      val port = Props.getInt("jetty.port")
+    "Interpolate values from the given interpolator" in {
+      val testProps = TestProps()
+
+      testProps.appendInterpolator(Map("PORT" -> "8080"))
+      val port = testProps.getInt("jetty.port")
 
       port must_== Full(8080)
     }
 
-    "Interpolate multiple values in a string from the given interpolator" in new props {
-      Props.appendInterpolator(Map("DB_HOST" -> "localhost", "DB_PORT" -> "3306"))
-      val url = Props.get("db.url")
+    "Interpolate multiple values in a string from the given interpolator" in {
+      val testProps = TestProps()
+
+      testProps.appendInterpolator(Map("DB_HOST" -> "localhost", "DB_PORT" -> "3306"))
+      val url = testProps.get("db.url")
 
       url must_== Full("jdbc:mysql://localhost:3306/MYDB")
     }
 
-    "Find properties in append for require()" in new props {
-      Props.appendSource(Map("new.prop" -> "new.value"))
-      Props.require("new.prop") must_== Nil
+    "Find properties in append for require()" in {
+      val testProps = TestProps()
+
+      testProps.appendSource(Map("new.prop" -> "new.value"))
+      testProps.require("new.prop") must_== Nil
     }
 
-    "Find properties in prepend for require()" in new props {
-      Props.prependSource(Map("new.prop" -> "new.value"))
-      Props.require("new.prop") must_== Nil
-    }
-  }
-}
+    "Find properties in prepend for require()" in {
+      val testProps = TestProps()
 
-trait props extends After {
-  def after = {
-    Props.removeSources(_ != Props.props)
-    Props.removeInterpolators(_ => true)
+      testProps.prependSource(Map("new.prop" -> "new.value"))
+      testProps.require("new.prop") must_== Nil
+    }
   }
 }


### PR DESCRIPTION
I haven't heard any feedback on the [ML thread] (https://groups.google.com/forum/#!searchin/liftweb/properties%7Csort:date/liftweb/5T_4xm1amr8/XaruS3VMBwAJ) regarding this enhancement, so I thought I'd take the next step to make a PR to have some more eyes on it.

Briefly, this PR allows Lift to be configured via `LiftRules` to (1) look up properties from more sources than just the `*.props` files such as JVM `System` properties, OS environment properties, or arbitrary `Map[String, String]` and (2) to reference other properties with unix-like `${propName}` syntax.  The extra property sources' precedence is well-defined and dictated by the developer via calling `prepend` vs `append`.  For interpolators we have `appendInterpolator` only since there is not a fixed resource to work around.

Note that interpolation is implemented such that infinite recursion is not possible. We do not check the values found for more keys to look up. 

The only missing feature I feel we have here is the ability to interpolate from the `*.props` files themselves. Currently we can only look up from maps provided to `appendInterpolator`.

See `net.liftweb.util.PropsSpec` for working usage examples.  Looking forward to the feedback!