### PR TITLE
Ajax Event Extraction: Allow event extraction in AJAX responses

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/ListHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/ListHelpers.scala
@@ -238,10 +238,7 @@ trait ListHelpers {
   }
 
   /** Add utility methods to Lists */
-  implicit def toSuperList[T](in: List[T]): SuperList[T] = new SuperList(in)
-
-  /** Add utility methods to Lists */
-  class SuperList[T](val what: List[T]) {
+  implicit class SuperList[T](what: List[T]) extends AnyRef {
     /** permute the elements of a list */
     def permute = permuteList(what)
 

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Menu.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Menu.scala
@@ -441,12 +441,14 @@ object Menu extends DispatchSnippet {
       }
 
       (S.request.flatMap(_.location), S.attr("param"), SiteMap.findAndTestLoc(name)) match {
-         case (_, Full(param), Full(loc: Loc[T] with ConvertableLoc[T])) => {
+         case (_, Full(param), Full(loc: Loc[_] with ConvertableLoc[_])) => {
+           val typedLoc = loc.asInstanceOf[Loc[T] with ConvertableLoc[T]]
+
            (for {
-             pv <- loc.convert(param)
-             link <- loc.createLink(pv)
+             pv <- typedLoc.convert(param)
+             link <- typedLoc.createLink(pv)
            } yield 
-             Helpers.addCssClass(loc.cssClassForMenuItem,
+             Helpers.addCssClass(typedLoc.cssClassForMenuItem,
                                  <a href={link}></a> % 
                                  S.prefixedAttrsToMetaData("a"))) openOr
            Text("")

--- a/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
@@ -257,7 +257,7 @@ private[http] final object HtmlNormalizer {
                     normalizeHtmlAndEventHandlers(element.child, contextPath, stripComments, nextState, additionalChanges)
 
                   (
-                    normalizedNodes.+:[Node,NodeSeq](element.copy(child = newChildren)),
+                    normalizedNodes.:+[Node,NodeSeq](element.copy(child = newChildren)),
                     extractedJs & elementJsCmds & additionalJsCmds & childJsCmds
                   )
 
@@ -277,13 +277,13 @@ private[http] final object HtmlNormalizer {
                   additionalChanges
                 )
 
-              (normalizedNodes.+:[Node,NodeSeq](Group(normalizedGroupNodes)), extractedJs & js)
+              (normalizedNodes.:+[Node,NodeSeq](Group(normalizedGroupNodes)), extractedJs & js)
 
             case c: Comment if stripComments =>
               (normalizedNodes, extractedJs)
 
             case _ =>
-              (normalizedNodes.+:[Node,NodeSeq](nodeToNormalize): NodeSeq, extractedJs)
+              (normalizedNodes.:+[Node,NodeSeq](nodeToNormalize): NodeSeq, extractedJs)
           }
       }): (NodeSeq, JsCmd)
     }

--- a/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
@@ -1,0 +1,291 @@
+package net.liftweb
+package http
+
+import scala.xml._
+import scala.collection.immutable.Vector
+
+import js.JsCmd
+import js.JsCmds.Noop
+import js.JE.{AnonFunc, Call, JsRaw}
+
+import util.Helpers._
+
+/**
+ * Represents an HTML attribute for an event handler. Carries the event name and
+ * the JS that should run when that event is triggered as a String.
+ */
+private case class EventAttribute(eventName: String, jsString: String)
+private object EventAttribute {
+  /**
+   * Some elements allow a URL attribute to take a `javascript:(//)`-style
+   * URL instead of setting an `on*` event in order to invoke JS. For example,
+   * you can (and Lift does) set a form's `action` attribute to
+   * `javascript://(some JS)` instead of setting `onsubmit` to `(someJS);
+   * return false`.
+   *
+   * This is a map from those attribute names to the corresponding JS event
+   * that would be used to execute that JS when it isn't run in line.
+   */
+  val eventsByAttributeName =
+    Map(
+      "action" -> "submit",
+      "href" -> "click"
+    )
+
+  object EventForAttribute {
+    def unapply(attributeName: String): Option[String] = {
+      eventsByAttributeName.get(attributeName)
+    }
+  }
+}
+
+/**
+ * Helper class that performs certain Lift-specific normalizations of HTML
+ * represented as `NodeSeq`s:
+ *  - Fixes URLs for `link`, `a`, `form`, and `script` elements to properly
+ *    prepend the container's context path in case these are absolute URLs.
+ *  - Extracts event attributes (replacing them with
+ *    `[[LiftRules.attributeForRemovedEventAttributes]]` if needed), returning
+ *    instead JavaScript that will attach the corresponding event handler to
+ *    that element.
+ *  - Provides for caller-specific additional processing for each node.
+ */
+private[http] final object HtmlNormalizer {
+  // Fix URLs using Req.normalizeHref and extract JS event attributes for
+  // putting into page JS. Returns a triple of:
+  //  - The optional id that was found in this set of attributes.
+  //  - The normalized metadata.
+  //  - A list of extracted `EventAttribute`s.
+  private def normalizeUrlAndExtractEvents(
+    attributeToNormalize: String,
+    attributes: MetaData,
+    contextPath: String,
+    shouldRewriteUrl: Boolean, // whether to apply URLRewrite.rewriteFunc
+    eventAttributes: List[EventAttribute] = Nil
+  ): (Option[String], MetaData, List[EventAttribute]) = {
+    if (attributes == Null) {
+      (None, Null, eventAttributes)
+    } else {
+      // Note: we don't do this tail-recursively because we have to preserve
+      // attribute order!
+      val (id, normalizedRemainingAttributes, remainingEventAttributes) =
+        normalizeUrlAndExtractEvents(
+          attributeToNormalize,
+          attributes.next,
+          contextPath,
+          shouldRewriteUrl,
+          eventAttributes
+        )
+
+      attributes match {
+        case attribute @ UnprefixedAttribute(
+               EventAttribute.EventForAttribute(eventName),
+               attributeValue,
+               remainingAttributes
+             ) if attributeValue.text.startsWith("javascript:") =>
+          val attributeJavaScript = {
+            // Could be javascript: or javascript://.
+            val base = attributeValue.text.substring(11)
+            val strippedJs =
+              if (base.startsWith("//"))
+                base.substring(2)
+              else
+                base
+
+            if (strippedJs.trim.isEmpty) {
+              Nil
+            } else {
+              // When using javascript:-style URIs, event.preventDefault is implied.
+              List(strippedJs + "; event.preventDefault();")
+            }
+          }
+
+          val updatedEventAttributes =
+            attributeJavaScript.map(EventAttribute(eventName, _)) :::
+            remainingEventAttributes
+
+          (id, normalizedRemainingAttributes, updatedEventAttributes)
+
+        case UnprefixedAttribute(name, _, _) if name == attributeToNormalize =>
+          val normalizedUrl =
+            Req.normalizeHref(
+              contextPath,
+              attributes.value,
+              shouldRewriteUrl,
+              URLRewriter.rewriteFunc
+            )
+
+          val newMetaData =
+            new UnprefixedAttribute(
+              attributeToNormalize,
+              normalizedUrl,
+              normalizedRemainingAttributes
+            )
+
+          (id, newMetaData, remainingEventAttributes)
+
+        case UnprefixedAttribute(name, attributeValue, _) if name.startsWith("on") =>
+          val updatedEventAttributes =
+            EventAttribute(name.substring(2), attributeValue.text) ::
+            remainingEventAttributes
+
+          (id, normalizedRemainingAttributes, updatedEventAttributes)
+
+        case UnprefixedAttribute("id", attributeValue, _) =>
+          val idValue = Option(attributeValue.text).filter(_.nonEmpty)
+
+          (idValue, attributes.copy(normalizedRemainingAttributes), remainingEventAttributes)
+
+        case _ =>
+          (id, attributes.copy(normalizedRemainingAttributes), remainingEventAttributes)
+      }
+    }
+  }
+
+  // Given an element id and the `EventAttribute`s to apply to elements with
+  // that id, return a JsCmd that binds all those event handlers to that id.
+  private def jsForEventAttributes(elementId: String, eventAttributes: List[EventAttribute]): JsCmd = {
+    eventAttributes.map {
+      case EventAttribute(name, handlerJs) =>
+        Call(
+          "lift.onEvent",
+          elementId,
+          name,
+          AnonFunc("event", JsRaw(handlerJs).cmd)
+        ).cmd
+    }.foldLeft(Noop)(_ & _)
+  }
+
+  private def normalizeElementAndAttributes(element: Elem, attributeToNormalize: String, contextPath: String, shouldRewriteUrl: Boolean): (Elem, JsCmd) = {
+    val (id, normalizedAttributes, eventAttributes) =
+      normalizeUrlAndExtractEvents(
+        attributeToNormalize,
+        element.attributes,
+        contextPath,
+        shouldRewriteUrl
+      )
+
+    val attributesIncludingEventsAsData =
+      LiftRules.attributeForRemovedEventAttributes match {
+        case Some(attribute) if eventAttributes.nonEmpty =>
+          val removedAttributes = eventAttributes.map {
+            case EventAttribute(event, _) =>
+              s"on$event"
+          }
+          new UnprefixedAttribute(attribute, removedAttributes.mkString(" "), normalizedAttributes)
+
+        case _ =>
+          normalizedAttributes
+      }
+
+    id.map { foundId =>
+      (
+        element.copy(attributes = attributesIncludingEventsAsData),
+        jsForEventAttributes(foundId, eventAttributes)
+      )
+    } getOrElse {
+      if (eventAttributes.nonEmpty) {
+        val generatedId = s"lift-event-js-${nextFuncName}"
+
+        (
+          element.copy(attributes = new UnprefixedAttribute("id", generatedId, attributesIncludingEventsAsData)),
+          jsForEventAttributes(generatedId, eventAttributes)
+        )
+      } else {
+        (
+          element.copy(attributes = attributesIncludingEventsAsData),
+          Noop
+        )
+      }
+    }
+  }
+  
+  /**
+   * Base for all the normalizeHtml* implementations; in addition to what it
+   * usually does, takes an `[[additionalChanges]]` function that is passed a
+   * state object and the current (post-normalization) node and can adjust the
+   * state and tweak the normalized nodes or even add more JsCmds to be
+   * included.  That state is in turn passed to any invocations for any of the
+   * children of the current node. Note that state is '''not''' passed back up
+   * the node hierarchy, so state updates are '''only''' seen by children of
+   * the node.
+   *
+   * See `[[LiftMerge.merge]]` for sample usage.
+   */
+  def normalizeHtmlAndEventHandlers[State](
+    nodes: NodeSeq,
+    contextPath: String,
+    stripComments: Boolean,
+    state: State,
+    additionalChanges: (State, Elem)=>(State, NodeSeq, JsCmd)
+  ): (NodeSeq, JsCmd) = {
+    nodes.foldLeft((Vector[Node](), Noop): (NodeSeq, JsCmd)) { (soFar, nodeToNormalize) =>
+      (soFar match {
+        case (normalizedNodes, extractedJs) =>
+          nodeToNormalize match {
+            case element: Elem =>
+              val (attributeToFix, shouldRewriteUrl) =
+                element.label match {
+                  case "form" =>
+                    ("action", true)
+
+                  case "a" =>
+                    ("href", true)
+                  case "link" =>
+                    ("href", false)
+
+                  case "script" =>
+                    ("src", false)
+                  case _ =>
+                    ("src", true)
+                }
+
+              val (normalizedElement, elementJsCmds) =
+                normalizeElementAndAttributes(
+                  element,
+                  attributeToFix,
+                  contextPath,
+                  shouldRewriteUrl
+                )
+
+              val (nextState, customResult, additionalJsCmds) =
+                additionalChanges(state, normalizedElement)
+
+              customResult match {
+                case element: Elem =>
+                  val (newChildren, childJsCmds) =
+                    normalizeHtmlAndEventHandlers(element.child, contextPath, stripComments, nextState, additionalChanges)
+
+                  (
+                    normalizedNodes.+:[Node,NodeSeq](element.copy(child = newChildren)),
+                    extractedJs & elementJsCmds & additionalJsCmds & childJsCmds
+                  )
+
+                case _ =>
+                  (
+                    normalizedNodes ++ customResult,
+                    extractedJs & elementJsCmds & additionalJsCmds
+                  )
+              }
+            case Group(groupNodes) =>
+              val (normalizedGroupNodes: NodeSeq, js: JsCmd) =
+                normalizeHtmlAndEventHandlers(
+                  groupNodes,
+                  contextPath,
+                  stripComments,
+                  state,
+                  additionalChanges
+                )
+
+              (normalizedNodes.+:[Node,NodeSeq](Group(normalizedGroupNodes)), extractedJs & js)
+
+            case c: Comment if stripComments =>
+              (normalizedNodes, extractedJs)
+
+            case _ =>
+              (normalizedNodes.+:[Node,NodeSeq](nodeToNormalize): NodeSeq, extractedJs)
+          }
+      }): (NodeSeq, JsCmd)
+    }
+  }
+}

--- a/web/webkit/src/main/scala/net/liftweb/http/Req.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Req.scala
@@ -1320,6 +1320,12 @@ object RewriteResponse {
   def apply(path: ParsePath, params: Map[String, String]) = new RewriteResponse(path, params, false)
 }
 
+/**
+ * Provides access to a thread-local URL rewriter. Typically uses either an
+ * applicable entry in `[[LiftRules.decorateUrl]]` or the container's built-in
+ * URL decoration which may append the session id to the URL (dependent on
+ * `[[LiftRules.encodeJSessionIdInUrl_?]]`).
+ */
 object URLRewriter {
   private val funcHolder = new ThreadGlobal[(String) => String]
 

--- a/web/webkit/src/main/scala/net/liftweb/http/Req.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Req.scala
@@ -543,7 +543,10 @@ object Req {
     ParsePath(lst.map(urlDecode), suffix, front, back)
   }
 
-  var fixHref = _fixHref _
+  @deprecated("Use normalizeHref instead.", "3.0.0")
+  def fixHref = normalizeHref
+
+  var normalizeHref = _fixHref _
 
   private def _fixHref(contextPath: String, v: Seq[Node], fixURL: Boolean, rewrite: Box[String => String]): Text = {
     val hv = v.text
@@ -561,16 +564,21 @@ object Req {
          rewrite.openOrThrowException("legacy code").apply(updated) else updated)
   }
 
+  @deprecated("Use normalizeHtml instead.", "3.0.0")
+  def fixHtml(contextPath: String, in: NodeSeq): NodeSeq = {
+    normalizeHtml(contextPath, in)
+  }
+
   /**
    * Corrects the HTML content,such as applying context path to URI's, session information if cookies are disabled etc.
    */
-  def fixHtml(contextPath: String, in: NodeSeq): NodeSeq = {
+  def normalizeHtml(contextPath: String, in: NodeSeq): NodeSeq = {
     val rewrite = URLRewriter.rewriteFunc
 
     def fixAttrs(toFix: String, attrs: MetaData, fixURL: Boolean): MetaData = {
       if (attrs == Null) Null
       else if (attrs.key == toFix) {
-        new UnprefixedAttribute(toFix, Req.fixHref(contextPath, attrs.value, fixURL, rewrite), fixAttrs(toFix, attrs.next, fixURL))
+        new UnprefixedAttribute(toFix, Req.normalizeHref(contextPath, attrs.value, fixURL, rewrite), fixAttrs(toFix, attrs.next, fixURL))
       } else attrs.copy(fixAttrs(toFix, attrs.next, fixURL))
     }
 
@@ -1175,7 +1183,10 @@ class Req(val path: ParsePath,
 
   val options_? = requestType.options_?
 
-  def fixHtml(in: NodeSeq): NodeSeq = Req.fixHtml(contextPath, in)
+  @deprecated("Use normalizeHtml instead.", "3.0.0")
+  def fixHtml(in: NodeSeq): NodeSeq = normalizeHtml(in)
+  
+  def normalizeHtml(in: NodeSeq): NodeSeq = Req.normalizeHtml(contextPath, in)
 
   lazy val uri: String = request match {
     case null => "Outside HTTP Request (e.g., on Actor)"

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -601,12 +601,17 @@ trait HtmlFixer {
 
     val w = new java.io.StringWriter
 
-    val xhtml = S.session.
-    map(s =>
-      s.fixHtml(s.processSurroundAndInclude("JS SetHTML id: "
-                                            + uid,
-                                            content))).
-    openOr(content)
+    val xhtml =
+      S.session.map { session =>
+        session.normalizeHtmlAndAppendEventHandlers(
+          session.processSurroundAndInclude(
+            s"JS SetHTML id: $uid",
+            content
+          )
+        )
+      } openOr {
+        content
+      }
 
     import scala.collection.mutable.ListBuffer
     val lb = new ListBuffer[JsCmd]


### PR DESCRIPTION
Abstract out extraction of HTML event attributes into JS via
a common `HtmlNormalizer` singleton that also handles URL
normalization (prefixing of context path, rewriting, etc). This
extracts some functionality that was mostly in `LiftMerge`, and
allows for extensible invocations that let `LiftMerge` do the
additional things it needs to do to properly render a full page
(like HTML head and tail merging).

The current code is decent but not final, and there are currently
no tests. I'll be going back and writing tests for `LiftMerge`'s
original behavior to confirm that there were no regressions, though
of course that's always hard to do after the fact.

Would appreciate a first pass at what's here now—I've improved
verbiage throughout and things should hopefully be easier to follow
than they were before.

This fixes #1700.