### PR TITLE
Future with session

### DIFF
--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -262,8 +262,8 @@ object LAFuture {
    * @tparam T the type
    * @return an LAFuture that will yield its value when the value has been computed
    */
-  def apply[T](f: () => T, scheduler: LAScheduler = LAScheduler): LAFuture[T] = {
-    val ret = new LAFuture[T](scheduler)
+  def apply[T](f: () => T, scheduler: LAScheduler = LAScheduler, context:ContextFn = None): LAFuture[T] = {
+    val ret = new LAFuture[T](scheduler, context)
     scheduler.execute(() => {
       try {
       ret.satisfy(f())
@@ -280,8 +280,8 @@ object LAFuture {
    * @tparam T the type that
    * @return
    */
-  def build[T](f: => T, scheduler: LAScheduler = LAScheduler): LAFuture[T] = {
-    this.apply(() => f, scheduler)
+  def build[T](f: => T, scheduler: LAScheduler = LAScheduler, context:ContextFn = None): LAFuture[T] = {
+    this.apply(() => f, scheduler, context)
   }
 
   private val threadInfo = new ThreadLocal[List[LAFuture[_] => Unit]]

--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -24,7 +24,7 @@ import common._
  * A container that contains a calculated value
  * or may contain one in the future
  */
-class LAFuture[T](val scheduler: LAScheduler) {
+class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
   private var item: T = _
   private var failure: Box[Nothing] = Empty
   private var satisfied = false
@@ -32,10 +32,6 @@ class LAFuture[T](val scheduler: LAScheduler) {
   private var toDo: List[T => Unit] = Nil
   private var onFailure: List[Box[Nothing] => Unit] = Nil
   private var onComplete: List[Box[T] => Unit] = Nil
-
-  def this() {
-    this(LAScheduler)
-  }
 
   LAFuture.notifyObservers(this)
 

--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -79,7 +79,7 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler, context:LAFuture.Con
    * Private tail-recursive implementation of get
    */
   @scala.annotation.tailrec
-  private def get_rec: T = synchronized {
+  private [this] def get_rec: T = synchronized {
     if (satisfied) item
     else if (aborted) throw new AbortedFutureException(failure)
     else {

--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -77,15 +77,20 @@ class LAFuture[T](val scheduler: LAScheduler) {
   /**
    * Get the future value
    */
+  def get: T = get_rec
+
+  /**
+   * Private tail-recursive implementation of get
+   */
   @scala.annotation.tailrec
-  final def get: T = synchronized {
+  private def get_rec: T = synchronized {
     if (satisfied) item
     else if (aborted) throw new AbortedFutureException(failure)
     else {
       this.wait()
       if (satisfied) item
       else if (aborted) throw new AbortedFutureException(failure)
-      else get
+      else get_rec
     }
   }
 

--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -24,7 +24,7 @@ import common._
  * A container that contains a calculated value
  * or may contain one in the future
  */
-class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
+class LAFuture[T](val scheduler: LAScheduler = LAScheduler, wrapper:CommonLoanWrapper = LAFuture.defaultWrapper) {
   private var item: T = _
   private var failure: Box[Nothing] = Empty
   private var satisfied = false
@@ -48,7 +48,7 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
           val ret = toDo
           toDo = Nil
           onFailure = Nil
-          onComplete.foreach(f => LAFuture.executeWithObservers(scheduler, () => f(Full(value))))
+          onComplete.foreach(f => LAFuture.executeWithObservers(scheduler, () => wrapper(f(Full(value)))))
           onComplete = Nil
           ret
         } else Nil
@@ -56,7 +56,7 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
         notifyAll()
       }
     }
-    funcs.foreach(f => LAFuture.executeWithObservers(scheduler, () => f(value)))
+    funcs.foreach(f => LAFuture.executeWithObservers(scheduler, () => wrapper(f(value))))
   }
 
   /**
@@ -106,13 +106,13 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
    * @return a Future that represents the function applied to the value of the future
    */
   def map[A](f: T => A): LAFuture[A] = {
-    val ret = new LAFuture[A](scheduler)
+    val ret = new LAFuture[A](scheduler, wrapper)
     onComplete(v => ret.complete(v.flatMap(n => Box.tryo(f(n)))))
     ret
   }
 
   def flatMap[A](f: T => LAFuture[A]): LAFuture[A] = {
-    val ret = new LAFuture[A](scheduler)
+    val ret = new LAFuture[A](scheduler, wrapper)
     onComplete(v => v match {
       case Full(v) =>
         Box.tryo(f(v)) match {
@@ -125,7 +125,7 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
   }
 
   def filter(f: T => Boolean): LAFuture[T] = {
-    val ret = new LAFuture[T](scheduler)
+    val ret = new LAFuture[T](scheduler, wrapper)
     onComplete(v => ret.complete(v.filter(f)))
     ret
   }
@@ -176,7 +176,7 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
    */
   def onSuccess(f: T => Unit) {
     synchronized {
-      if (satisfied) {LAFuture.executeWithObservers(scheduler, () => f(item))} else
+      if (satisfied) {LAFuture.executeWithObservers(scheduler, () => wrapper(f(item)))} else
       if (!aborted) {
         toDo ::= f
       }
@@ -190,7 +190,7 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
    */
   def onFail(f: Box[Nothing] => Unit) {
     synchronized {
-      if (aborted) LAFuture.executeWithObservers(scheduler, () => f(failure)) else
+      if (aborted) LAFuture.executeWithObservers(scheduler, () => wrapper(f(failure))) else
       if (!satisfied) {
         onFailure ::= f
       }
@@ -204,8 +204,8 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
    */
   def onComplete(f: Box[T] => Unit) {
     synchronized {
-      if (satisfied) {LAFuture.executeWithObservers(scheduler, () => f(Full(item)))} else
-      if (aborted) {LAFuture.executeWithObservers(scheduler, () => f(failure))} else
+      if (satisfied) {LAFuture.executeWithObservers(scheduler, () => wrapper(f(Full(item))))} else
+      if (aborted) {LAFuture.executeWithObservers(scheduler, () => wrapper(f(failure)))} else
       onComplete ::= f
     }
   }
@@ -227,8 +227,8 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
       if (!satisfied && !aborted) {
         aborted = true
         failure = e
-        onFailure.foreach(f => LAFuture.executeWithObservers(scheduler, () => f(e)))
-        onComplete.foreach(f => LAFuture.executeWithObservers(scheduler, () => f(e)))
+        onFailure.foreach(f => LAFuture.executeWithObservers(scheduler, () => wrapper(f(e))))
+        onComplete.foreach(f => LAFuture.executeWithObservers(scheduler, () => wrapper(f(e))))
         onComplete = Nil
         onFailure = Nil
         toDo = Nil
@@ -250,6 +250,10 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler) {
 final class AbortedFutureException(why: Box[Nothing]) extends Exception("Aborted Future")
 
 object LAFuture {
+  val defaultWrapper:CommonLoanWrapper = new CommonLoanWrapper {
+    override def apply[T](f: => T): T = f
+  }
+
   /**
    * Create an LAFuture from a function that
    * will be applied on a separate thread. The LAFuture

--- a/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
@@ -31,15 +31,15 @@ class FutureWithSession[+T](future:Future[T])(implicit session:LiftSession) exte
     future.andThen { case t => S.initIfUninitted(session) ( pf(t) ) }.withImplicitSession
   override def failed: Future[Throwable] = future.failed.withImplicitSession
   override def fallbackTo[U >: T](that: Future[U]): Future[U] = future.fallbackTo(that).withImplicitSession
-  override def flatMap[S](f: (T) ⇒ Future[S])(implicit executor: ExecutionContext): Future[S] =
+  override def flatMap[S](f: (T) => Future[S])(implicit executor: ExecutionContext): Future[S] =
     future.flatMap ( t => S.initIfUninitted(session) ( f(t) )).withImplicitSession
-  override def map[S](f: (T) ⇒ S)(implicit executor: ExecutionContext): Future[S] =
+  override def map[S](f: (T) => S)(implicit executor: ExecutionContext): Future[S] =
     future.map ( t => S.initIfUninitted(session) ( f(t) )).withImplicitSession
   override def recover[U >: T](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): Future[U] =
     future.recover { case t => S.initIfUninitted(session) ( pf(t) ) }.withImplicitSession
   override def recoverWith[U >: T](pf: PartialFunction[Throwable, Future[U]])(implicit executor: ExecutionContext): Future[U] =
     future.recoverWith { case t => S.initIfUninitted(session) ( pf(t) ) }.withImplicitSession
-  override def transform[S](s: (T) ⇒ S, f: (Throwable) ⇒ Throwable)(implicit executor: ExecutionContext): Future[S] =
+  override def transform[S](s: (T) => S, f: (Throwable) => Throwable)(implicit executor: ExecutionContext): Future[S] =
     future.transform( t => S.initIfUninitted(session) ( s(t) ), t => S.initIfUninitted(session) ( f(t) ) ).withImplicitSession
   override def zip[U](that: Future[U]): Future[(T, U)] = future.zip(that).withImplicitSession
 

--- a/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
@@ -52,8 +52,8 @@ import scala.util.Try
   * @see LAFutureWithSession
   */
 object FutureWithSession {
-  implicit class FutureDecorator[+T](future:Future[T]) {
-    val withCurrentSession:Future[T] = S.session match {
+  implicit class FutureDecorator[+T](val future:Future[T]) extends AnyVal {
+    def withCurrentSession:Future[T] = S.session match {
       case Full(s) => new FutureWithSession[T](future)(s)
       case Failure(_, Full(ex), _) => Future.failed(ex)
       case Failure(msg, _, _) => Future.failed(new Exception(msg))

--- a/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
@@ -5,6 +5,8 @@ import net.liftweb.common.{Empty, Failure, Full}
 import scala.concurrent.{ExecutionContext, CanAwait, Future}
 import scala.concurrent.duration.Duration
 import scala.util.Try
+import FutureWithSession._
+
 
 /**
   * Contains implicit conversion for `scala.concurrent.Future` to ease access to `LiftSession` resources.
@@ -64,8 +66,6 @@ object FutureWithSession {
 }
 
 private [http] class FutureWithSession[+T](future:Future[T])(implicit session:LiftSession) extends Future[T] {
-  import FutureWithSession._
-
   // Override all of the abstract Future[T] stuff to pass thru
   override def isCompleted:Boolean = future.isCompleted
   override def value:Option[Try[T]] = future.value

--- a/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
@@ -20,6 +20,10 @@ class FutureWithSession[+T](future:Future[T])(implicit session:LiftSession) exte
     future.map ( t => S.initIfUninitted(session) ( f(t) )).withImplicitSession
   override def flatMap[S](f: (T) ⇒ Future[S])(implicit executor: ExecutionContext): Future[S] =
     future.flatMap ( t => S.initIfUninitted(session) ( f(t) )).withImplicitSession
+  override def andThen[U](pf: PartialFunction[Try[T], U])(implicit executor: ExecutionContext): Future[T] =
+    future.andThen { case t => S.initIfUninitted(session) ( pf(t) ) }.withImplicitSession
+  override def failed: Future[Throwable] = future.failed.withImplicitSession
+//  override def fallbackTo[U >: T](that: Future[U]): Future[U] = future.fallbackTo(that)
 
   // Override all of the abstract Future[T] stuff to pass thru
   override def isCompleted = future.isCompleted

--- a/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
@@ -13,6 +13,13 @@ object FutureWithSession {
 }
 
 class FutureWithSession[+T](future:Future[T], session:LiftSession) extends Future[T] {
+  import FutureWithSession._
+
+  override def map[S](f: (T) ⇒ S)(implicit executor: ExecutionContext): Future[S] =
+    future.map ( t => S.initIfUninitted(session) ( f(t) )).withSession
+  override def flatMap[S](f: (T) ⇒ Future[S])(implicit executor: ExecutionContext): Future[S] =
+    future.flatMap ( t => S.initIfUninitted(session) ( f(t) )).withSession
+
   // Override all of the abstract Future[T] stuff to pass thru
   override def isCompleted = future.isCompleted
   override def value = future.value

--- a/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
@@ -12,7 +12,7 @@ object FutureWithSession {
   }
 }
 
-class FutureWithSession[+T](future:Future[T])(implicit session:LiftSession) extends Future[T] {
+private [http] class FutureWithSession[+T](future:Future[T])(implicit session:LiftSession) extends Future[T] {
   import FutureWithSession._
 
   // Override all of the abstract Future[T] stuff to pass thru

--- a/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
@@ -10,11 +10,11 @@ import scala.util.Try
   * If you need to access session state (such as a `SessionVar`) within the context of a `Future`, then import
   * `FutureWithSession` and convert your `Future`s with either `withCurrentSession` or `withImplicitSession`.
   * Use `withCurrentSession` when you are already in the context of a `LiftSession`.  Use `withImplicitSession`
-  * if you have a reference to the `LiftSession`.
+  * if you instead have a reference to the `LiftSession`.
   *
-  * Note that the returned `Future` writes through to the original, and each method which returns another
-  * `Future` also will be an `FutureWithSession`.  Hence any calls can be chained together, allowing an
-  * `FutureWithSession` to work in an arbitrary for-comprehension.
+  * The `Future` returned by `withCurrentSession` or `withImplicitSession` is satisfied by the same value
+  * as the original `Future` and each method which returns another `Future` also will be a `FutureWithSession`.
+  * Hence any calls can be chained together, allowing a `FutureWithSession` to work in an arbitrary for-comprehension.
   *
   * Full working example:
   * {{{

--- a/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
@@ -1,0 +1,25 @@
+package net.liftweb.http
+
+import net.liftweb.common._
+import scala.concurrent._
+import scala.concurrent.duration.Duration
+import scala.util.Try
+
+object FutureWithSession {
+  implicit class FutureDecorator[+T](future:Future[T]) {
+    val withSession:Future[T] = S.session.map(new FutureWithSession[T](future, _)).
+      openOr(Future.failed(new Exception("LiftSession not available in this thread context")))
+  }
+}
+
+class FutureWithSession[+T](future:Future[T], session:LiftSession) extends Future[T] {
+  // Override all of the abstract Future[T] stuff to pass thru
+  override def isCompleted = future.isCompleted
+  override def value = future.value
+  override def onComplete[U](f: (Try[T]) => U)(implicit executor:ExecutionContext) = future.onComplete(f)
+  override def result(atMost: Duration)(implicit permit: CanAwait) = future.result(atMost)
+  override def ready(atMost: Duration)(implicit permit: CanAwait) = {
+    future.ready(atMost)
+    this
+  }
+}

--- a/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
@@ -1,7 +1,6 @@
 package net.liftweb.http
 
-import net.liftweb.common._
-import scala.concurrent._
+import scala.concurrent.{ExecutionContext, CanAwait, Future} 
 import scala.concurrent.duration.Duration
 import scala.util.Try
 
@@ -16,22 +15,34 @@ object FutureWithSession {
 class FutureWithSession[+T](future:Future[T])(implicit session:LiftSession) extends Future[T] {
   import FutureWithSession._
 
-  override def map[S](f: (T) ⇒ S)(implicit executor: ExecutionContext): Future[S] =
-    future.map ( t => S.initIfUninitted(session) ( f(t) )).withImplicitSession
-  override def flatMap[S](f: (T) ⇒ Future[S])(implicit executor: ExecutionContext): Future[S] =
-    future.flatMap ( t => S.initIfUninitted(session) ( f(t) )).withImplicitSession
-  override def andThen[U](pf: PartialFunction[Try[T], U])(implicit executor: ExecutionContext): Future[T] =
-    future.andThen { case t => S.initIfUninitted(session) ( pf(t) ) }.withImplicitSession
-  override def failed: Future[Throwable] = future.failed.withImplicitSession
-//  override def fallbackTo[U >: T](that: Future[U]): Future[U] = future.fallbackTo(that)
-
   // Override all of the abstract Future[T] stuff to pass thru
-  override def isCompleted = future.isCompleted
-  override def value = future.value
-  override def onComplete[U](f: (Try[T]) => U)(implicit executor:ExecutionContext) = future.onComplete(f)
-  override def result(atMost: Duration)(implicit permit: CanAwait) = future.result(atMost)
+  override def isCompleted:Boolean = future.isCompleted
+  override def value:Option[Try[T]] = future.value
+  override def result(atMost: Duration)(implicit permit: CanAwait):T = future.result(atMost)
   override def ready(atMost: Duration)(implicit permit: CanAwait) = {
     future.ready(atMost)
     this
   }
+  override def onComplete[U](f: (Try[T]) => U)(implicit executor:ExecutionContext):Unit =
+    future.onComplete( t => S.initIfUninitted(session) ( f(t) ) )
+
+  // Override all methods with functions that need to run in session scope and/or return other futures
+  override def andThen[U](pf: PartialFunction[Try[T], U])(implicit executor: ExecutionContext): Future[T] =
+    future.andThen { case t => S.initIfUninitted(session) ( pf(t) ) }.withImplicitSession
+  override def failed: Future[Throwable] = future.failed.withImplicitSession
+  override def fallbackTo[U >: T](that: Future[U]): Future[U] = future.fallbackTo(that).withImplicitSession
+  override def flatMap[S](f: (T) ⇒ Future[S])(implicit executor: ExecutionContext): Future[S] =
+    future.flatMap ( t => S.initIfUninitted(session) ( f(t) )).withImplicitSession
+  override def map[S](f: (T) ⇒ S)(implicit executor: ExecutionContext): Future[S] =
+    future.map ( t => S.initIfUninitted(session) ( f(t) )).withImplicitSession
+  override def recover[U >: T](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): Future[U] =
+    future.recover { case t => S.initIfUninitted(session) ( pf(t) ) }.withImplicitSession
+  override def recoverWith[U >: T](pf: PartialFunction[Throwable, Future[U]])(implicit executor: ExecutionContext): Future[U] =
+    future.recoverWith { case t => S.initIfUninitted(session) ( pf(t) ) }.withImplicitSession
+  override def transform[S](s: (T) ⇒ S, f: (Throwable) ⇒ Throwable)(implicit executor: ExecutionContext): Future[S] =
+    future.transform( t => S.initIfUninitted(session) ( s(t) ), t => S.initIfUninitted(session) ( f(t) ) ).withImplicitSession
+  override def zip[U](that: Future[U]): Future[(T, U)] = future.zip(that).withImplicitSession
+
+  // Note that the following methods are implemented reusing existing methods: filter, foreach, mapTo, onFailure, onSuccess
+  // We still have them covered by tests in case future changes to the Scala standard lib changes this.
 }

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -1,7 +1,7 @@
 package net.liftweb.http
 
 import net.liftweb.actor.LAFuture
-import net.liftweb.common.{Empty, Failure}
+import net.liftweb.common.{Box, Empty, Failure}
 
 object LAFutureWithSession {
   implicit class LAFutureDecorator[T](future:LAFuture[T]) {
@@ -17,4 +17,7 @@ object LAFutureWithSession {
 }
 
 class LAFutureWithSession[T](future:LAFuture[T])(implicit session:LiftSession) extends LAFuture[T] {
+  override def satisfy(value: T): Unit = future.satisfy(value)
+  override def get(timeout: Long): Box[T] = future.get(timeout)
+  override def onComplete(f: Box[T] => Unit) = future.onComplete( b => S.initIfUninitted(session) { f(b) } )
 }

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -1,0 +1,20 @@
+package net.liftweb.http
+
+import net.liftweb.actor.LAFuture
+import net.liftweb.common.{Empty, Failure}
+
+object LAFutureWithSession {
+  implicit class LAFutureDecorator[T](future:LAFuture[T]) {
+    val withCurrentSession:LAFuture[T] = S.session.map(new LAFutureWithSession[T](future)(_)).
+      openOr {
+        val f = new LAFuture[T]()
+        f.fail(Failure("LiftSession not available in this thread context", Empty, Empty))
+        f
+      }
+
+    def withImplicitSession(implicit session:LiftSession):LAFuture[T] = new LAFutureWithSession[T](future)
+  }
+}
+
+class LAFutureWithSession[T](future:LAFuture[T])(implicit session:LiftSession) extends LAFuture[T] {
+}

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -54,13 +54,13 @@ object LAFutureWithSession {
     override def apply[T](f: => T): T = S.initIfUninitted(session) { f }
   })
 
-  private def withSession[T](f:LAFuture[T], s:LiftSession):LAFuture[T] = {
+  private [this] def withSession[T](f:LAFuture[T], s:LiftSession):LAFuture[T] = {
     val sf = new LAFuture[T](f.scheduler, sessionWrapper(s))
     f.onComplete(sf.complete)
     sf
   }
 
-  private def withFailure[T](f:LAFuture[T], failure:Failure):LAFuture[T] = {
+  private [this] def withFailure[T](f:LAFuture[T], failure:Failure):LAFuture[T] = {
     val ff = new LAFuture[T](f.scheduler)
     ff.complete(failure)
     ff

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -7,7 +7,7 @@ object LAFutureWithSession {
   implicit class LAFutureDecorator[T](future:LAFuture[T]) {
     val withCurrentSession:LAFuture[T] = S.session.map(new LAFutureWithSession[T](future)(_)).
       openOr {
-        val f = new LAFuture[T]()
+        val f = new LAFuture[T](future.scheduler)
         f.fail(Failure("LiftSession not available in this thread context", Empty, Empty))
         f
       }
@@ -16,8 +16,30 @@ object LAFutureWithSession {
   }
 }
 
-class LAFutureWithSession[T](future:LAFuture[T])(implicit session:LiftSession) extends LAFuture[T] {
+class LAFutureWithSession[T](future:LAFuture[T])(implicit session:LiftSession) extends LAFuture[T](future.scheduler) {
+  import LAFutureWithSession._
+
+  // The following methods don't need access to the session, but need to write through to the original future
+  override def abort() = future.abort()
+  override def isAborted: Boolean = future.isAborted
+  override def complete_? : Boolean = future.complete_?
+  override def fail(e: Box[Nothing]) = future.fail(e)
   override def satisfy(value: T): Unit = future.satisfy(value)
   override def get(timeout: Long): Box[T] = future.get(timeout)
+  override def get: T = future.get
+  override def isSatisfied: Boolean = future.isSatisfied
+
+  // The following methods execute the function arguments in the session
   override def onComplete(f: Box[T] => Unit) = future.onComplete( b => S.initIfUninitted(session) { f(b) } )
+  override def onFail(f: Box[Nothing] => Unit) = future.onFail( b => S.initIfUninitted(session) { f(b) } )
+  override def onSuccess(f: T => Unit) = future.onSuccess( v => S.initIfUninitted(session) { f(v) } )
+
+  // The following methods reuse existing methods, so no need to handle sessions here. Overriding so chaining
+  // and hence for-comprehensions work.
+  override def flatMap[A](f: T => LAFuture[A]): LAFuture[A] = future.flatMap(f).withImplicitSession
+  override def filter(f: T => Boolean): LAFuture[T] = future.filter(f).withImplicitSession
+  override def map[A](f: T => A): LAFuture[A] = future.map(f).withImplicitSession
+
+  // The following methods are implemented reusing existing methods: complete, foreach, fail(Exception), and withFilter
+  // We still have them covered by tests in case future changes to the LAFuture changes this.
 }

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -16,7 +16,7 @@ object LAFutureWithSession {
   }
 }
 
-class LAFutureWithSession[T](future:LAFuture[T])(implicit session:LiftSession) extends LAFuture[T](future.scheduler) {
+private [http] class LAFutureWithSession[T](future:LAFuture[T])(implicit session:LiftSession) extends LAFuture[T](future.scheduler) {
   import LAFutureWithSession._
 
   // The following methods don't need access to the session, but need to write through to the original future

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -3,6 +3,49 @@ package net.liftweb.http
 import net.liftweb.actor.LAFuture
 import net.liftweb.common.{Box, Empty, Failure}
 
+/**
+  * Contains implicit conversion for `net.liftweb.actor.LAFuture` to ease access to `LiftSession` resources.
+  *
+  * If you need to access session state (such as a `SessionVar`) within the context of an `LAFuture`, then import
+  * `LAFutureWithSession` and convert your `LAFuture`s with either `withCurrentSession` or `withImplicitSession`.
+  * Use `withCurrentSession` when you are already in the context of a `LiftSession`.  Use `withImplicitSession`
+  * if you have a reference to the `LiftSession`.
+  *
+  * Note that the returned `LAFuture` writes through to the original, and each method which returns another
+  * `LAFuture` also will be an `LAFutureWithSession`.  Hence any calls can be chained together, allowing an
+  * `LAFutureWithSession` to work in an arbitrary for-comprehension.
+  *
+  * Full working example:
+  * {{{
+  * package code.snippet
+  *
+  * import net.liftweb.actor.LAFuture
+  * import net.liftweb.http.{SessionVar, SHtml}
+  * import net.liftweb.http.LAFutureWithSession._
+  * import net.liftweb.http.js.JE.JsVar
+  * import net.liftweb.http.js.JsCmds
+  * import net.liftweb.util.Helpers._
+  *
+  * object MyVar extends SessionVar("init")
+  *
+  * object AjaxButton {
+  *   def render = "type=button [onclick]" #>
+  *     SHtml.ajaxCall(
+  *       JsVar("window.myGlobal"),
+  *       myGlobal => {
+  *         futureOp(myGlobal)
+  *           .withCurrentSession
+  *           .foreach(MyVar.set(_))
+  *         JsCmds.Noop
+  *       }
+  *     )
+  *
+  *   def futureOp(s:String):LAFuture[String] = LAFuture(() => "Back to the Future[T]: "+s)
+  * }
+  * }}}
+  *
+  * @see FutureWithSession
+  */
 object LAFutureWithSession {
   implicit class LAFutureDecorator[T](future:LAFuture[T]) {
     val withCurrentSession:LAFuture[T] = S.session.map(new LAFutureWithSession[T](future)(_)).

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -68,9 +68,8 @@ object LAFutureWithSession {
 
   implicit class LAFutureDecorator[T](future:LAFuture[T]) {
     val withCurrentSession:LAFuture[T] = S.session match {
-      case Full(s) =>   withSession(future, s)
-      case f:Failure => withFailure(future, f)
-      case Empty =>     withFailure(future, Failure("LiftSession not available in this thread context", Empty, Empty))
+      case Full(s) =>    withSession(future, s)
+      case f:EmptyBox => withFailure(future, f ?~! "LiftSession not available in this thread context")
     }
 
     def withImplicitSession(implicit session:LiftSession):LAFuture[T] = withSession(future, session)

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -66,8 +66,8 @@ object LAFutureWithSession {
     ff
   }
 
-  implicit class LAFutureDecorator[T](future:LAFuture[T]) {
-    val withCurrentSession:LAFuture[T] = S.session match {
+  implicit class LAFutureDecorator[T](val future:LAFuture[T]) extends AnyVal {
+    def withCurrentSession:LAFuture[T] = S.session match {
       case Full(s) =>    withSession(future, s)
       case f:EmptyBox => withFailure(future, f ?~! "LiftSession not available in this thread context")
     }

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -50,9 +50,9 @@ import net.liftweb.common.{CommonLoanWrapper, Box, Empty, Failure}
   * @see FutureWithSession
   */
 object LAFutureWithSession {
-  def sessionWrapper(session:LiftSession):CommonLoanWrapper = new CommonLoanWrapper {
+  def sessionWrapper(session:LiftSession):LAFuture.ContextFn = Some(new CommonLoanWrapper {
     override def apply[T](f: => T): T = S.initIfUninitted(session) { f }
-  }
+  })
 
   private def withSession[T](f:LAFuture[T], s:LiftSession):LAFuture[T] = {
     val sf = new LAFuture[T](f.scheduler, sessionWrapper(s))

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -1,7 +1,7 @@
 package net.liftweb.http
 
 import net.liftweb.actor.LAFuture
-import net.liftweb.common.{Box, Empty, Failure}
+import net.liftweb.common.{CommonLoanWrapper, Box, Empty, Failure}
 
 /**
   * Contains implicit conversion for `net.liftweb.actor.LAFuture` to ease access to `LiftSession` resources.
@@ -47,42 +47,18 @@ import net.liftweb.common.{Box, Empty, Failure}
   * @see FutureWithSession
   */
 object LAFutureWithSession {
+  def sessionWrapper(session:LiftSession):CommonLoanWrapper = new CommonLoanWrapper {
+    override def apply[T](f: => T): T = S.initIfUninitted(session) { f }
+  }
+
   implicit class LAFutureDecorator[T](future:LAFuture[T]) {
-    val withCurrentSession:LAFuture[T] = S.session.map(new LAFutureWithSession[T](future)(_)).
+    val withCurrentSession:LAFuture[T] = S.session.map(s => new LAFuture[T](future.scheduler, sessionWrapper(s))).
       openOr {
         val f = new LAFuture[T](future.scheduler)
         f.fail(Failure("LiftSession not available in this thread context", Empty, Empty))
         f
       }
 
-    def withImplicitSession(implicit session:LiftSession):LAFuture[T] = new LAFutureWithSession[T](future)
+    def withImplicitSession(implicit session:LiftSession):LAFuture[T] = new LAFuture[T](future.scheduler, sessionWrapper(session))
   }
-}
-
-private [http] class LAFutureWithSession[T](future:LAFuture[T])(implicit session:LiftSession) extends LAFuture[T](future.scheduler) {
-  import LAFutureWithSession._
-
-  // The following methods don't need access to the session, but need to write through to the original future
-  override def abort() = future.abort()
-  override def isAborted: Boolean = future.isAborted
-  override def complete_? : Boolean = future.complete_?
-  override def fail(e: Box[Nothing]) = future.fail(e)
-  override def satisfy(value: T): Unit = future.satisfy(value)
-  override def get(timeout: Long): Box[T] = future.get(timeout)
-  override def get: T = future.get
-  override def isSatisfied: Boolean = future.isSatisfied
-
-  // The following methods execute the function arguments in the session
-  override def onComplete(f: Box[T] => Unit) = future.onComplete( b => S.initIfUninitted(session) { f(b) } )
-  override def onFail(f: Box[Nothing] => Unit) = future.onFail( b => S.initIfUninitted(session) { f(b) } )
-  override def onSuccess(f: T => Unit) = future.onSuccess( v => S.initIfUninitted(session) { f(v) } )
-
-  // The following methods reuse existing methods, so no need to handle sessions here. Overriding so chaining
-  // and hence for-comprehensions work.
-  override def flatMap[A](f: T => LAFuture[A]): LAFuture[A] = future.flatMap(f).withImplicitSession
-  override def filter(f: T => Boolean): LAFuture[T] = future.filter(f).withImplicitSession
-  override def map[A](f: T => A): LAFuture[A] = future.map(f).withImplicitSession
-
-  // The following methods are implemented reusing existing methods: complete, foreach, fail(Exception), and withFilter
-  // We still have them covered by tests in case future changes to the LAFuture changes this.
 }

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -9,11 +9,14 @@ import net.liftweb.common.{CommonLoanWrapper, Box, Empty, Failure}
   * If you need to access session state (such as a `SessionVar`) within the context of an `LAFuture`, then import
   * `LAFutureWithSession` and convert your `LAFuture`s with either `withCurrentSession` or `withImplicitSession`.
   * Use `withCurrentSession` when you are already in the context of a `LiftSession`.  Use `withImplicitSession`
-  * if you have a reference to the `LiftSession`.
+  * if you instead have a reference to the `LiftSession`.
   *
-  * Note that the returned `LAFuture` writes through to the original, and each method which returns another
-  * `LAFuture` also will be an `LAFutureWithSession`.  Hence any calls can be chained together, allowing an
-  * `LAFutureWithSession` to work in an arbitrary for-comprehension.
+  * The `LAFuture` returned by `withCurrentSession` or `withImplicitSession` is satisfied by the same value
+  * as the original `LAFuture` and each method which returns another `LAFuture` also will be an `LAFutureWithSession`.
+  * Hence any calls can be chained together, allowing an `LAFutureWithSession` to work in an arbitrary for-comprehension.
+  *
+  * Note that the returned `LAFuture` does NOT write through to the original, hence satisfying the
+  * `LAFutureWithSession` will have no bearing on the original `LAFuture`.
   *
   * Full working example:
   * {{{

--- a/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
@@ -44,7 +44,7 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
         case _ => // Just to avoid the compiler warning
       }
 
-      S.initIfUninitted(session) { TestVar1.get must eventually(beEqualTo("onComplete")) }
+      S.initIfUninitted(session) { TestVar1.is must eventually(beEqualTo("onComplete")) }
     }
 
     "have access to session variables in andThen() chains" in {
@@ -62,8 +62,8 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
       val expected:Option[Try[String]] = Some(Success("new value"))
 
       S.initIfUninitted(session) {
-        TestVar1.get must eventually(beEqualTo("new value"))
-        TestVar2.get must eventually(beEqualTo("new value"))
+        TestVar1.is must eventually(beEqualTo("new value"))
+        TestVar2.is must eventually(beEqualTo("new value"))
         actual.value must eventually(beEqualTo(expected))
       }
     }
@@ -77,8 +77,8 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
         Future("something").withCurrentSession
       }
       val actual:Future[String] = future
-        .collect { case s:String => s+"-"+TestVar1.get }
-        .collect { case s:String => s+"-"+TestVar2.get }
+        .collect { case s:String => s+"-"+TestVar1.is }
+        .collect { case s:String => s+"-"+TestVar2.is }
       val expected:Option[Try[String]] = Some(Success("something-collect1-collect2"))
 
       actual.value must eventually(beEqualTo(expected))
@@ -92,7 +92,7 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
         Future.failed[String](new Exception("failure")).withCurrentSession
       }
       val actual:Future[String] = future.failed
-        .collect { case e:Exception => e.getMessage+"-"+TestVar1.get }
+        .collect { case e:Exception => e.getMessage+"-"+TestVar1.is }
       val expected:Option[Try[String]] = Some(Success("failure-fail"))
 
       actual.value must eventually(beEqualTo(expected))
@@ -106,7 +106,7 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
         Future.failed[String](new Exception("failure")).withCurrentSession
       }
       val actual:Future[String] = future.fallbackTo(Future("success"))
-        .map(_+"-"+TestVar1.get)
+        .map(_+"-"+TestVar1.is)
       val expected:Option[Try[String]] = Some(Success("success-fallbackTo"))
 
       actual.value must eventually(beEqualTo(expected))
@@ -121,8 +121,8 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
         Future("has map1").withCurrentSession
       }
       val actual:Future[String] = future
-        .filter(_.contains(TestVar1.get))
-        .filter(_.contains(TestVar2.get))
+        .filter(_.contains(TestVar1.is))
+        .filter(_.contains(TestVar2.is))
 
       val expected:Option[Try[String]] = Some(Success("has map1"))
 
@@ -138,8 +138,8 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
         Future("something").withCurrentSession
       }
       val actual:Future[String] = future
-        .flatMap{in => val out = in+"-"+TestVar1.get; Future(out)}
-        .flatMap{in => val out = in+"-"+TestVar2.get; Future(out)}
+        .flatMap{in => val out = in+"-"+TestVar1.is; Future(out)}
+        .flatMap{in => val out = in+"-"+TestVar2.is; Future(out)}
       val expected:Option[Try[String]] = Some(Success("something-map1-map2"))
 
       actual.value must eventually(beEqualTo(expected))
@@ -151,7 +151,7 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
       val future:Future[String] = Future("foreach").withImplicitSession
       future.foreach(TestVar1.set)
 
-      S.initIfUninitted(session) { TestVar1.get } must eventually(beEqualTo("foreach"))
+      S.initIfUninitted(session) { TestVar1.is } must eventually(beEqualTo("foreach"))
     }
 
     "have access to session variables in map() chains" in {
@@ -163,8 +163,8 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
         Future("something").withCurrentSession
       }
       val actual:Future[String] = future
-        .map(_+"-"+TestVar1.get)
-        .map(_+"-"+TestVar2.get)
+        .map(_+"-"+TestVar1.is)
+        .map(_+"-"+TestVar2.is)
       val expected:Option[Try[String]] = Some(Success("something-map1-map2"))
 
       actual.value must eventually(beEqualTo(expected))
@@ -179,7 +179,7 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
       }
       val actual:Future[String] = future
         .mapTo[String]
-        .map(_+"-"+TestVar1.get)
+        .map(_+"-"+TestVar1.is)
       val expected:Option[Try[String]] = Some(Success("something-mapTo"))
 
       actual.value must eventually(beEqualTo(expected))
@@ -191,7 +191,7 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
       val future:Future[String] = Future.failed[String](new Exception("failure")).withImplicitSession
       future.onFailure { case e:Exception => TestVar1.set(e.getMessage) }
 
-      S.initIfUninitted(session) { TestVar1.get } must eventually(beEqualTo("failure"))
+      S.initIfUninitted(session) { TestVar1.is } must eventually(beEqualTo("failure"))
     }
 
     "have access to session variables in onSuccess()" in {
@@ -200,7 +200,7 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
       val future:Future[String] = Future("onSuccess").withImplicitSession
       future.onSuccess { case s => TestVar1.set(s) }
 
-      S.initIfUninitted(session) { TestVar1.get } must eventually(beEqualTo("onSuccess"))
+      S.initIfUninitted(session) { TestVar1.is } must eventually(beEqualTo("onSuccess"))
     }
 
     "have access to session variables with recover()" in {
@@ -212,8 +212,8 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
         Future.failed[String](new Exception("failure")).withCurrentSession
       }
       val actual:Future[String] = future
-        .recover { case e:Throwable => e.getMessage+"-"+TestVar1.get }
-        .map(_+"-"+TestVar2.get)
+        .recover { case e:Throwable => e.getMessage+"-"+TestVar1.is }
+        .map(_+"-"+TestVar2.is)
       val expected:Option[Try[String]] = Some(Success("failure-recover1-recover2"))
 
       actual.value must eventually(beEqualTo(expected))
@@ -228,8 +228,8 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
         Future.failed[String](new Exception("failure")).withCurrentSession
       }
       val actual:Future[String] = future
-        .recoverWith { case e:Throwable => val out = e.getMessage+"-"+TestVar1.get; Future(out) }
-        .map(_+"-"+TestVar2.get)
+        .recoverWith { case e:Throwable => val out = e.getMessage+"-"+TestVar1.is; Future(out) }
+        .map(_+"-"+TestVar2.is)
       val expected:Option[Try[String]] = Some(Success("failure-recover1-recover2"))
 
       actual.value must eventually(beEqualTo(expected))
@@ -244,8 +244,8 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
         Future("orig").withCurrentSession
       }
       val actual:Future[String] = future
-        .transform( s => throw new Exception(TestVar1.get), identity[Throwable] )
-        .transform( identity[String], t => new Exception(t.getMessage+"-"+TestVar2.get) )
+        .transform( s => throw new Exception(TestVar1.is), identity[Throwable] )
+        .transform( identity[String], t => new Exception(t.getMessage+"-"+TestVar2.is) )
         .recover { case e:Exception => e.getMessage }
 
       val expected:Option[Try[String]] = Some(Success("transform1-transform2"))
@@ -262,7 +262,7 @@ object FutureWithSessionSpec extends Specification with ThrownMessages {
       }
       val actual:Future[String] = future
         .zip(Future("two"))
-        .collect { case (one, two) => one+"-"+TestVar1.get+"-"+two }
+        .collect { case (one, two) => one+"-"+TestVar1.is+"-"+two }
 
       val expected:Option[Try[String]] = Some(Success("one-zip-two"))
 

--- a/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
@@ -9,8 +9,8 @@ import scala.util.{Try, Success}
 
 object FutureWithSessionSpec extends Specification {
 
-  object TestVar1 extends SessionVar[String]("test1")
-  object TestVar2 extends SessionVar[String]("test2")
+  object TestVar1 extends SessionVar[String]("Uninitialized1")
+  object TestVar2 extends SessionVar[String]("Uninitialized2")
 
   "A FutureWithSession" should {
     "fail if session is not available" in {
@@ -35,53 +35,13 @@ object FutureWithSessionSpec extends Specification {
       }
     }
 
-    "have access to session variables in map() chains" in {
-      val session = new LiftSession("Test Session", "", Empty)
+    "have access to session variables in onComplete()" in {
+      implicit val session = new LiftSession("Test Session", "", Empty)
 
-      val future:Future[String] = S.initIfUninitted(session) {
-        TestVar1("map1")
-        TestVar2("map2")
-        Future("something").withCurrentSession
-      }
-      val actual:Future[String] = future
-        .map(_+"-"+TestVar1.get)
-        .map(_+"-"+TestVar2.get)
-      val expected:Option[Try[String]] = Some(Success("something-map1-map2"))
+      val future:Future[String] = Future("onComplete").withImplicitSession
+      future.onComplete { case Success(s) => TestVar1.set(s) }
 
-      actual.value must eventually(beEqualTo(expected))
-    }
-
-    "have access to session variables in flatMap() chains" in {
-      val session = new LiftSession("Test Session", "", Empty)
-
-      val future:Future[String] = S.initIfUninitted(session) {
-        TestVar1("map1")
-        TestVar2("map2")
-        Future("something").withCurrentSession
-      }
-      val actual:Future[String] = future
-        .flatMap{in => val out = in+"-"+TestVar1.get; Future(out)}
-        .flatMap{in => val out = in+"-"+TestVar2.get; Future(out)}
-      val expected:Option[Try[String]] = Some(Success("something-map1-map2"))
-
-      actual.value must eventually(beEqualTo(expected))
-    }
-
-    "have access to session variables in filter() chains" in {
-      val session = new LiftSession("Test Session", "", Empty)
-
-      val future:Future[String] = S.initIfUninitted(session) {
-        TestVar1("map1")
-        TestVar2("map")
-        Future("has map1").withCurrentSession
-      }
-      val actual:Future[String] = future
-        .filter(_.contains(TestVar1.get))
-        .filter(_.contains(TestVar2.get))
-
-      val expected:Option[Try[String]] = Some(Success("has map1"))
-
-      actual.value must eventually(beEqualTo(expected))
+      S.initIfUninitted(session) { TestVar1.get must beEqualTo("onComplete") }
     }
 
     "have access to session variables in andThen() chains" in {
@@ -135,18 +95,175 @@ object FutureWithSessionSpec extends Specification {
       actual.value must eventually(beEqualTo(expected))
     }
 
+    "have access to session variables after calling fallbackTo()" in {
+      val session = new LiftSession("Test Session", "", Empty)
 
-    "initialize with an implicit LiftSession" in {
-      implicit val session = new LiftSession("Test Session", "", Empty)
-      S.initIfUninitted(session) {
-        TestVar1("map")
+      val future:Future[String] = S.initIfUninitted(session) {
+        TestVar1("fallbackTo")
+        Future.failed[String](new Exception("failure")).withCurrentSession
       }
-
-      val actual:Future[String] = Future("something").withImplicitSession.map(_+"-"+TestVar1.get)
-      val expected:Option[Try[String]] = Some(Success("something-map"))
+      val actual:Future[String] = future.fallbackTo(Future("success"))
+        .map(_+"-"+TestVar1.get)
+      val expected:Option[Try[String]] = Some(Success("success-fallbackTo"))
 
       actual.value must eventually(beEqualTo(expected))
     }
 
+    "have access to session variables in filter() chains" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[String] = S.initIfUninitted(session) {
+        TestVar1("map1")
+        TestVar2("map")
+        Future("has map1").withCurrentSession
+      }
+      val actual:Future[String] = future
+        .filter(_.contains(TestVar1.get))
+        .filter(_.contains(TestVar2.get))
+
+      val expected:Option[Try[String]] = Some(Success("has map1"))
+
+      actual.value must eventually(beEqualTo(expected))
+    }
+
+    "have access to session variables in flatMap() chains" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[String] = S.initIfUninitted(session) {
+        TestVar1("map1")
+        TestVar2("map2")
+        Future("something").withCurrentSession
+      }
+      val actual:Future[String] = future
+        .flatMap{in => val out = in+"-"+TestVar1.get; Future(out)}
+        .flatMap{in => val out = in+"-"+TestVar2.get; Future(out)}
+      val expected:Option[Try[String]] = Some(Success("something-map1-map2"))
+
+      actual.value must eventually(beEqualTo(expected))
+    }
+
+    "have access to session variables in foreach()" in {
+      implicit val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[String] = Future("foreach").withImplicitSession
+      future.foreach(TestVar1.set)
+
+      S.initIfUninitted(session) { TestVar1.get } must eventually(beEqualTo("foreach"))
+    }
+
+    "have access to session variables in map() chains" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[String] = S.initIfUninitted(session) {
+        TestVar1("map1")
+        TestVar2("map2")
+        Future("something").withCurrentSession
+      }
+      val actual:Future[String] = future
+        .map(_+"-"+TestVar1.get)
+        .map(_+"-"+TestVar2.get)
+      val expected:Option[Try[String]] = Some(Success("something-map1-map2"))
+
+      actual.value must eventually(beEqualTo(expected))
+    }
+
+    "yield another FutureWithSession with mapTo()" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[Object] = S.initIfUninitted(session) {
+        TestVar1("mapTo")
+        Future("something").withCurrentSession
+      }
+      val actual:Future[String] = future
+        .mapTo[String]
+        .map(_+"-"+TestVar1.get)
+      val expected:Option[Try[String]] = Some(Success("something-mapTo"))
+
+      actual.value must eventually(beEqualTo(expected))
+    }
+
+    "have access to session variables in onFailure()" in {
+      implicit val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[String] = Future.failed[String](new Exception("failure")).withImplicitSession
+      future.onFailure { case e:Exception => TestVar1.set(e.getMessage) }
+
+      S.initIfUninitted(session) { TestVar1.get } must eventually(beEqualTo("failure"))
+    }
+
+    "have access to session variables in onSuccess()" in {
+      implicit val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[String] = Future("onSuccess").withImplicitSession
+      future.onSuccess { case s => TestVar1.set(s) }
+
+      S.initIfUninitted(session) { TestVar1.get } must eventually(beEqualTo("onSuccess"))
+    }
+
+    "have access to session variables with recover()" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[String] = S.initIfUninitted(session) {
+        TestVar1("recover1")
+        TestVar2("recover2")
+        Future.failed[String](new Exception("failure")).withCurrentSession
+      }
+      val actual:Future[String] = future
+        .recover { case e:Throwable => e.getMessage+"-"+TestVar1.get }
+        .map(_+"-"+TestVar2.get)
+      val expected:Option[Try[String]] = Some(Success("failure-recover1-recover2"))
+
+      actual.value must eventually(beEqualTo(expected))
+    }
+
+    "have access to session variables with recoverWith()" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[String] = S.initIfUninitted(session) {
+        TestVar1("recover1")
+        TestVar2("recover2")
+        Future.failed[String](new Exception("failure")).withCurrentSession
+      }
+      val actual:Future[String] = future
+        .recoverWith { case e:Throwable => val out = e.getMessage+"-"+TestVar1.get; Future(out) }
+        .map(_+"-"+TestVar2.get)
+      val expected:Option[Try[String]] = Some(Success("failure-recover1-recover2"))
+
+      actual.value must eventually(beEqualTo(expected))
+    }
+
+    "have access to session variables with transform()" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[String] = S.initIfUninitted(session) {
+        TestVar1("transform1")
+        TestVar2("transform2")
+        Future("orig").withCurrentSession
+      }
+      val actual:Future[String] = future
+        .transform( s => throw new Exception(TestVar1.get), identity[Throwable] )
+        .transform( identity[String], t => new Exception(t.getMessage+"-"+TestVar2.get) )
+        .recover { case e:Exception => e.getMessage }
+
+      val expected:Option[Try[String]] = Some(Success("transform1-transform2"))
+
+      actual.value must eventually(beEqualTo(expected))
+    }
+
+    "yield another FutureWithSession with zip()" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      val future:Future[String] = S.initIfUninitted(session) {
+        TestVar1("zip")
+        Future("one").withCurrentSession
+      }
+      val actual:Future[String] = future
+        .zip(Future("two"))
+        .collect { case (one, two) => one+"-"+TestVar1.get+"-"+two }
+
+      val expected:Option[Try[String]] = Some(Success("one-zip-two"))
+
+      actual.value must eventually(beEqualTo(expected))
+    }
   }
 }

--- a/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
@@ -39,9 +39,12 @@ object FutureWithSessionSpec extends Specification {
       implicit val session = new LiftSession("Test Session", "", Empty)
 
       val future:Future[String] = Future("onComplete").withImplicitSession
-      future.onComplete { case Success(s) => TestVar1.set(s) }
+      future.onComplete { 
+        case Success(s) => TestVar1.set(s) 
+        case _ => // Just to avoid the compiler warning
+      }
 
-      S.initIfUninitted(session) { TestVar1.get must beEqualTo("onComplete") }
+      S.initIfUninitted(session) { TestVar1.get must eventually(beEqualTo("onComplete")) }
     }
 
     "have access to session variables in andThen() chains" in {
@@ -59,8 +62,8 @@ object FutureWithSessionSpec extends Specification {
       val expected:Option[Try[String]] = Some(Success("new value"))
 
       S.initIfUninitted(session) {
-        TestVar1.get must beEqualTo("new value")
-        TestVar2.get must beEqualTo("new value")
+        TestVar1.get must eventually(beEqualTo("new value"))
+        TestVar2.get must eventually(beEqualTo("new value"))
         actual.value must eventually(beEqualTo(expected))
       }
     }

--- a/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
@@ -1,0 +1,37 @@
+package net.liftweb.http
+
+import net.liftweb.common.Empty
+import scala.concurrent._
+import org.specs2.mutable.Specification
+import FutureWithSession._
+
+import scala.util.{Try, Success}
+
+object FutureWithSessionSpec extends Specification {
+
+  object TestVar extends SessionVar[String]("test")
+
+  "A FutureWithSession" should {
+    "fail if session is not available" in {
+      val actual = Future("something").withSession
+
+      // TODO: Why the hell does this not work??
+//      val expected:Option[Try[String]] = Some(Failure(new Exception))
+//      actual.value must eventually(beEqualTo(expected))
+
+      actual.value.isDefined must eventually(beTrue)
+      actual.value.get must beFailedTry.withThrowable[Exception]("LiftSession not available in this thread context")
+    }
+
+    "succeed with the original value if in a session" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      S.initIfUninitted(session) {
+        val actual = Future("something").withSession
+        val expected:Option[Try[String]] = Some(Success("something"))
+
+        actual.value must eventually(beEqualTo(expected))
+      }
+    }
+  }
+}

--- a/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
@@ -13,7 +13,7 @@ object FutureWithSessionSpec extends Specification {
 
   "A FutureWithSession" should {
     "fail if session is not available" in {
-      val actual = Future("something").withSession
+      val actual:Future[String] = Future("something").withSession
 
       // TODO: Why the hell does this not work??
 //      val expected:Option[Try[String]] = Some(Failure(new Exception))
@@ -27,7 +27,7 @@ object FutureWithSessionSpec extends Specification {
       val session = new LiftSession("Test Session", "", Empty)
 
       S.initIfUninitted(session) {
-        val actual = Future("something").withSession
+        val actual:Future[String] = Future("something").withSession
         val expected:Option[Try[String]] = Some(Success("something"))
 
         actual.value must eventually(beEqualTo(expected))

--- a/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
@@ -39,7 +39,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
     "have access to session variables in onComplete()" in {
       implicit val session = new LiftSession("Test Session", "", Empty)
 
-      val future = LAFuture(() => "onComplete", futureSpecScheduler).withImplicitSession
+      val future = LAFuture.build("onComplete", futureSpecScheduler).withImplicitSession
       future.onComplete {
         case Full(s) => TestVar1.set(s)
         case _ => fail("The future should have completed!")
@@ -75,7 +75,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
       val session = new LiftSession("Test Session", "", Empty)
 
       S.initIfUninitted(session) {
-        val future = LAFuture(() => "something in it", futureSpecScheduler).withCurrentSession
+        val future = LAFuture.build("something in it", futureSpecScheduler).withCurrentSession
         TestVar1("something")
         TestVar2("in it")
 
@@ -91,7 +91,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
       val session = new LiftSession("Test Session", "", Empty)
 
       S.initIfUninitted(session) {
-        val future = LAFuture(() => "something in it", futureSpecScheduler).withCurrentSession
+        val future = LAFuture.build("something in it", futureSpecScheduler).withCurrentSession
         TestVar1("something")
         TestVar2("in it")
 
@@ -107,7 +107,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
       val session = new LiftSession("Test Session", "", Empty)
 
       S.initIfUninitted(session) {
-        val future = LAFuture(() => "this", futureSpecScheduler).withCurrentSession
+        val future = LAFuture.build("this", futureSpecScheduler).withCurrentSession
         TestVar1(" and ")
         TestVar2("that")
 
@@ -130,7 +130,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
       val session = new LiftSession("Test Session", "", Empty)
 
       S.initIfUninitted(session) {
-        val future = LAFuture(() => "this", futureSpecScheduler).withCurrentSession
+        val future = LAFuture.build("this", futureSpecScheduler).withCurrentSession
         TestVar1(" and ")
         TestVar2("that")
 
@@ -144,7 +144,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
       val session = new LiftSession("Test Session", "", Empty)
 
       S.initIfUninitted(session) {
-        val future = LAFuture(() => "stuff", futureSpecScheduler).withCurrentSession
+        val future = LAFuture.build("stuff", futureSpecScheduler).withCurrentSession
         future.foreach(TestVar1.apply(_))
 
         TestVar1.get must eventually(beEqualTo("stuff"))
@@ -152,7 +152,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
     }
 
     "have the same scheduler as the original LAFuture when no session is available" in {
-      val future = LAFuture(() => "stuff", futureSpecScheduler).withCurrentSession
+      val future = LAFuture.build("stuff", futureSpecScheduler).withCurrentSession
 
       future.scheduler must beEqualTo(futureSpecScheduler)
     }
@@ -161,7 +161,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
       val session = new LiftSession("Test Session", "", Empty)
 
       S.initIfUninitted(session) {
-        val future = LAFuture(() => "stuff", futureSpecScheduler).withCurrentSession
+        val future = LAFuture.build("stuff", futureSpecScheduler).withCurrentSession
 
         future.scheduler must beEqualTo(futureSpecScheduler)
       }

--- a/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
@@ -1,0 +1,21 @@
+package net.liftweb.http
+
+import net.liftweb.actor.LAFuture
+import net.liftweb.common.{ Failure, Full, Empty }
+import org.specs2.matcher.ThrownMessages
+import org.specs2.mutable.Specification
+
+import LAFutureWithSession._
+
+object LAFutureWithSessionSpec extends Specification with ThrownMessages {
+  object TestVar1 extends SessionVar[String]("Uninitialized1")
+  object TestVar2 extends SessionVar[String]("Uninitialized2")
+
+  "An LAFutureWithSession" should {
+    "fail if session is not available" in {
+      val actual: LAFuture[String] = new LAFuture[String]().withCurrentSession
+
+      actual.get(0) must beEqualTo(Failure("LiftSession not available in this thread context", Empty, Empty))
+    }
+  }
+}

--- a/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
@@ -45,7 +45,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
         case _ => fail("The future should have completed!")
       }
 
-      S.initIfUninitted(session) { TestVar1.get must eventually(beEqualTo("onComplete")) }
+      S.initIfUninitted(session) { TestVar1.is must eventually(beEqualTo("onComplete")) }
     }
 
     "have access to session variables in onFail()" in {
@@ -58,7 +58,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
       }
       future.fail(new Exception("fail"))
 
-      S.initIfUninitted(session) { TestVar1.get must eventually(beEqualTo("fail")) }
+      S.initIfUninitted(session) { TestVar1.is must eventually(beEqualTo("fail")) }
     }
 
     "have access to session variables in onSuccess()" in {
@@ -68,7 +68,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
       future.onSuccess(TestVar1.apply(_))
       future.satisfy("success!!")
 
-      S.initIfUninitted(session) { TestVar1.get must eventually(beEqualTo("success!!")) }
+      S.initIfUninitted(session) { TestVar1.is must eventually(beEqualTo("success!!")) }
     }
 
     "have access to session variables in chains of filter()" in {
@@ -80,8 +80,8 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
         TestVar2("in it")
 
         val filtered = future
-          .filter(_.contains(TestVar1.get))
-          .filter(_.contains(TestVar2.get))
+          .filter(_.contains(TestVar1.is))
+          .filter(_.contains(TestVar2.is))
 
         filtered.get(timeout) must beEqualTo(Full("something in it"))
       }
@@ -96,8 +96,8 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
         TestVar2("in it")
 
         val filtered = future
-          .withFilter(_.contains(TestVar1.get))
-          .withFilter(_.contains(TestVar2.get))
+          .withFilter(_.contains(TestVar1.is))
+          .withFilter(_.contains(TestVar2.is))
 
         filtered.get(timeout) must beEqualTo(Full("something in it"))
       }
@@ -113,12 +113,12 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
 
         val fm1 = future.flatMap { s =>
           val f = new LAFuture[String](futureSpecScheduler)
-          f.satisfy(s + TestVar1.get)
+          f.satisfy(s + TestVar1.is)
           f
         }
         val fm2 = fm1.flatMap { s =>
           val f = new LAFuture[String](futureSpecScheduler)
-          f.satisfy(s + TestVar2.get)
+          f.satisfy(s + TestVar2.is)
           f
         }
 
@@ -134,7 +134,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
         TestVar1(" and ")
         TestVar2("that")
 
-        val mapped = future.map(_ + TestVar1.get).map(_ + TestVar2.get)
+        val mapped = future.map(_ + TestVar1.is).map(_ + TestVar2.is)
 
         mapped.get(timeout) must beEqualTo(Full("this and that"))
       }
@@ -147,7 +147,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
         val future = LAFuture.build("stuff", futureSpecScheduler).withCurrentSession
         future.foreach(TestVar1.apply(_))
 
-        TestVar1.get must eventually(beEqualTo("stuff"))
+        TestVar1.is must eventually(beEqualTo("stuff"))
       }
     }
 

--- a/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
@@ -166,56 +166,5 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
         future.scheduler must beEqualTo(futureSpecScheduler)
       }
     }
-
-
-    "pass thru for abort() and isAborted" in {
-      val session = new LiftSession("Test Session", "", Empty)
-      val f = new LAFuture[String](futureSpecScheduler)
-      val withS  = S.initIfUninitted(session) { f.withCurrentSession }
-
-      withS.abort()
-
-      f.isAborted must beEqualTo(true)
-      withS.isAborted must beEqualTo(true)
-    }
-
-    "pass thru for complete(), complete_?, and get" in {
-      val session = new LiftSession("Test Session", "", Empty)
-      val f = new LAFuture[String](futureSpecScheduler)
-      val withS  = S.initIfUninitted(session) { f.withCurrentSession }
-
-      withS.complete(Full("complete"))
-
-      f.complete_? must beEqualTo(true)
-      withS.complete_? must beEqualTo(true)
-
-      // TODO: This will hang indefinitely if get is not implemented. Better way to test??
-      f.get must beEqualTo("complete")
-      withS.get must beEqualTo("complete")
-    }
-
-    "pass thru for fail(Box) and get(Long)" in {
-      val session = new LiftSession("Test Session", "", Empty)
-      val f = new LAFuture[String](futureSpecScheduler)
-      val withS  = S.initIfUninitted(session) { f.withCurrentSession }
-      val failure = Failure("BOOM", Empty, Empty)
-
-      withS.fail(failure)
-
-      f.get(timeout) must beEqualTo(failure)
-      withS.get(timeout) must beEqualTo(failure)
-    }
-
-    "pass thru for isSatisfied" in {
-      val session = new LiftSession("Test Session", "", Empty)
-      val f = new LAFuture[String](futureSpecScheduler)
-      val withS  = S.initIfUninitted(session) { f.withCurrentSession }
-
-      withS.satisfy("doesn't matter")
-
-      f.isSatisfied must beEqualTo(true)
-      withS.isSatisfied must beEqualTo(true)
-    }
-
   }
 }

--- a/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
@@ -1,21 +1,52 @@
 package net.liftweb.http
 
-import net.liftweb.actor.LAFuture
+import net.liftweb.actor.{LAScheduler, LAFuture}
 import net.liftweb.common.{ Failure, Full, Empty }
 import org.specs2.matcher.ThrownMessages
 import org.specs2.mutable.Specification
 
 import LAFutureWithSession._
 
-object LAFutureWithSessionSpec extends Specification with ThrownMessages {
+class LAFutureWithSessionSpec extends Specification with ThrownMessages {
+  sequential
+  val timeout = 20000L
+  LAScheduler
+
   object TestVar1 extends SessionVar[String]("Uninitialized1")
   object TestVar2 extends SessionVar[String]("Uninitialized2")
 
   "An LAFutureWithSession" should {
-    "fail if session is not available" in {
-      val actual: LAFuture[String] = new LAFuture[String]().withCurrentSession
-
-      actual.get(0) must beEqualTo(Failure("LiftSession not available in this thread context", Empty, Empty))
+    val futureSpecScheduler = new LAScheduler {
+      override def execute(f: () => Unit): Unit = f()
     }
+
+    "fail if session is not available" in {
+      val future = LAFuture(() => "something", futureSpecScheduler).withCurrentSession
+
+      future.get(timeout) shouldEqual Failure("LiftSession not available in this thread context", Empty, Empty)
+    }
+
+    "succeed with the original value if in a session" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      S.initIfUninitted(session) {
+        val future = LAFuture(() => "something", futureSpecScheduler).withCurrentSession
+
+        future.get(timeout) shouldEqual Full("something")
+      }
+    }
+
+    "have access to session variables in onComplete()" in {
+      implicit val session = new LiftSession("Test Session", "", Empty)
+
+      val future = LAFuture(() => "onComplete", futureSpecScheduler).withImplicitSession
+      future.onComplete {
+        case Full(s) => TestVar1.set(s)
+        case _ => fail("The future should have completed!")
+      }
+
+      S.initIfUninitted(session) { TestVar1.get must eventually(beEqualTo("onComplete")) }
+    }
+
   }
 }

--- a/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
@@ -21,7 +21,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
     }
 
     "fail if session is not available" in {
-      val future = LAFuture(() => "something", futureSpecScheduler).withCurrentSession
+      val future = LAFuture.build("something", futureSpecScheduler).withCurrentSession
 
       future.get(timeout) shouldEqual Failure("LiftSession not available in this thread context", Empty, Empty)
     }
@@ -30,7 +30,7 @@ class LAFutureWithSessionSpec extends Specification with ThrownMessages {
       val session = new LiftSession("Test Session", "", Empty)
 
       S.initIfUninitted(session) {
-        val future = LAFuture(() => "something", futureSpecScheduler).withCurrentSession
+        val future = LAFuture.build("something", futureSpecScheduler).withCurrentSession
 
         future.get(timeout) shouldEqual Full("something")
       }


### PR DESCRIPTION
Our code base at work is getting littered with `S.session.map { session => S.initIfUninitted(session) { /** stuff */ } }` because we interleave threads from akka actors and futures.  Now that Lift supports only 2.11.x I think it would be a nice addition to have `LiftSession`-aware `scala.concurrent.Future[T]`'s that I've been working on for our project.

Just to take an excerpt from the spec code, this will now work:

``` scala
object TestVar1 extends SessionVar[String]("test1")
object TestVar2 extends SessionVar[String]("test2")

"A FutureWithSession" should {
  "have access to session variables in map() chains" in {
    val session = new LiftSession("Test Session", "", Empty)

    val future:Future[String] = S.initIfUninitted(session) {
      TestVar1("map1")
      TestVar2("map2")
      Future("something").withCurrentSession
    }
    val actual:Future[String] = future
      .map(_+"-"+TestVar1.get)
      .map(_+"-"+TestVar2.get)
    val expected:Option[Try[String]] = Some(Success("something-map1-map2"))

    actual.value must eventually(beEqualTo(expected))
  }
}
```

Because I converted the `Future("something")` into a `FutureWIthSession[T]` via the implicit `withCurrentSession` val, I am able to access the `SessionVar`s in the map lambdas.  

How do y'all feel about this addition? I've implemented everything we need at work, but I'll gladly finish this out if everyone likes it for Lift.
