### PR TITLE
Making the default for LiftRules.autoIncludeAjaxCalc smarter 

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1695,7 +1695,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   @volatile var autoIncludeComet: LiftSession => Boolean = session => true
 
   val autoIncludeAjaxCalc: FactoryMaker[() => LiftSession => Boolean] =
-  new FactoryMaker(() => () => (session: LiftSession) => true) {}
+  new FactoryMaker(() => () => (session: LiftSession) => session.stateful_?) {}
 
   /**
    * Tells Lift which JavaScript settings to use. If Empty, does not


### PR DESCRIPTION
Per [this ML thread](https://groups.google.com/forum/#!searchin/liftweb/LiftRules.autoIncludeAjaxCalc%7Csort:date/liftweb/B5B8BqEScoc/-wQRWbm8BAAJ).  See my [lift-help autoIncludeAjaxCalc-default branch](https://github.com/joescii/lift-help/tree/autoIncludeAjaxCalc-default) for a quick and dirty project exercising the change.