### PR TITLE
Js config

### DIFF
--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -17,8 +17,11 @@
         toWatch = {},
         knownPromises = {};
 
+    // The settings object which we build up
+    var settings = {};
+
     // default settings
-    var settings = {
+    var defaults = {
       /**
         * Contains the Ajax URI path used by Lift to process Ajax requests.
         */
@@ -548,7 +551,7 @@
     return {
       init: function(optionFn, extendWith) {
         // Pass the defaults settings to the option-producing function
-        var options = optionFn(settings);
+        var options = optionFn(defaults);
 
         // Add jQuery or Vanilla stuff
         this.extend(options, extendWith);

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -546,7 +546,8 @@
     ///// Public Object /////////////////////////////////
     ////////////////////////////////////////////////
     return {
-      init: function(options) {
+      init: function(options, extendWith) {
+        this.extend(options, extendWith);
         // override default settings
         this.extend(settings, options);
 

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -546,7 +546,11 @@
     ///// Public Object /////////////////////////////////
     ////////////////////////////////////////////////
     return {
-      init: function(options, extendWith) {
+      init: function(optionFn, extendWith) {
+        // Pass the defaults settings to the option-producing function
+        var options = optionFn(settings);
+
+        // Add jQuery or Vanilla stuff
         this.extend(options, extendWith);
         // override default settings
         this.extend(settings, options);

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -898,7 +898,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    *   LiftRules.jsLogFunc = Full(v => JE.Call("alert",v).cmd)
    */
   @volatile var jsLogFunc: Box[JsVar => JsCmd] =
-    if (Props.devMode) Full(v => JE.Call("lift.logError", v))
+    if (Props.devMode) Full(v => JE.Call("default.logError", v))
     else Empty
 
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -898,7 +898,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    *   LiftRules.jsLogFunc = Full(v => JE.Call("alert",v).cmd)
    */
   @volatile var jsLogFunc: Box[JsVar => JsCmd] =
-    if (Props.devMode) Full(v => JE.Call("default.logError", v))
+    if (Props.devMode) Full(v => JE.Call("defaults.logError", v))
     else Empty
 
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
@@ -80,7 +80,7 @@ object LiftJavaScript {
       case _ => "liftVanilla"
     }
 
-    JsCrVar("lift_settings", settings) &
-    Call("window.lift.init", JsVar("lift_settings"), JsVar("window", extendWith))
+    JsCrVar("lift_settingsFn", AnonFunc("defaults", JsReturn(settings))) &
+    Call("window.lift.init", JsVar("lift_settingsFn"), JsVar("window", extendWith))
   }
 }

--- a/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
@@ -75,20 +75,12 @@ object LiftJavaScript {
   }
 
   def initCmd(settings: JsObj): JsCmd = {
-    val extendCmd = LiftRules.jsArtifacts match {
-      case jsa: JQueryArtifacts => Call("window.lift.extend", JsVar("lift_settings"), JsVar("window", "liftJQuery"))
-      case _ => Call("window.lift.extend", JsVar("lift_settings"), JsVar("window", "liftVanilla"))
+    val extendWith = LiftRules.jsArtifacts match {
+      case jsa: JQueryArtifacts => "liftJQuery"
+      case _ => "liftVanilla"
     }
 
     JsCrVar("lift_settings", settings) &
-    extendCmd &
-    Call("window.lift.init", JsVar("lift_settings"))
-
-    /*val extendCmd = LiftRules.jsArtifacts match {
-      case jsa: JQueryArtifacts => Call("window.lift.extend", settings, JsVar("window.liftJQuery"))
-      case _ => Call("window.lift.extend", settings, JsVar("window.liftVanilla"))
-    }
-
-    Call("window.lift.init", extendCmd)*/
+    Call("window.lift.init", JsVar("lift_settings"), JsVar("window", extendWith))
   }
 }


### PR DESCRIPTION
In this PR I am reworking how we configure the options/settings in `lift.js` to (1) be more flexible by exposing more of the functionality to configuration and (2) make use of the default code in the `settings` object.

Note that this is a work in progress and not ready for merge.  I am opening it now per @Shadowfiend's request so we can consider this option for resolving #1720 instead of current PR #1721. 