### PR TITLE
Fix BaseParsers ws parser to not match newlines.

### DIFF
--- a/core/markdown/src/main/scala/net/liftweb/markdown/BaseParsers.scala
+++ b/core/markdown/src/main/scala/net/liftweb/markdown/BaseParsers.scala
@@ -46,7 +46,7 @@ trait BaseParsers extends RegexParsers {
     /** accepts one or more spaces or tabs
      * returns the matched whitespace
      */
-    def ws:Parser[String] = """( |\t|\v)+""".r
+    def ws:Parser[String] = """( |\t|\x0B)+""".r
 
     /** accepts zero or more spaces or tabs
      * returns the matched whitespace


### PR DESCRIPTION
In lift-markdown, BaseParsers was using a regex containing `\v` to indicate a
vertical tab. As of Java 8, `\v` refers to a character class that contains all
vertical whitespace, including newlines. We now explicitly use the unicode
value for vertical tab in the regex, fixing the failing test in Java 8 and
generally making things work as expected.

See [initial report from @farmdawgnation ](https://groups.google.com/forum/#!topic/liftweb/10aF9sk-jO0).