### PR TITLE
Implement radioCssSel alternative for binding radios.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -2139,8 +2139,8 @@ trait SHtml extends Loggable {
    * {{{
    * def render = {
    *   SHtml.radioCssSel[String](Empty, submitHandler) (
-   *     "all-emails" -> "All emails",
-   *     "some-emails" -> "Some emails"
+   *     "#all-emails" -> "All emails",
+   *     "#some-emails" -> "Some emails"
    *   )
    * }
    * }}}

--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -2143,6 +2143,10 @@ trait SHtml extends Loggable {
    *     "#some-emails" -> "Some emails"
    *   )
    * }
+   * 
+   * val submitHandler:Box[String] => Unit = { box =>
+   *   println("We got a box!! "+box)
+   * }
    * }}}
    *
    * @param initialValue initial value or Empty if no initial value

--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -2138,10 +2138,10 @@ trait SHtml extends Loggable {
    *
    * {{{
    * def render = {
-   *   SHtml.radioCssSel[String](Empty, submitHandler) {
+   *   SHtml.radioCssSel[String](Empty, submitHandler) (
    *     "all-emails" -> "All emails",
    *     "some-emails" -> "Some emails"
-   *   }
+   *   )
    * }
    * }}}
    *


### PR DESCRIPTION
This PR implements an alternative to the standard radio button binding function. The new function, named `radioCssSel`, preserves the original structure of the page / form that you're binding the radio button on. This makes your page and its associated styles behave in a more predictable manner.