### PR TITLE
Well Rested Futures: Implement Scala Future support in RestHelper

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/CanResolveAsync.scala
+++ b/core/util/src/main/scala/net/liftweb/util/CanResolveAsync.scala
@@ -40,7 +40,10 @@ trait CanResolveAsync[ResolvableType, ResolvedType] {
    */
   def resolveAsync(resolvable: ResolvableType, onResolved: (ResolvedType)=>Unit): Unit
 }
-object CanResolveAsync {
+
+trait LowPriorityCanResolveAsyncImplicits {
+  self: CanResolveAsync.type =>
+
   // Low priority implicit for resolving Scala Futures.
   implicit def resolveFuture[T](implicit executionContext: ExecutionContext) = {
     new CanResolveAsync[Future[T],T] {
@@ -59,3 +62,4 @@ object CanResolveAsync {
     }
   }
 }
+object CanResolveAsync extends LowPriorityCanResolveAsyncImplicits

--- a/core/util/src/main/scala/net/liftweb/util/CanResolveAsync.scala
+++ b/core/util/src/main/scala/net/liftweb/util/CanResolveAsync.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package util
+
+import scala.concurrent.{ExecutionContext,Future}
+
+import actor.LAFuture
+
+/**
+ * Represents a unifying class that can resolve an asynchronous container.  For
+ * example, a `Future[String]` can be resolved by a
+ * `CanResolveAsync[Future[String], String]`.
+ *
+ * Provides one method, `[[resolveAsync]]`, that takes the async container and
+ * a function to run when the container resolves.
+ */
+trait CanResolveAsync[ResolvableType, ResolvedType] {
+  /**
+   * Should return a function that, when given the resolvable and a function
+   * that takes the resolved value, attaches the function to the resolvable
+   * so that it will asynchronously execute it when its value is resolved.
+   *
+   * See `CanResolveFuture` and `CanResolveLAFuture` in `lift-webkit` for
+   * example usages.
+   */
+  def resolveAsync(resolvable: ResolvableType, onResolved: (ResolvedType)=>Unit): Unit
+}
+object CanResolveAsync {
+  // Low priority implicit for resolving Scala Futures.
+  implicit def resolveFuture[T](implicit executionContext: ExecutionContext) = {
+    new CanResolveAsync[Future[T],T] {
+      def resolveAsync(future: Future[T], onResolved: (T)=>Unit) = {
+        future.foreach(onResolved)
+      }
+    }
+  }
+
+  // Low priority implicit for resolving Lift LAFutures.
+  implicit def resolveLaFuture[T] = {
+    new CanResolveAsync[LAFuture[T],T] {
+      def resolveAsync(future: LAFuture[T], onResolved: (T)=>Unit) = {
+        future.onSuccess(onResolved)
+      }
+    }
+  }
+}

--- a/core/util/src/test/scala/net/liftweb/util/CanResolveAsyncSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/CanResolveAsyncSpec.scala
@@ -30,15 +30,13 @@ object CanResolveAsyncSpec extends Specification {
 
       val resolver = implicitly[CanResolveAsync[Future[String], String]]
 
-      var receivedResolution: Option[String] = None
-      resolver.resolveAsync(
-        myPromise.future,
-        { resolution => receivedResolution = Some(resolution) }
-      )
+      val receivedResolution = new LAFuture[String]
+      resolver.resolveAsync(myPromise.future, receivedResolution.satisfy _)
 
       myPromise.success("All done!")
 
-      receivedResolution must_== Some("All done!")
+      receivedResolution.complete_? must_== true
+      receivedResolution.get must_== "All done!"
     }
 
     "resolve LAFutures" in {
@@ -46,15 +44,13 @@ object CanResolveAsyncSpec extends Specification {
 
       val resolver = implicitly[CanResolveAsync[LAFuture[String], String]]
 
-      var receivedResolution: Option[String] = None
-      resolver.resolveAsync(
-        myFuture,
-        { resolution => receivedResolution = Some(resolution) }
-      )
+      val receivedResolution = new LAFuture[String]
+      resolver.resolveAsync(myFuture, receivedResolution.satisfy _)
 
       myFuture.satisfy("Got it!")
 
-      receivedResolution must_== Some("Got it!")
+      receivedResolution.complete_? must_== true
+      receivedResolution.get must_== "Got it!"
     }
   }
 }

--- a/core/util/src/test/scala/net/liftweb/util/CanResolveAsyncSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/CanResolveAsyncSpec.scala
@@ -35,7 +35,6 @@ object CanResolveAsyncSpec extends Specification {
 
       myPromise.success("All done!")
 
-      receivedResolution.complete_? must_== true
       receivedResolution.get must_== "All done!"
     }
 
@@ -49,7 +48,6 @@ object CanResolveAsyncSpec extends Specification {
 
       myFuture.satisfy("Got it!")
 
-      receivedResolution.complete_? must_== true
       receivedResolution.get must_== "Got it!"
     }
   }

--- a/core/util/src/test/scala/net/liftweb/util/CanResolveAsyncSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/CanResolveAsyncSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package util
+
+import scala.concurrent.{Future, Promise}
+
+import org.specs2.mutable.Specification
+
+import actor.LAFuture
+
+object CanResolveAsyncSpec extends Specification {
+  "CanResolveAsync" should {
+    "resolve Scala Futures" in {
+      val myPromise = Promise[String]()
+
+      val resolver = implicitly[CanResolveAsync[Future[String], String]]
+
+      var receivedResolution: Option[String] = None
+      resolver.resolveAsync(
+        myPromise.future,
+        { resolution => receivedResolution = Some(resolution) }
+      )
+
+      myPromise.success("All done!")
+
+      receivedResolution must_== Some("All done!")
+    }
+
+    "resolve LAFutures" in {
+      val myFuture = new LAFuture[String]
+
+      val resolver = implicitly[CanResolveAsync[LAFuture[String], String]]
+
+      var receivedResolution: Option[String] = None
+      resolver.resolveAsync(
+        myFuture,
+        { resolution => receivedResolution = Some(resolution) }
+      )
+
+      myFuture.satisfy("Got it!")
+
+      receivedResolution must_== Some("Got it!")
+    }
+  }
+}

--- a/web/webkit/src/main/scala/net/liftweb/http/package.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/package.scala
@@ -25,34 +25,6 @@ import http.js.JsCmds.Replace
 import util._
 
 package object http {
-  trait CanResolveAsync[ResolvableType, ResolvedType] {
-    /**
-     * Should return a function that, when given the resolvable and a function
-     * that takes the resolved value, attaches the function to the resolvable
-     * so that it will asynchronously execute it when its value is resolved.
-     *
-     * See `CanResolveFuture` and `CanResolveLAFuture` for examples.
-     */
-    def resolveAsync(resolvable: ResolvableType, onResolved: (ResolvedType)=>Unit): Unit
-  }
-  object CanResolveAsync {
-    implicit def resolveFuture[T](implicit executionContext: ExecutionContext) = {
-      new CanResolveAsync[Future[T],T] {
-        def resolveAsync(future: Future[T], onResolved: (T)=>Unit) = {
-          future.foreach(onResolved)
-        }
-      }
-    }
-
-    implicit def resolveLaFuture[T] = {
-      new CanResolveAsync[LAFuture[T],T] {
-        def resolveAsync(future: LAFuture[T], onResolved: (T)=>Unit) = {
-          future.onSuccess(onResolved)
-        }
-      }
-    }
-  }
-
   /**
    * Provides support for binding anything that has a `CanResolveAsync`
    * implementation. Out of the box, that's just Scala `Future`s and

--- a/web/webkit/src/test/scala/net/liftweb/http/rest/RestHelperSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/rest/RestHelperSpec.scala
@@ -2,9 +2,12 @@ package net.liftweb.http.rest
 
 import net.liftweb.mockweb.WebSpec
 import net.liftweb.mocks.MockHttpServletRequest
-import net.liftweb.http._
 import net.liftweb.common.Full
 
+import net.liftweb.actor.LAFuture
+import net.liftweb.json._
+
+import net.liftweb.http._
 
 object RestHelperSpecBoot {
   def boot() {
@@ -17,10 +20,15 @@ class RestHelperSpec extends WebSpec(RestHelperSpecBoot.boot _) {
   sequential  // This is important for using SessionVars, etc.
 
   "RestHelper" should {
-    val testUrl = "http://foo.com/api/info"
+    val testOptionsUrl = "http://foo.com/api/info"
+    val testFutureUrl = "http://foo.com/api/futured"
 
-    val testOptionsReq = new MockHttpServletRequest(testUrl){
+    val testOptionsReq = new MockHttpServletRequest(testOptionsUrl){
       method = "OPTIONS"
+    }
+
+    val testFutureReq = new MockHttpServletRequest(testFutureUrl){
+      method = "GET"
     }
 
     "set OPTIONS method" withReqFor testOptionsReq in { req =>
@@ -28,9 +36,30 @@ class RestHelperSpec extends WebSpec(RestHelperSpecBoot.boot _) {
     }
 
     "give the correct response" withReqFor testOptionsReq in { req =>
-      RestHelperSpecRest(req)() match {
-        case Full(OkResponse()) => success
-        case other =>              failure("Invalid response : " + other)
+      RestHelperSpecRest(req)() must beLike {
+        case Full(OkResponse()) => ok
+      }
+    }
+
+    "respond async with LAFutures" withReqFor testFutureReq in { req =>
+      val helper = FutureRestSpecHelper()
+
+      try {
+        helper(req)()
+
+        failure("Failed to respond asynchronously.")
+      } catch {
+        case ContinuationException(_, _, resolverFunction) =>
+          val result = new LAFuture[LiftResponse]
+
+          resolverFunction({ response => result.satisfy(response) })
+
+          helper.future.satisfy(JObject(Nil))
+
+          result.get must beLike {
+            case JsonResponse(_, _, _, code) =>
+              code must_== 200
+          }
       }
     }
   }
@@ -39,5 +68,14 @@ class RestHelperSpec extends WebSpec(RestHelperSpecBoot.boot _) {
 object RestHelperSpecRest extends RestHelper  {
   serve {
     case "api" :: "info" :: Nil Options req => OkResponse()
+  }
+}
+
+case class FutureRestSpecHelper() extends RestHelper {
+  val future = new LAFuture[JValue]
+
+  serve {
+    case "api" :: "futured" :: Nil Get _ =>
+      future
   }
 }

--- a/web/webkit/src/test/scala/net/liftweb/http/rest/RestHelperSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/rest/RestHelperSpec.scala
@@ -41,7 +41,7 @@ class RestHelperSpec extends WebSpec(RestHelperSpecBoot.boot _) {
       }
     }
 
-    "respond async with LAFutures" withReqFor testFutureReq in { req =>
+    "respond async with something that CanResolveAsync" withReqFor testFutureReq in { req =>
       val helper = FutureRestSpecHelper()
 
       try {

--- a/web/webkit/src/test/scala/net/liftweb/http/rest/XMLApiSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/rest/XMLApiSpec.scala
@@ -60,7 +60,7 @@ object XmlApiSpec extends Specification  {
       case r @ Req(List("api","max"), _, GetRequest) => () => doMax(r)
       case r @ Req(List("api","min"), _, GetRequest) => () => doMin(r)
       // Tests putResponseInBox
-      case Req("api" :: _, _, _) => () => BadResponse()
+      case Req("api" :: _, _, _) => () => BadRequestResponse()
     }
 
     // ===== Handler methods =====


### PR DESCRIPTION
`RestHelper` has long supported returning an `LAFuture` as the result of
a `RestHelper` block and auto-wrapped those in `RestHelper.async` so
they're dealt with via continuation, much like comet responses. This PR
extends `RestHelper` to support the same functionality for Scala `Future`s,
thus rounding out our dual support for Scala and Lift futures both here and
in snippet bindings.

We do this by moving the `CanResolveAsync` abstraction introduced for
snippet async future binding into `lift-util` and then reusing that abstraction
in `RestHelper`. We also add some specs for `CanResolveAsync` and a
spec to prove that `LAFuture` is still working as expected.

Closes #1735.