### PR TITLE
Has Pwn Property: Fix hasOwnProperty use in IE.

### DIFF
--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -619,7 +619,7 @@
       },
       extend: function(obj1, obj2) {
         for (var item in obj2) {
-          if (hasOwnProperty.call(obj2, item) {
+          if (hasOwnProperty.call(obj2, item)) {
             obj1[item] = obj2[item];
           }
         }

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -1,6 +1,8 @@
 (function(window, undefined) {
   "use strict";
 
+  var hasOwnProperty = Object.prototype.hasOwnProperty;
+
   window.lift = (function() {
     // "private" vars
     var ajaxPath = function() { return settings.liftPath + '/ajax' },
@@ -616,8 +618,8 @@
         }
       },
       extend: function(obj1, obj2) {
-        for(var item in obj2) {
-          if (obj2.hasOwnProperty(item)) {
+        for (var item in obj2) {
+          if (hasOwnProperty.call(obj2, item) {
             obj1[item] = obj2[item];
           }
         }


### PR DESCRIPTION
There was code that referenced a nonexistent hasOwnProperty variable, which we
now introduce, and we change the one other usage of hasOwnProperty to also use
this variable. This should generally be IE-safe---the core issue is that IE 8
does not have hasOwnProperty on native objects like Array, which can cause
things to go boom boom.

Fixes #1743.