### PR TITLE
Upgrade mongo-java-driver to v2.14.0

### DIFF
--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/DBRefField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/DBRefField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2011 WorldWide Conferencing, LLC
+ * Copyright 2010-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ class DBRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefT
 
   def asXHtml = <div></div>
 
-  def defaultValue = new DBRef(null, null, null)
+  def defaultValue = new DBRef("", null)
 
   def setFromAny(in: Any): Box[DBRef] = in match {
     case ref: DBRef => Full(set(ref))
@@ -81,13 +81,11 @@ class DBRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefT
   // assume string is json
   def setFromString(in: String): Box[DBRef] = {
     val dbo = JSON.parse(in).asInstanceOf[BasicDBObject]
-    MongoDB.use(ref.meta.connectionIdentifier) ( db => {
-      val id = dbo.get("$id").toString
-      ObjectId.isValid(id) match {
-        case true => Full(set(new DBRef(db, dbo.get("$ref").toString, new ObjectId(id))))
-        case false => Full(set(new DBRef(db, dbo.get("$ref").toString, id)))
-      }
-    })
+    val id = dbo.get("$id").toString
+    ObjectId.isValid(id) match {
+      case true => Full(set(new DBRef(dbo.get("$ref").toString, new ObjectId(id))))
+      case false => Full(set(new DBRef(dbo.get("$ref").toString, id)))
+    }
   }
 
   def toForm: Box[NodeSeq] = Empty

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoCaseClassField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoCaseClassField.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2010-2011 WorldWide Conferencing, LLC
+* Copyright 2010-2015 WorldWide Conferencing, LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -107,6 +107,7 @@ class MongoCaseClassListField[OwnerType <: Record[OwnerType],CaseType](rec: Owne
     asJValue match {
       case JArray(list) =>
         list.foreach(v => dbl.add(JObjectParser.parse(v.asInstanceOf[JObject])))
+      case _ =>
     }
 
     dbl

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoClientSaveSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoClientSaveSpec.scala
@@ -64,7 +64,7 @@ class MongoClientSaveSpec extends Specification with MongoTestKit {
     sd2.save(false) // no exception thrown
     sd2.save(true) must throwA[MongoException]
     sd2.saveBox() must beLike {
-      case Failure(msg, _, _) => msg must contain("E11000 duplicate key error") // exception thrown
+      case Failure(msg, _, _) => msg must contain("E11000")
     }
     sd3.save()
 

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoClientSaveSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoClientSaveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WorldWide Conferencing, LLC
+ * Copyright 2014-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ package mongoclientsaverecords {
   object SaveDoc extends SaveDoc with MongoMetaRecord[SaveDoc] {
     import BsonDSL._
 
-    ensureIndex(("name" -> 1), true) // unique name
+    createIndex(("name" -> 1), true) // unique name
   }
 }
 
@@ -64,7 +64,7 @@ class MongoClientSaveSpec extends Specification with MongoTestKit {
     sd2.save(false) // no exception thrown
     sd2.save(true) must throwA[MongoException]
     sd2.saveBox() must beLike {
-      case Failure(msg, _, _) => msg must contain("E11000 duplicate key error index") // exception thrown
+      case Failure(msg, _, _) => msg must contain("E11000 duplicate key error") // exception thrown
     }
     sd3.save()
 

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 WorldWide Conferencing, LLC
+ * Copyright 2006-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,7 +246,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
       ttjo,
       rec.mandatoryJsonObjectField,
       new JsExp {
-        def toJsCmd = Printer.compact(render(json))
+        def toJsCmd = compactRender(json)
       },
       json,
       Empty
@@ -496,7 +496,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
         lst,
         rec.mandatoryMongoJsonObjectListField,
         new JsExp {
-          def toJsCmd = Printer.compact(render(json))
+          def toJsCmd = compactRender(json)
         },
         json,
         Empty
@@ -575,7 +575,7 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
         ("uuid" -> ("$uuid" -> subRec.uuid.value.toString))
 
       val srJsExp = new JsExp {
-        def toJsCmd = Printer.compact(render(srJson))
+        def toJsCmd = compactRender(srJson)
       }
 
       passBasicTests(subRec, subRec2, rec.mandatoryBsonRecordField, Full(rec.legacyOptionalBsonRecordField), false)
@@ -624,10 +624,10 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundExample
         ("uuid" -> ("$uuid" -> lst(1).uuid.value.toString))
 
       val sr1JsExp = new JsExp {
-        def toJsCmd = compact(render(sr1Json))
+        def toJsCmd = compactRender(sr1Json)
       }
       val sr2JsExp = new JsExp {
-        def toJsCmd = compact(render(sr2Json))
+        def toJsCmd = compactRender(sr2Json)
       }
 
       passBasicTests(lst, lst2, rec.mandatoryBsonRecordListField, Full(rec.legacyOptionalBsonRecordListField))

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoRecordExamplesSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoRecordExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,7 +183,7 @@ package mongotestrecords {
 
     import net.liftweb.json.JsonDSL._
 
-    ensureIndex(("name" -> 1), true) // unique name
+    createIndex(("name" -> 1), true) // unique name
   }
 }
 

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoRecordSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoRecordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -495,31 +495,31 @@ class MongoRecordSpec extends Specification with MongoTestKit {
     }
 
     "get set from json string using lift-json parser" in {
-      val mfftrFromJson = MongoFieldTypeTestRecord.fromJsonString(compact(render(mfttrJson)))
+      val mfftrFromJson = MongoFieldTypeTestRecord.fromJsonString(compactRender(mfttrJson))
       mfftrFromJson.isDefined must_== true
       mfftrFromJson foreach { tr =>
         tr mustEqual mfttr
       }
 
-      val pftrFromJson = PatternFieldTestRecord.fromJsonString(compact(render(pftrJson)))
+      val pftrFromJson = PatternFieldTestRecord.fromJsonString(compactRender(pftrJson))
       pftrFromJson.isDefined must_== true
       pftrFromJson foreach { tr =>
         tr mustEqual pftr
       }
 
-      val ltrFromJson = ListTestRecord.fromJsonString(compact(render(ltrJson)))
+      val ltrFromJson = ListTestRecord.fromJsonString(compactRender(ltrJson))
       ltrFromJson.isDefined must_== true
       ltrFromJson foreach { tr =>
         tr mustEqual ltr
       }
 
-      val mtrFromJson = MapTestRecord.fromJsonString(compact(render(mtrJson)))
+      val mtrFromJson = MapTestRecord.fromJsonString(compactRender(mtrJson))
       mtrFromJson.isDefined must_== true
       mtrFromJson.toList map { tr =>
         tr mustEqual mtr
       }
 
-      val joftrFromJson = JObjectFieldTestRecord.fromJsonString(compact(render(joftrJson)))
+      val joftrFromJson = JObjectFieldTestRecord.fromJsonString(compactRender(joftrJson))
       joftrFromJson must_== Full(joftr)
     }
 

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoTestKit.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoTestKit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ trait MongoTestKit extends Specification with BeforeAfterExample {
         false
       else {
         dbs foreach { case (id, _) =>
-          MongoDB.use(id) ( db => { db.getLastError } )
+          MongoDB.use(id) ( db => { db.getName } )
         }
         true
       }

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/QueryExamplesSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/QueryExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 WorldWide Conferencing, LLC
+ * Copyright 2011-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ package queryexamplesfixtures {
   }
   object Person extends Person with MongoMetaRecord[Person] {
     // index name
-    ensureIndex(("name" -> 1))
+    createIndex(("name" -> 1))
 
     // implicit formats already exists
     def findAllBornAfter(dt: Date) = findAll(("birthDate" -> ("$gt" -> dt)))

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Mongo.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Mongo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ object MongoDB {
   /**
     * Define and authenticate a Mongo db using a MongoClient instance.
     */
+  @deprecated("Credentials are now passed in via MongoClient", "3.0")
   def defineDbAuth(name: ConnectionIdentifier, mngo: MongoClient, dbName: String, username: String, password: String) {
     if (!mngo.getDB(dbName).authenticate(username, password.toCharArray))
       throw new MongoException("Authorization failed: "+mngo.toString)
@@ -126,6 +127,7 @@ object MongoDB {
     * and the use of getLastError.
     * See: http://docs.mongodb.org/ecosystem/drivers/java-concurrency/
     */
+  @deprecated("No longer relevant. See mongo-java-drivers's JavaDocs for details", "3.0")
   def useSession[T](name: ConnectionIdentifier)(f: (DB) => T): T = {
 
     val db = getDb(name) match {
@@ -147,6 +149,7 @@ object MongoDB {
   /**
     * Same as above except uses DefaultConnectionIdentifier
     */
+  @deprecated("No longer relevant. See mongo-java-drivers's JavaDocs for details", "3.0")
   def useSession[T](f: (DB) => T): T = {
 
     val db = getDb(DefaultConnectionIdentifier) match {

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Mongo.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Mongo.scala
@@ -127,7 +127,7 @@ object MongoDB {
     * and the use of getLastError.
     * See: http://docs.mongodb.org/ecosystem/drivers/java-concurrency/
     */
-  @deprecated("No longer relevant. See mongo-java-drivers's JavaDocs for details", "3.0")
+  @deprecated("No longer needed. See mongo-java-drivers's JavaDocs for details", "3.0")
   def useSession[T](name: ConnectionIdentifier)(f: (DB) => T): T = {
 
     val db = getDb(name) match {
@@ -149,7 +149,7 @@ object MongoDB {
   /**
     * Same as above except uses DefaultConnectionIdentifier
     */
-  @deprecated("No longer relevant. See mongo-java-drivers's JavaDocs for details", "3.0")
+  @deprecated("No longer needed. See mongo-java-drivers's JavaDocs for details", "3.0")
   def useSession[T](f: (DB) => T): T = {
 
     val db = getDb(DefaultConnectionIdentifier) match {

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,12 +200,12 @@ class MongoDirectSpec extends Specification with MongoTestKit {
     success
   }
 
-  "Mongo useSession example" in {
+  "Mongo more examples" in {
 
     checkMongoIsRunning
 
-    // use a Mongo instance directly with a session
-    MongoDB.useSession ( db => {
+    // use a Mongo instance directly
+    MongoDB.use ( db => {
       val coll = db.getCollection("testCollection")
 
       // create a unique index on name
@@ -233,7 +233,7 @@ class MongoDirectSpec extends Specification with MongoTestKit {
       coll.save(doc2, WriteConcern.SAFE) must throwA[MongoException]
       Helpers.tryo(coll.save(doc2, WriteConcern.SAFE)) must beLike {
         case Failure(msg, _, _) =>
-          msg must contain("E11000 duplicate key error index")
+          msg must contain("E11000 duplicate key error")
       }
       Helpers.tryo(coll.save(doc3, WriteConcern.SAFE)).toOption must beSome
 
@@ -244,18 +244,11 @@ class MongoDirectSpec extends Specification with MongoTestKit {
       // modifier operations $inc, $set, $push...
       val o2 = new BasicDBObject
       o2.put("$inc", new BasicDBObject("count", 1)) // increment count by 1
-      //o2.put("$set", new BasicDBObject("type", "docdb")) // set type
-      /**
-       * The update method only updates one document. see:
-       * http://jira.mongodb.org/browse/SERVER-268
-       */
       coll.update(qry, o2, false, false).getN must_== 1
       coll.update(qry, o2, false, false).isUpdateOfExisting must_== true
 
-
       // this update query won't find any docs to update
       coll.update(new BasicDBObject("name", "None"), o2, false, false).getN must_== 0
-      db.getLastError.get("updatedExisting") must_== false
 
       // regex query example
       val key = "name"

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectSpec.scala
@@ -233,7 +233,7 @@ class MongoDirectSpec extends Specification with MongoTestKit {
       coll.save(doc2, WriteConcern.SAFE) must throwA[MongoException]
       Helpers.tryo(coll.save(doc2, WriteConcern.SAFE)) must beLike {
         case Failure(msg, _, _) =>
-          msg must contain("E11000 duplicate key error")
+          msg must contain("E11000")
       }
       Helpers.tryo(coll.save(doc3, WriteConcern.SAFE)).toOption must beSome
 

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDocumentExamplesSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDocumentExamplesSpec.scala
@@ -494,7 +494,7 @@ class MongoDocumentExamplesSpec extends Specification with MongoTestKit {
       SessCollection.save(tc2, db) must throwA[MongoException]
       Helpers.tryo(SessCollection.save(tc2, db)) must beLike {
         case Failure(msg, _, _) =>
-          msg must contain("E11000 duplicate key error")
+          msg must contain("E11000")
       }
 
       Helpers.tryo(SessCollection.save(tc3, db)).toOption must beSome

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDocumentExamplesSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDocumentExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -478,7 +478,7 @@ class MongoDocumentExamplesSpec extends Specification with MongoTestKit {
     success
   }
 
-  "Mongo useSession example" in {
+  "Mongo examples" in {
 
     checkMongoIsRunning
 
@@ -486,15 +486,15 @@ class MongoDocumentExamplesSpec extends Specification with MongoTestKit {
     val tc2 = SessCollection(ObjectId.get, "MongoSession", "db", 1)
     val tc3 = SessCollection(ObjectId.get, "MongoDB", "db", 1)
 
-    // use a Mongo instance directly with a session
-    MongoDB.useSession( db => {
+    // use a Mongo instance directly
+    MongoDB.use( db => {
 
       // save to db
       Helpers.tryo(SessCollection.save(tc, db)).toOption must beSome
       SessCollection.save(tc2, db) must throwA[MongoException]
       Helpers.tryo(SessCollection.save(tc2, db)) must beLike {
         case Failure(msg, _, _) =>
-          msg must contain("E11000 duplicate key error index")
+          msg must contain("E11000 duplicate key error")
       }
 
       Helpers.tryo(SessCollection.save(tc3, db)).toOption must beSome
@@ -505,16 +505,8 @@ class MongoDocumentExamplesSpec extends Specification with MongoTestKit {
 
       // modifier operations $inc, $set, $push...
       val o2 = ("$inc" -> ("count" -> 1)) // increment count by 1
-      //("$set" -> ("dbtype" -> "docdb")) // set dbtype
       SessCollection.update(qry, o2, db)
-      db.getLastError.get("updatedExisting") must_== true
-      /* The update method only updates one document. */
-      db.getLastError.get("n") must_== 1
-
-      /* Multiple documents now supported */
       SessCollection.update(qry, o2, db, Multi)
-      db.getLastError.get("updatedExisting") must_== true
-      db.getLastError.get("n") must_== 2
 
       // regex query example
       val lst = SessCollection.findAll(new BasicDBObject("name", Pattern.compile("^Mongo")))

--- a/persistence/record/src/test/scala/net/liftweb/record/RecordSpec.scala
+++ b/persistence/record/src/test/scala/net/liftweb/record/RecordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -214,7 +214,7 @@ object RecordSpec extends Specification {
         ("mandatoryBinaryField" -> "EhMU") ~
         ("mandatoryJodaTimeField" -> dt.getMillis)
 
-      val fttrJson: String = compact(render(fttrJValue))
+      val fttrJson: String = compactRender(fttrJValue)
 
       val fttrAsJsObj = JsObj(
         ("mandatoryBooleanField", JsFalse),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 WorldWide Conferencing, LLC
+ * Copyright 2011-2015 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ object Dependencies {
   lazy val joda_time              = "joda-time"                  % "joda-time"          % "2.6"
   lazy val joda_convert           = "org.joda"                   % "joda-convert"       % "1.2"
   lazy val htmlparser             = "nu.validator.htmlparser"    % "htmlparser"         % "1.4"
-  lazy val mongo_java_driver      = "org.mongodb"                % "mongo-java-driver"  % "2.12.2"
+  lazy val mongo_java_driver      = "org.mongodb"                % "mongo-java-driver"  % "2.14.0"
   lazy val paranamer              = "com.thoughtworks.paranamer" % "paranamer"          % "2.4.1"
   lazy val scalajpa               = "org.scala-libs"             % "scalajpa"           % "1.5"     cross CVMappingAll
   lazy val scalap: ModuleMap      = "org.scala-lang"             % "scalap"             % _


### PR DESCRIPTION
Fixes #1747 

We can't upgrade to the 3 series until we remove a few functions, which I've deprecated in this commit. This version is compatible with the latest server versions, so it should be sufficient for a while longer.