### PR TITLE
7 Javas and a Samurai: Drop build to Java 7 for now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
 services:
   - mongodb
 jdk:
-  - oraclejdk8
+  - oraclejdk7
 
 script: ./travis.sh
 


### PR DESCRIPTION
Drop our travis build (and therefore snapshots) to use Java 7 until
we get M7 out the door. Then we'll bump to Java 8 for the final Lift 3
release.