### PR TITLE
Making the Msgs fade and effect scripts append to lift's page script

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msg.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msg.scala
@@ -116,13 +116,13 @@ object Msg extends DispatchSnippet {
   }
 
   /**
-   * This method renders a <script/> element that renders effects for
+   * This method appends a script element to lift's page script that renders effects for
    * the given id.
    *
    * @see net.liftweb.builtin.snippet.Msgs#effects[T](Box[NoticeType.Value],String,T,Box[JsCmd => T])
    */
   def effects(id: String): NodeSeq =
-    Msgs.effects(Empty, id, NodeSeq.Empty, Msgs.tailScript)
+    Msgs.effects(Empty, id, NodeSeq.Empty, Msgs.appendScript)
 }
 
 /**

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msg.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msg.scala
@@ -115,9 +115,9 @@ object Msg extends DispatchSnippet {
     }
   }
 
-  /**
-   * This method appends a script element to lift's page script that renders effects for
-   * the given id.
+  /** 
+   * This method produces and appends a script element to lift's page script 
+   * to render effects on a element with the given id.
    *
    * @see net.liftweb.builtin.snippet.Msgs#effects[T](Box[NoticeType.Value],String,T,Box[JsCmd => T])
    */

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msgs.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msgs.scala
@@ -141,7 +141,10 @@ object Msgs extends DispatchSnippet {
          (S.notices, NoticeType.Notice, MsgsNoticeMeta)).flatMap(computeMessageDiv)
   }
 
-  // This wraps the JavaScript fade and effect scripts into lift's page script that runs onLoad
+  /**
+   *  This method wraps the JavaScript fade and effect scripts into lift's page 
+   *  script that runs onLoad.
+   */
   private[snippet] def appendScript (script : JsCmd) : NodeSeq = { 
     S.appendJs(script)
     NodeSeq.Empty 
@@ -163,8 +166,8 @@ object Msgs extends DispatchSnippet {
     } openOr default
 
   /**
-   * This method produces an appropriate <script> tag to fade out the given
-   * notice type.
+   * This method produces and appends a script element to lift's page script
+   * to fade out the given notice type. 
    *
    * @see net.liftweb.http.LiftRules.noticesAutoFadeOut
    */
@@ -186,8 +189,8 @@ object Msgs extends DispatchSnippet {
     }
 
   /**
-   * This method produces an appropriate <script> tag to apply effects to
-   * the given notice type.
+   * This method produces and appends a script element to lift's page script
+   * to apply effects to the given notice type.
    *
    * @see net.liftweb.http.LiftRules.noticesEffects
    */

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msgs.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msgs.scala
@@ -145,6 +145,12 @@ object Msgs extends DispatchSnippet {
   private[snippet] def tailScript (script : JsCmd) : NodeSeq =
     <lift:tail>{Script(OnLoad(script))}</lift:tail>
 
+  // This wraps the JavaScript fade and effect scripts into lift's page script that runs onLoad
+  private[snippet] def appendScript (script : JsCmd) : NodeSeq = { 
+    S.appendJs(script)
+    NodeSeq.Empty 
+  }
+
   /**
    * This method produces appropriate JavaScript to fade out the given
    * notice type. The caller must provide a default value for cases where
@@ -167,7 +173,7 @@ object Msgs extends DispatchSnippet {
    * @see net.liftweb.http.LiftRules.noticesAutoFadeOut
    */
   def noticesFadeOut(noticeType: NoticeType.Value): NodeSeq = 
-    noticesFadeOut(noticeType, NodeSeq.Empty, tailScript)
+    noticesFadeOut(noticeType, NodeSeq.Empty, appendScript)
 
   /**
    * This method produces appropriate JavaScript to apply effects to the given
@@ -190,7 +196,7 @@ object Msgs extends DispatchSnippet {
    * @see net.liftweb.http.LiftRules.noticesEffects
    */
   def effects(noticeType: NoticeType.Value): NodeSeq =
-    effects(Full(noticeType), noticeType.id, NodeSeq.Empty, tailScript)
+    effects(Full(noticeType), noticeType.id, NodeSeq.Empty, appendScript)
 }
 
 /**

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msgs.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Msgs.scala
@@ -141,10 +141,6 @@ object Msgs extends DispatchSnippet {
          (S.notices, NoticeType.Notice, MsgsNoticeMeta)).flatMap(computeMessageDiv)
   }
 
-  // This wraps the JavaScript fade and effect scripts into a script that runs onLoad
-  private[snippet] def tailScript (script : JsCmd) : NodeSeq =
-    <lift:tail>{Script(OnLoad(script))}</lift:tail>
-
   // This wraps the JavaScript fade and effect scripts into lift's page script that runs onLoad
   private[snippet] def appendScript (script : JsCmd) : NodeSeq = { 
     S.appendJs(script)


### PR DESCRIPTION
Instead of (as in lift 2.6) using the in-lining tailScript function Msgs fade and effect scripts will now instead append to lifts page script. The change makes it better align with Lifts CSP settings. 