### PR TITLE
The FocusOnLoad object and avoiding inlining javascript 

### DIFF
--- a/persistence/proto/src/main/scala/net/liftweb/proto/ProtoUser.scala
+++ b/persistence/proto/src/main/scala/net/liftweb/proto/ProtoUser.scala
@@ -796,7 +796,7 @@ trait ProtoUser {
    * default: S.?("email.address.not.found")
    */
   def userNameNotFoundString: String = S.?("email.address.not.found")
-
+ 
   def loginXhtml = {
     (<form method="post" action={S.uri}><table><tr><td
               colspan="2">{S.?("log.in")}</td></tr>
@@ -867,8 +867,9 @@ trait ProtoUser {
     val emailElemId = nextFuncName
     S.appendJs(Focus(emailElemId))
     val bind =
-      ".email" #> <input type="text" name="username" id={emailElemId}/> &
-      ".password" #> <input type="password" name="password"/> &
+      ".email [id]" #> emailElemId &
+      ".email [name]" #> "username" &
+      ".password [name]" #> "password" &
       "type=submit" #> loginSubmitButton(S.?("log.in"))
 
     bind(loginXhtml)

--- a/persistence/proto/src/main/scala/net/liftweb/proto/ProtoUser.scala
+++ b/persistence/proto/src/main/scala/net/liftweb/proto/ProtoUser.scala
@@ -864,8 +864,10 @@ trait ProtoUser {
       }
     }
 
+    val (emailElem, id) = findOrAddId(<input type="text" name="username"/>)
+    FocusOnLoadAppendJs(id)
     val bind =
-      ".email" #> FocusOnLoad(<input type="text" name="username"/>) &
+      ".email" #> emailElem &
       ".password" #> <input type="password" name="password"/> &
       "type=submit" #> loginSubmitButton(S.?("log.in"))
 

--- a/persistence/proto/src/main/scala/net/liftweb/proto/ProtoUser.scala
+++ b/persistence/proto/src/main/scala/net/liftweb/proto/ProtoUser.scala
@@ -864,10 +864,10 @@ trait ProtoUser {
       }
     }
 
-    val (emailElem, id) = findOrAddId(<input type="text" name="username"/>)
-    FocusOnLoadAppendJs(id)
+    val emailElemId = nextFuncName
+    S.appendJs(Focus(emailElemId))
     val bind =
-      ".email" #> emailElem &
+      ".email" #> <input type="text" name="username" id={emailElemId}/> &
       ".password" #> <input type="password" name="password"/> &
       "type=submit" #> loginSubmitButton(S.?("log.in"))
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -703,7 +703,7 @@ object JsCmds {
    *
    * @return the element and a script that will give the element focus
    */
-  @deprecated("Use S.appendJs(Focus(id))","Since v3.0")
+  @deprecated("Use S.appendJs(Focus(id))","3.0.0")
   object FocusOnLoad {
     def apply(in: Elem): NodeSeq = {
       val (elem, id) = findOrAddId(in)

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -697,34 +697,18 @@ object JsCmds {
   }
 
   /**
-   * Makes the parameter the selected HTML element on load of the page by appending 
-   * a script snippet to lifts page script that will give the element focus.
+   * Makes the parameter the selected HTML element on load of the page
    *
    * @param in the element that should have focus
    *
-   * @return the element 
+   * @return the element and a script that will give the element focus
    */
+  @deprecated("Use S.appendJs(Focus(id))","Since v3.0")
   object FocusOnLoad {
     def apply(in: Elem): NodeSeq = {
       val (elem, id) = findOrAddId(in)
-      FocusOnLoadAppendJs(id)
-      elem 
+      elem ++ Script(LiftRules.jsArtifacts.onLoad(Run("if (document.getElementById(" + id.encJs + ")) {document.getElementById(" + id.encJs + ").focus();};")))
     }
-  }
-
-  /**
-   * Makes the element with the given id the selected HTML element on load of the page 
-   * by appending a script snippet to lifts page script that will give the element focus.
-   *
-   * @param in the id of the element that should have focus
-   *
-   * @return Unit 
-   */  
-  object FocusOnLoadAppendJs {
-    def apply(id: String): Unit = {
-      val focusJs = JE.JsRaw("""if (document.getElementById(%s)) {document.getElementById(%s).focus();};""".format(id.encJs,id.encJs)).cmd
-      S.appendJs(focusJs);
-    }    
   }
   
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -697,16 +697,19 @@ object JsCmds {
   }
 
   /**
-   * Makes the parameter the selected HTML element on load of the page
+   * Makes the parameter the selected HTML element on load of the page by appending 
+   * a script snippet to lifts page script that will give the element focus.
    *
    * @param in the element that should have focus
    *
-   * @return the element and a script that will give the element focus
+   * @return the element 
    */
   object FocusOnLoad {
     def apply(in: Elem): NodeSeq = {
       val (elem, id) = findOrAddId(in)
-      elem ++ Script(LiftRules.jsArtifacts.onLoad(Run("if (document.getElementById(" + id.encJs + ")) {document.getElementById(" + id.encJs + ").focus();};")))
+      val focusJs = JE.JsRaw("""if (document.getElementById(%s)) {document.getElementById(%s).focus();};""".format(id.encJs,id.encJs)).cmd
+      S.appendJs(focusJs);
+      elem 
     }
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -707,12 +707,26 @@ object JsCmds {
   object FocusOnLoad {
     def apply(in: Elem): NodeSeq = {
       val (elem, id) = findOrAddId(in)
-      val focusJs = JE.JsRaw("""if (document.getElementById(%s)) {document.getElementById(%s).focus();};""".format(id.encJs,id.encJs)).cmd
-      S.appendJs(focusJs);
+      FocusOnLoadAppendJs(id)
       elem 
     }
   }
 
+  /**
+   * Makes the element with the given id the selected HTML element on load of the page 
+   * by appending a script snippet to lifts page script that will give the element focus.
+   *
+   * @param in the id of the element that should have focus
+   *
+   * @return Unit 
+   */  
+  object FocusOnLoadAppendJs {
+    def apply(id: String): Unit = {
+      val focusJs = JE.JsRaw("""if (document.getElementById(%s)) {document.getElementById(%s).focus();};""".format(id.encJs,id.encJs)).cmd
+      S.appendJs(focusJs);
+    }    
+  }
+  
   /**
    * Sets the value of an element and sets the focus
    */


### PR DESCRIPTION
The FocusOnLoad object is now avoiding in-lining javascript by now instead utilizing lifts page script file.

While working on the lift_30_sbt lift_basic template I noticed that the ProtoUser controlled login page added a **in-line** element focus script via ProtoUser's use of the FocusOnLoad object. To avoid relaxing Lift 3's CSP rules by setting UnsafeInline for the script sources in lift_basic a change to the FocusOnLoad object was needed.   