### PR TITLE
LAFuture Spec Reliability: Execute map/flatMap LAFuture tests on same thread for reliability.

### DIFF
--- a/core/actor/src/test/scala/net/liftweb/actor/LAFutureSpec.scala
+++ b/core/actor/src/test/scala/net/liftweb/actor/LAFutureSpec.scala
@@ -2,15 +2,20 @@ package net.liftweb.actor
 
 import net.liftweb.common.{Failure, Box}
 import org.specs2.mutable.Specification
+import java.util.concurrent.atomic.AtomicBoolean
 
 class LAFutureSpec extends Specification {
-  val timeout = 5000L
+  sequential
+  val timeout = 20000L
+  LAScheduler
 
   "LAFuture" should {
+    val futureSpecScheduler = new LAScheduler {
+      override def execute(f: ()=>Unit): Unit = f()
+    }
+
     "map to failing future if transforming function throws an Exception" in {
-      val future = LAFuture { () =>
-        1
-      }
+      val future = LAFuture(() => 1, futureSpecScheduler)
       def tranformThrowingException(input: Int) = {
         throw new Exception("fail")
       }
@@ -27,9 +32,7 @@ class LAFutureSpec extends Specification {
     }
 
     "flatMap to failing future if transforming function throws an Exception" in {
-      val future = LAFuture { () =>
-        1
-      }
+      val future = LAFuture(() => 1, futureSpecScheduler)
       def tranformThrowingException(input: Int): LAFuture[Int] = {
         throw new Exception("fail")
       }


### PR DESCRIPTION
We were running into issues with test realibility in TravisCI with these
specs. So, let's make them more reliable by using an LAScheduler that
doesn't start a separate thread.