### PR TITLE
85th Normal Form: Allow event extraction in AJAX responses.

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/ListHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/ListHelpers.scala
@@ -238,10 +238,7 @@ trait ListHelpers {
   }
 
   /** Add utility methods to Lists */
-  implicit def toSuperList[T](in: List[T]): SuperList[T] = new SuperList(in)
-
-  /** Add utility methods to Lists */
-  class SuperList[T](val what: List[T]) {
+  implicit class SuperList[T](what: List[T]) extends AnyRef {
     /** permute the elements of a list */
     def permute = permuteList(what)
 

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Menu.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Menu.scala
@@ -441,15 +441,19 @@ object Menu extends DispatchSnippet {
       }
 
       (S.originalRequest.flatMap(_.location), S.attr("param"), SiteMap.findAndTestLoc(name)) match {
-         case (_, Full(param), Full(loc: Loc[T] with ConvertableLoc[T])) => {
+         case (_, Full(param), Full(loc: Loc[_] with ConvertableLoc[_])) => {
+           val typedLoc = loc.asInstanceOf[Loc[T] with ConvertableLoc[T]]
+
            (for {
-             pv <- loc.convert(param)
-             link <- loc.createLink(pv)
-           } yield
-             Helpers.addCssClass(loc.cssClassForMenuItem,
+             pv <- typedLoc.convert(param)
+             link <- typedLoc.createLink(pv)
+           } yield {
+             Helpers.addCssClass(typedLoc.cssClassForMenuItem,
                                  <a href={link}></a> %
-                                 S.prefixedAttrsToMetaData("a"))) openOr
-           Text("")
+                                 S.prefixedAttrsToMetaData("a"))
+           }) openOr {
+             Text("")
+           }
          }
 
          case (Full(loc), _, _) if loc.name == name => {

--- a/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
@@ -282,15 +282,16 @@ private[http] final object HtmlNormalizer {
     nodes.foldLeft(NodesAndEventJs(Vector[Node](), Noop)) { (soFar, nodeToNormalize) =>
       normalizeNode(nodeToNormalize, contextPath, stripComments).map {
         case NodeAndEventJs(normalizedElement: Elem, js: JsCmd) =>
+          val NodesAndEventJs(normalizedChildren, childJs) =
+            normalizeHtmlAndEventHandlers(
+              normalizedElement.child,
+              contextPath,
+              stripComments
+            )
+
           soFar
             .append(js)
-            .append(
-              normalizeHtmlAndEventHandlers(
-                normalizedElement.child,
-                contextPath,
-                stripComments
-              )
-            )
+            .append(normalizedElement.copy(child = normalizedChildren), childJs)
 
         case node =>
           soFar.append(node)

--- a/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
@@ -122,7 +122,7 @@ private[http] final object HtmlNormalizer {
               Nil
             } else {
               // When using javascript:-style URIs, event.preventDefault is implied.
-              List(strippedJs + "; event.preventDefault();")
+              List(strippedJs + "; event.preventDefault()")
             }
           }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
@@ -82,7 +82,7 @@ private[http] final object HtmlNormalizer {
   //  - The optional id that was found in this set of attributes.
   //  - The normalized metadata.
   //  - A list of extracted `EventAttribute`s.
-  private def normalizeUrlAndExtractEvents(
+  private[this] def normalizeUrlAndExtractEvents(
     attributeToNormalize: String,
     attributes: MetaData,
     contextPath: String,
@@ -170,7 +170,7 @@ private[http] final object HtmlNormalizer {
 
   // Given an element id and the `EventAttribute`s to apply to elements with
   // that id, return a JsCmd that binds all those event handlers to that id.
-  private def jsForEventAttributes(elementId: String, eventAttributes: List[EventAttribute]): JsCmd = {
+  private[this] def jsForEventAttributes(elementId: String, eventAttributes: List[EventAttribute]): JsCmd = {
     eventAttributes.map {
       case EventAttribute(name, handlerJs) =>
         Call(

--- a/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
@@ -257,7 +257,7 @@ private[http] final object HtmlNormalizer {
                     normalizeHtmlAndEventHandlers(element.child, contextPath, stripComments, nextState, additionalChanges)
 
                   (
-                    normalizedNodes.+:[Node,NodeSeq](element.copy(child = newChildren)),
+                    normalizedNodes.:+[Node,NodeSeq](element.copy(child = newChildren)),
                     extractedJs & elementJsCmds & additionalJsCmds & childJsCmds
                   )
 
@@ -277,13 +277,13 @@ private[http] final object HtmlNormalizer {
                   additionalChanges
                 )
 
-              (normalizedNodes.+:[Node,NodeSeq](Group(normalizedGroupNodes)), extractedJs & js)
+              (normalizedNodes.:+[Node,NodeSeq](Group(normalizedGroupNodes)), extractedJs & js)
 
             case c: Comment if stripComments =>
               (normalizedNodes, extractedJs)
 
             case _ =>
-              (normalizedNodes.+:[Node,NodeSeq](nodeToNormalize): NodeSeq, extractedJs)
+              (normalizedNodes.:+[Node,NodeSeq](nodeToNormalize): NodeSeq, extractedJs)
           }
       }): (NodeSeq, JsCmd)
     }

--- a/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/HtmlNormalizer.scala
@@ -1,0 +1,291 @@
+package net.liftweb
+package http
+
+import scala.xml._
+import scala.collection.immutable.Vector
+
+import js.JsCmd
+import js.JsCmds.Noop
+import js.JE.{AnonFunc, Call, JsRaw}
+
+import util.Helpers._
+
+/**
+ * Represents an HTML attribute for an event handler. Carries the event name and
+ * the JS that should run when that event is triggered as a String.
+ */
+private case class EventAttribute(eventName: String, jsString: String)
+private object EventAttribute {
+  /**
+   * Some elements allow a URL attribute to take a `javascript:(//)`-style
+   * URL instead of setting an `on*` event in order to invoke JS. For example,
+   * you can (and Lift does) set a form's `action` attribute to
+   * `javascript://(some JS)` instead of setting `onsubmit` to `(someJS);
+   * return false`.
+   *
+   * This is a map from those attribute names to the corresponding JS event
+   * that would be used to execute that JS when it isn't run in line.
+   */
+  val eventsByAttributeName =
+    Map(
+      "action" -> "submit",
+      "href" -> "click"
+    )
+
+  object EventForAttribute {
+    def unapply(attributeName: String): Option[String] = {
+      eventsByAttributeName.get(attributeName)
+    }
+  }
+}
+
+/**
+ * Helper class that performs certain Lift-specific normalizations of HTML
+ * represented as `NodeSeq`s:
+ *  - Fixes URLs for `link`, `a`, `form`, and `script` elements to properly
+ *    prepend the container's context path in case these are absolute URLs.
+ *  - Extracts event attributes (replacing them with
+ *    `[[LiftRules.attributeForRemovedEventAttributes]]` if needed), returning
+ *    instead JavaScript that will attach the corresponding event handler to
+ *    that element.
+ *  - Provides for caller-specific additional processing for each node.
+ */
+private[http] final object HtmlNormalizer {
+  // Fix URLs using Req.normalizeHref and extract JS event attributes for
+  // putting into page JS. Returns a triple of:
+  //  - The optional id that was found in this set of attributes.
+  //  - The normalized metadata.
+  //  - A list of extracted `EventAttribute`s.
+  private def normalizeUrlAndExtractEvents(
+    attributeToNormalize: String,
+    attributes: MetaData,
+    contextPath: String,
+    shouldRewriteUrl: Boolean, // whether to apply URLRewrite.rewriteFunc
+    eventAttributes: List[EventAttribute] = Nil
+  ): (Option[String], MetaData, List[EventAttribute]) = {
+    if (attributes == Null) {
+      (None, Null, eventAttributes)
+    } else {
+      // Note: we don't do this tail-recursively because we have to preserve
+      // attribute order!
+      val (id, normalizedRemainingAttributes, remainingEventAttributes) =
+        normalizeUrlAndExtractEvents(
+          attributeToNormalize,
+          attributes.next,
+          contextPath,
+          shouldRewriteUrl,
+          eventAttributes
+        )
+
+      attributes match {
+        case attribute @ UnprefixedAttribute(
+               EventAttribute.EventForAttribute(eventName),
+               attributeValue,
+               remainingAttributes
+             ) if attributeValue.text.startsWith("javascript:") =>
+          val attributeJavaScript = {
+            // Could be javascript: or javascript://.
+            val base = attributeValue.text.substring(11)
+            val strippedJs =
+              if (base.startsWith("//"))
+                base.substring(2)
+              else
+                base
+
+            if (strippedJs.trim.isEmpty) {
+              Nil
+            } else {
+              // When using javascript:-style URIs, event.preventDefault is implied.
+              List(strippedJs + "; event.preventDefault();")
+            }
+          }
+
+          val updatedEventAttributes =
+            attributeJavaScript.map(EventAttribute(eventName, _)) :::
+            remainingEventAttributes
+
+          (id, normalizedRemainingAttributes, updatedEventAttributes)
+
+        case UnprefixedAttribute(name, _, _) if name == attributeToNormalize =>
+          val normalizedUrl =
+            Req.normalizeHref(
+              contextPath,
+              attributes.value,
+              shouldRewriteUrl,
+              URLRewriter.rewriteFunc
+            )
+
+          val newMetaData =
+            new UnprefixedAttribute(
+              attributeToNormalize,
+              normalizedUrl,
+              normalizedRemainingAttributes
+            )
+
+          (id, newMetaData, remainingEventAttributes)
+
+        case UnprefixedAttribute(name, attributeValue, _) if name.startsWith("on") =>
+          val updatedEventAttributes =
+            EventAttribute(name.substring(2), attributeValue.text) ::
+            remainingEventAttributes
+
+          (id, normalizedRemainingAttributes, updatedEventAttributes)
+
+        case UnprefixedAttribute("id", attributeValue, _) =>
+          val idValue = Option(attributeValue.text).filter(_.nonEmpty)
+
+          (idValue, attributes.copy(normalizedRemainingAttributes), remainingEventAttributes)
+
+        case _ =>
+          (id, attributes.copy(normalizedRemainingAttributes), remainingEventAttributes)
+      }
+    }
+  }
+
+  // Given an element id and the `EventAttribute`s to apply to elements with
+  // that id, return a JsCmd that binds all those event handlers to that id.
+  private def jsForEventAttributes(elementId: String, eventAttributes: List[EventAttribute]): JsCmd = {
+    eventAttributes.map {
+      case EventAttribute(name, handlerJs) =>
+        Call(
+          "lift.onEvent",
+          elementId,
+          name,
+          AnonFunc("event", JsRaw(handlerJs).cmd)
+        ).cmd
+    }.foldLeft(Noop)(_ & _)
+  }
+
+  private def normalizeElementAndAttributes(element: Elem, attributeToNormalize: String, contextPath: String, shouldRewriteUrl: Boolean): (Elem, JsCmd) = {
+    val (id, normalizedAttributes, eventAttributes) =
+      normalizeUrlAndExtractEvents(
+        attributeToNormalize,
+        element.attributes,
+        contextPath,
+        shouldRewriteUrl
+      )
+
+    val attributesIncludingEventsAsData =
+      LiftRules.attributeForRemovedEventAttributes match {
+        case Some(attribute) if eventAttributes.nonEmpty =>
+          val removedAttributes = eventAttributes.map {
+            case EventAttribute(event, _) =>
+              s"on$event"
+          }
+          new UnprefixedAttribute(attribute, removedAttributes.mkString(" "), normalizedAttributes)
+
+        case _ =>
+          normalizedAttributes
+      }
+
+    id.map { foundId =>
+      (
+        element.copy(attributes = attributesIncludingEventsAsData),
+        jsForEventAttributes(foundId, eventAttributes)
+      )
+    } getOrElse {
+      if (eventAttributes.nonEmpty) {
+        val generatedId = s"lift-event-js-${nextFuncName}"
+
+        (
+          element.copy(attributes = new UnprefixedAttribute("id", generatedId, attributesIncludingEventsAsData)),
+          jsForEventAttributes(generatedId, eventAttributes)
+        )
+      } else {
+        (
+          element.copy(attributes = attributesIncludingEventsAsData),
+          Noop
+        )
+      }
+    }
+  }
+  
+  /**
+   * Base for all the normalizeHtml* implementations; in addition to what it
+   * usually does, takes an `[[additionalChanges]]` function that is passed a
+   * state object and the current (post-normalization) node and can adjust the
+   * state and tweak the normalized nodes or even add more JsCmds to be
+   * included.  That state is in turn passed to any invocations for any of the
+   * children of the current node. Note that state is '''not''' passed back up
+   * the node hierarchy, so state updates are '''only''' seen by children of
+   * the node.
+   *
+   * See `[[LiftMerge.merge]]` for sample usage.
+   */
+  def normalizeHtmlAndEventHandlers[State](
+    nodes: NodeSeq,
+    contextPath: String,
+    stripComments: Boolean,
+    state: State,
+    additionalChanges: (State, Elem)=>(State, NodeSeq, JsCmd)
+  ): (NodeSeq, JsCmd) = {
+    nodes.foldLeft((Vector[Node](), Noop): (NodeSeq, JsCmd)) { (soFar, nodeToNormalize) =>
+      (soFar match {
+        case (normalizedNodes, extractedJs) =>
+          nodeToNormalize match {
+            case element: Elem =>
+              val (attributeToFix, shouldRewriteUrl) =
+                element.label match {
+                  case "form" =>
+                    ("action", true)
+
+                  case "a" =>
+                    ("href", true)
+                  case "link" =>
+                    ("href", false)
+
+                  case "script" =>
+                    ("src", false)
+                  case _ =>
+                    ("src", true)
+                }
+
+              val (normalizedElement, elementJsCmds) =
+                normalizeElementAndAttributes(
+                  element,
+                  attributeToFix,
+                  contextPath,
+                  shouldRewriteUrl
+                )
+
+              val (nextState, customResult, additionalJsCmds) =
+                additionalChanges(state, normalizedElement)
+
+              customResult match {
+                case element: Elem =>
+                  val (newChildren, childJsCmds) =
+                    normalizeHtmlAndEventHandlers(element.child, contextPath, stripComments, nextState, additionalChanges)
+
+                  (
+                    normalizedNodes.+:[Node,NodeSeq](element.copy(child = newChildren)),
+                    extractedJs & elementJsCmds & additionalJsCmds & childJsCmds
+                  )
+
+                case _ =>
+                  (
+                    normalizedNodes ++ customResult,
+                    extractedJs & elementJsCmds & additionalJsCmds
+                  )
+              }
+            case Group(groupNodes) =>
+              val (normalizedGroupNodes: NodeSeq, js: JsCmd) =
+                normalizeHtmlAndEventHandlers(
+                  groupNodes,
+                  contextPath,
+                  stripComments,
+                  state,
+                  additionalChanges
+                )
+
+              (normalizedNodes.+:[Node,NodeSeq](Group(normalizedGroupNodes)), extractedJs & js)
+
+            case c: Comment if stripComments =>
+              (normalizedNodes, extractedJs)
+
+            case _ =>
+              (normalizedNodes.+:[Node,NodeSeq](nodeToNormalize): NodeSeq, extractedJs)
+          }
+      }): (NodeSeq, JsCmd)
+    }
+  }
+}

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -49,7 +49,7 @@ private[http] trait LiftMerge {
   }
 
   // Gather all page-specific JS into one JsCmd.
-  private def assemblePageSpecificJavaScript(eventJs: JsCmd): JsCmd = {
+  private[this] def assemblePageSpecificJavaScript(eventJs: JsCmd): JsCmd = {
     val allJs =
       LiftRules.javaScriptSettings.vend().map { settingsFn =>
         LiftJavaScript.initCmd(settingsFn(this))

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -1860,21 +1860,6 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
   }
 
   /**
-   * Same as `normalizeHtmlAndEventHandlers`, but allows additional handling
-   * and state management for the internal nodes. See
-   * `[[HtmlNormalizer.normalizeHtmlAndEventHandlers]]` for more.
-   */
-  private[http] def normalizeHtmlAndEventHandlers[State](in: NodeSeq, state: State, additionalChanges: (State, Elem)=>(State, NodeSeq, JsCmd)): (NodeSeq, JsCmd) = {
-    HtmlNormalizer.normalizeHtmlAndEventHandlers(
-      in,
-      S.contextPath,
-      LiftRules.stripComments.vend,
-      state,
-      additionalChanges
-    )
-  }
-
-  /**
    * Applies various HTML corrections to the passed HTML, including adding the
    * context path to links and extracting event handlers into a separate
    * `JsCmd`.
@@ -1883,11 +1868,11 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * `[[normalizeHtmlAndAppendEventHandlers]]` and not worry about the extra
    * `JsCmd`, as Lift will automatically append it to the response.
    */
-  def normalizeHtmlAndEventHandlers(in: NodeSeq): (NodeSeq, JsCmd) = {
-    normalizeHtmlAndEventHandlers[Unit](
-      in,
-      (),
-      (unit, elem) => (unit, elem, JsCmds.Noop)
+  def normalizeHtmlAndEventHandlers(nodes: NodeSeq): (NodeSeq, JsCmd) = {
+    HtmlNormalizer.normalizeHtmlAndEventHandlers(
+      nodes,
+      S.contextPath,
+      LiftRules.stripComments.vend
     )
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -1868,7 +1868,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * `[[normalizeHtmlAndAppendEventHandlers]]` and not worry about the extra
    * `JsCmd`, as Lift will automatically append it to the response.
    */
-  def normalizeHtmlAndEventHandlers(nodes: NodeSeq): (NodeSeq, JsCmd) = {
+  def normalizeHtmlAndEventHandlers(nodes: NodeSeq): NodesAndEventJs = {
     HtmlNormalizer.normalizeHtmlAndEventHandlers(
       nodes,
       S.contextPath,
@@ -1884,11 +1884,11 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * page, or the end of the returned JS if this is an AJAX or comet request).
    */
   def normalizeHtmlAndAppendEventHandlers(in: NodeSeq): NodeSeq = {
-    val (revisedHtml, eventJs) = normalizeHtmlAndEventHandlers(in)
+    val NodesAndEventJs(normalizedHtml, eventJs) = normalizeHtmlAndEventHandlers(in)
 
     S.appendJs(eventJs)
 
-    revisedHtml
+    normalizedHtml
   }
 
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/Req.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Req.scala
@@ -1320,6 +1320,12 @@ object RewriteResponse {
   def apply(path: ParsePath, params: Map[String, String]) = new RewriteResponse(path, params, false)
 }
 
+/**
+ * Provides access to a thread-local URL rewriter. Typically uses either an
+ * applicable entry in `[[LiftRules.decorateUrl]]` or the container's built-in
+ * URL decoration which may append the session id to the URL (dependent on
+ * `[[LiftRules.encodeJSessionIdInUrl_?]]`).
+ */
 object URLRewriter {
   private val funcHolder = new ThreadGlobal[(String) => String]
 

--- a/web/webkit/src/main/scala/net/liftweb/http/Req.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Req.scala
@@ -543,7 +543,10 @@ object Req {
     ParsePath(lst.map(urlDecode), suffix, front, back)
   }
 
-  var fixHref = _fixHref _
+  @deprecated("Use normalizeHref instead.", "3.0.0")
+  def fixHref = normalizeHref
+
+  var normalizeHref = _fixHref _
 
   private def _fixHref(contextPath: String, v: Seq[Node], fixURL: Boolean, rewrite: Box[String => String]): Text = {
     val hv = v.text
@@ -561,16 +564,21 @@ object Req {
          rewrite.openOrThrowException("legacy code").apply(updated) else updated)
   }
 
+  @deprecated("Use normalizeHtml instead.", "3.0.0")
+  def fixHtml(contextPath: String, in: NodeSeq): NodeSeq = {
+    normalizeHtml(contextPath, in)
+  }
+
   /**
    * Corrects the HTML content,such as applying context path to URI's, session information if cookies are disabled etc.
    */
-  def fixHtml(contextPath: String, in: NodeSeq): NodeSeq = {
+  def normalizeHtml(contextPath: String, in: NodeSeq): NodeSeq = {
     val rewrite = URLRewriter.rewriteFunc
 
     def fixAttrs(toFix: String, attrs: MetaData, fixURL: Boolean): MetaData = {
       if (attrs == Null) Null
       else if (attrs.key == toFix) {
-        new UnprefixedAttribute(toFix, Req.fixHref(contextPath, attrs.value, fixURL, rewrite), fixAttrs(toFix, attrs.next, fixURL))
+        new UnprefixedAttribute(toFix, Req.normalizeHref(contextPath, attrs.value, fixURL, rewrite), fixAttrs(toFix, attrs.next, fixURL))
       } else attrs.copy(fixAttrs(toFix, attrs.next, fixURL))
     }
 
@@ -1175,7 +1183,10 @@ class Req(val path: ParsePath,
 
   val options_? = requestType.options_?
 
-  def fixHtml(in: NodeSeq): NodeSeq = Req.fixHtml(contextPath, in)
+  @deprecated("Use normalizeHtml instead.", "3.0.0")
+  def fixHtml(in: NodeSeq): NodeSeq = normalizeHtml(in)
+  
+  def normalizeHtml(in: NodeSeq): NodeSeq = Req.normalizeHtml(contextPath, in)
 
   lazy val uri: String = request match {
     case null => "Outside HTTP Request (e.g., on Actor)"

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -601,12 +601,17 @@ trait HtmlFixer {
 
     val w = new java.io.StringWriter
 
-    val xhtml = S.session.
-    map(s =>
-      s.fixHtml(s.processSurroundAndInclude("JS SetHTML id: "
-                                            + uid,
-                                            content))).
-    openOr(content)
+    val xhtml =
+      S.session.map { session =>
+        session.normalizeHtmlAndAppendEventHandlers(
+          session.processSurroundAndInclude(
+            s"JS SetHTML id: $uid",
+            content
+          )
+        )
+      } openOr {
+        content
+      }
 
     import scala.collection.mutable.ListBuffer
     val lb = new ListBuffer[JsCmd]

--- a/web/webkit/src/test/scala/net/liftweb/http/HtmlNormalizerSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/HtmlNormalizerSpec.scala
@@ -1,0 +1,485 @@
+package net.liftweb
+package http
+
+import scala.xml._
+
+import org.specs2._
+  import execute.{Result, AsResult}
+  import mutable.{Around, Specification}
+  import matcher.XmlMatchers
+  import mock.Mockito
+
+import org.mockito.Mockito._
+
+import common._
+
+import js.JE.JsObj
+
+class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
+  val eventAttributeMatcher = "(?s).*\\W(on[a-zA-Z]+)=.*".r
+
+  "HtmlNormalizer when normalizing HTML and event handlers" should {
+    "leave the HTML structure unchanged" in {
+      val result =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <html>
+            <head>
+              <script src="testscript"></script>
+              <link href="testlink" />
+            </head>
+            <body>
+              <link href="testlink2" />
+              <form action="booyan">
+                <p>
+                  <link href="testlink3" />
+                </p>
+              </form>
+
+              <p>Thingies</p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          "/context-path",
+          false
+        ).nodes
+
+      result must ==/(
+        <html>
+          <head>
+            <script src="testscript"></script>
+            <link href="testlink" />
+          </head>
+          <body>
+            <link href="testlink2" />
+            <form action="booyan">
+              <p>
+                <link href="testlink3" />
+              </p>
+            </form>
+
+            <p>Thingies</p>
+            <p>More thingies</p>
+          </body>
+        </html>
+      )
+    }
+
+    "extract events from all elements at any depth" in {
+      val NodesAndEventJs(html, js) =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <html onevent="testJs1">
+            <head onresult="testJs2">
+              <script src="testscript" onmagic="testJs3"></script>
+              <link href="testlink" onthing="testJs4" />
+            </head>
+            <body onclick="testJs5">
+              <link href="testlink2" onclick="testJs5" />
+              <form action="booyan" onsubmit="testJs6">
+                <p onmouseover="testJs7">
+                  <link href="testlink3" onslippetydip="testJs8" />
+                </p>
+              </form>
+
+              <p onkeyup="testJs9">Thingies</p>
+              <p ondragstart="testJs10">More thingies</p>
+            </body>
+          </html>,
+          "/context-path",
+          false
+        )
+
+      List("testJs1", 
+           "testJs2",
+           "testJs3",
+           "testJs4",
+           "testJs5",
+           "testJs6",
+           "testJs7",
+           "testJs8",
+           "testJs9",
+           "testJs10")
+        .foreach(js.toJsCmd must contain(_))
+
+      html.toString must beLike {
+        case eventAttributeMatcher(eventAttribute) =>
+          ko(s"Contained unexpected event: ${eventAttribute}")
+        case _ =>
+          ok
+      }
+    }
+
+    "reuse ids when they are already on an element with an event" in {
+      val NodesAndEventJs(html, js) =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <myelement id="testid" onevent="doStuff" />,
+          "/context-path",
+          false
+        )
+
+      html must ==/(<myelement id="testid" />)
+      js.toJsCmd must_== """|
+        |
+        |lift.onEvent("testid","event",function(event) {doStuff;});
+        |""".stripMargin('|')
+    }
+
+    "generate ids for elements with events if they don't have one" in {
+      val NodesAndEventJs(html, js) =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <myelement onevent="doStuff" />,
+          "/context-path",
+          false
+        )
+
+      val id = html \@ "id"
+
+      id must not be empty
+      js.toJsCmd must_== s"""|
+        |
+        |lift.onEvent("$id","event",function(event) {doStuff;});
+        |""".stripMargin('|')
+    }
+
+    "extract event js correctly for multiple elements" in {
+      val NodesAndEventJs(_, js) =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <div>
+            <myelement onevent="doStuff" />
+            <myelement id="hello" onevent="doStuff2" />
+            <myelement onevent="doStuff3" />
+          </div>,
+          "/context-path",
+          false
+        )
+
+      js.toJsCmd must be matching(s"""|(?ms)
+        |
+        |
+        |
+        |
+        |lift\\.onEvent\\("lift-event-js-[^"]+","event",function\\(event\\) \\{doStuff;\\}\\);
+        |
+        |
+        |
+        |lift\\.onEvent\\("hello","event",function\\(event\\) \\{doStuff2;\\}\\);
+        |
+        |
+        |
+        |lift\\.onEvent\\("lift-event-js-[^"]+","event",function\\(event\\) \\{doStuff3;\\}\\);
+        |
+        |""".stripMargin('|').r
+      )
+    }
+
+    "extract events from hrefs and actions" in {
+      val NodesAndEventJs(html, js) =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <div>
+            <myelement href="javascript:doStuff" />
+            <myelement id="hello" action="javascript:doStuff2" />
+            <myelement id="hello2" href="javascript://doStuff3" />
+            // Note here we have the same behavior as browsers: javascript:/
+            // is *processed as JavaScript* but it is *invalid JavaScript*
+            // (i.e., it corresponds to a JS expression that starts with `/`).
+            <myelement action="javascript:/doStuff4" />
+          </div>,
+          "/context-path",
+          false
+        )
+
+      (html \ "myelement").map(_ \@ "href").filter(_.nonEmpty) must beEmpty
+      (html \ "myelement").map(_ \@ "action").filter(_.nonEmpty) must beEmpty
+      js.toJsCmd must be matching(s"""|(?ms)
+        |
+        |
+        |
+        |
+        |lift\\.onEvent\\("lift-event-js-[^"]+","click",function\\(event\\) \\{doStuff; event.preventDefault\\(\\);\\}\\);
+        |
+        |
+        |
+        |lift\\.onEvent\\("hello","submit",function\\(event\\) \\{doStuff2; event.preventDefault\\(\\);\\}\\);
+        |
+        |
+        |
+        |lift\\.onEvent\\("hello2","click",function\\(event\\) \\{doStuff3; event.preventDefault\\(\\);\\}\\);
+        |
+        |
+        |
+        |lift\\.onEvent\\("lift-event-js-[^"]+","submit",function\\(event\\) \\{/doStuff4; event.preventDefault\\(\\);\\}\\);
+        |
+        |""".stripMargin('|').r
+      )
+    }
+
+    "not extract events from hrefs and actions without the proper prefix" in {
+      val NodesAndEventJs(html, js) =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <div>
+            <myelement href="doStuff" />
+            <myelement id="hello" action="javascrip:doStuff2" />
+            <myelement id="hello2" href="javascrip://doStuff3" />
+            <myelement action="doStuff4" />
+          </div>,
+          "/context-path",
+          false
+        )
+
+      (html \ "myelement").map(_ \@ "href").filter(_.nonEmpty) must_== List("doStuff", "javascrip://doStuff3")
+      (html \ "myelement").map(_ \@ "action").filter(_.nonEmpty) must_== List("javascrip:doStuff2", "doStuff4")
+      js.toJsCmd.trim must beEmpty
+    }
+
+    "normalize absolute link hrefs everywhere" in {
+      val result =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <html>
+            <head>
+              <script src="testscript"></script>
+              <link href="/testlink" />
+            </head>
+            <body>
+              <link href="/testlink2" />
+              <div>
+                <p>
+                  <link href="/testlink3" />
+                </p>
+              </div>
+
+              <p>Thingies</p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          "/context-path",
+          false
+        ).nodes
+
+      (result \\ "link").map(_ \@ "href") must_== 
+        "/context-path/testlink" ::
+        "/context-path/testlink2" ::
+        "/context-path/testlink3" :: Nil
+    }
+
+    "normalize absolute script srcs everywhere" in {
+      val result =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <html>
+            <head>
+              <script src="/testscript"></script>
+              <link href="testlink" />
+            </head>
+            <body>
+              <script src="/testscript2"></script>
+              <link href="testlink2" />
+              <div>
+                <p>
+                  <link href="testlink3" />
+                </p>
+              </div>
+
+              <p>Thingies</p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          "/context-path",
+          false
+        ).nodes
+
+      (result \\ "script").map(_ \@ "src") must_== 
+        "/context-path/testscript" ::
+        "/context-path/testscript2" :: Nil
+    }
+
+    "normalize absolute a hrefs everywhere" in {
+      val result =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <html>
+            <head>
+              <a href="/testa1">Booyan</a>
+            </head>
+            <body>
+              <a href="/testa2">Booyan</a>
+              <a href="testa3">Booyan</a>
+              <div>
+                <a href="testa4">Booyan</a>
+                <p>
+                  <a href="/testa5">Booyan</a>
+                </p>
+              </div>
+
+              <p>Thingies <a href="/testa6">Booyan</a></p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          "/context-path",
+          false
+        ).nodes
+
+      (result \\ "a").map(_ \@ "href") must_== 
+        "/context-path/testa1" ::
+        "/context-path/testa2" ::
+        "testa3" ::
+        "testa4" ::
+        "/context-path/testa5" ::
+        "/context-path/testa6" :: Nil
+    }
+
+    "normalize absolute form actions everywhere" in {
+      val result =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <html>
+            <head>
+              <form action="/testform1">Booyan</form>
+            </head>
+            <body>
+              <form action="/testform2">Booyan</form>
+              <form action="testform3">Booyan</form>
+              <div>
+                <form action="testform4">Booyan</form>
+                <p>
+                  <form action="/testform5">Booyan</form>
+                </p>
+              </div>
+
+              <p>Thingies <form action="/testform6">Booyan</form></p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          "/context-path",
+          false
+        ).nodes
+
+      (result \\ "form").map(_ \@ "action") must_== 
+        "/context-path/testform1" ::
+        "/context-path/testform2" ::
+        "testform3" ::
+        "testform4" ::
+        "/context-path/testform5" ::
+        "/context-path/testform6" :: Nil
+    }
+
+    "not rewrite script srcs anywhere" in {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          HtmlNormalizer.normalizeHtmlAndEventHandlers(
+            <html>
+              <head>
+                <script src="testscript"></script>
+              </head>
+              <body>
+                <script src="testscript2"></script>
+                <div>
+                  <p>
+                    <script src="testscript3" />
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            "/context-path",
+            false
+          ).nodes
+        }
+
+      (result \\ "script").map(_ \@ "src") must_== 
+        "testscript" ::
+        "testscript2" ::
+        "testscript3" :: Nil
+    }
+
+    "not rewrite link hrefs anywhere" in {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          HtmlNormalizer.normalizeHtmlAndEventHandlers(
+            <html>
+              <head>
+                <link href="testlink" />
+              </head>
+              <body>
+                <link href="testlink2" />
+                <div>
+                  <p>
+                    <link href="testlink3" />
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            "/context-path",
+            false
+          ).nodes
+        }
+
+      (result \\ "link").map(_ \@ "href") must_== 
+        "testlink" ::
+        "testlink2" ::
+        "testlink3" :: Nil
+    }
+
+    "rewrite a hrefs everywhere" in {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          HtmlNormalizer.normalizeHtmlAndEventHandlers(
+            <html>
+              <head>
+                <a href="testa"></a>
+              </head>
+              <body>
+                <a href="testa2"></a>
+                <div>
+                  <p>
+                    <a href="testa3" />
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            "/context-path",
+            false
+          ).nodes
+        }
+
+      (result \\ "a").map(_ \@ "href") must_== 
+        "rewritten" ::
+        "rewritten" ::
+        "rewritten" :: Nil
+    }
+
+    "rewrite form actions everywhere" in {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          HtmlNormalizer.normalizeHtmlAndEventHandlers(
+            <html>
+              <head>
+                <form action="testform" />
+              </head>
+              <body>
+                <form action="testform2" />
+                <div>
+                  <p>
+                    <form action="testform3" />
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            "/context-path",
+            false
+          ).nodes
+        }
+
+      (result \\ "form").map(_ \@ "action") must_== 
+        "rewritten" ::
+        "rewritten" ::
+        "rewritten" :: Nil
+    }
+  }
+}

--- a/web/webkit/src/test/scala/net/liftweb/http/LiftMergeSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LiftMergeSpec.scala
@@ -1,0 +1,450 @@
+package net.liftweb
+package http
+
+import scala.xml._
+
+import org.specs2._
+  import execute.{Result, AsResult}
+  import mutable.{Around, Specification}
+  import matcher.XmlMatchers
+  import mock.Mockito
+
+import org.mockito.Mockito._
+
+import common._
+
+import js.JE.JsObj
+
+trait BaseAround extends Around {
+  override def around[T: AsResult](test: =>T): Result = {
+    AsResult(test)
+  }
+}
+
+trait LiftRulesSetup extends Around {
+  def rules: LiftRules
+
+  abstract override def around[T: AsResult](test: => T): Result = {
+    super.around {
+      LiftRulesMocker.devTestLiftRulesInstance.doWith(rules) {
+        AsResult(test)
+      }
+    }
+  }
+}
+
+trait SSetup extends Around {
+  def session: LiftSession
+  def req: Box[Req]
+
+  abstract override def around[T: AsResult](test: => T): Result = {
+    super.around {
+      S.init(req, session) {
+        AsResult(test)
+      }
+    }
+  }
+}
+
+class WithRules(val rules: LiftRules) extends BaseAround with LiftRulesSetup
+
+class WithLiftContext(val rules: LiftRules, val session: LiftSession, val req: Box[Req] = Empty) extends BaseAround with LiftRulesSetup with SSetup
+
+class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
+  val mockReq = mock[Req]
+  mockReq.contextPath returns "/context-path"
+
+  val testSession = new LiftSession("/context-path", "underlying id", Empty)
+
+  val testRules = new LiftRules()
+  // Avoid extra appended elements by default.
+  testRules.javaScriptSettings.default.set(() => () => Empty)
+  testRules.autoIncludeAjaxCalc.default.set(() => () => (_: LiftSession) => false)
+  testRules.excludePathFromContextPathRewriting.default
+    .set(
+      () => { in: String => 
+        in.startsWith("exclude-me")
+      }
+    )
+
+  "LiftMerge when doing the final page merge" should {
+    "merge head segments in the page body in order into main head" in new WithRules(testRules) {
+      val result =
+        testSession.merge(
+          <html>
+            <head>
+              <script src="testscript"></script>
+            </head>
+            <body>
+              <head>
+                <script src="testscript2"></script>
+                <link href="testlink" />
+              </head>
+              <div>
+                <p>
+                  <head>
+                    <link href="testlink2" />
+                  </head>
+                </p>
+              </div>
+            </body>
+          </html>,
+          mockReq
+        )
+
+      (result \ "head" \ "_") must_== (Seq(
+        <script src="testscript"></script>,
+        <script src="testscript2"></script>,
+        <link href="testlink" />,
+        <link href="testlink2" />
+      ): NodeSeq)
+    }
+
+    "merge tail segments in the page body in order at the end of the body" in new WithRules(testRules) {
+      val result =
+        testSession.merge(
+          <html>
+            <head>
+              <script src="testscript"></script>
+            </head>
+            <body>
+              <tail>
+                <script src="testscript2"></script>
+                <link href="testlink" />
+              </tail>
+              <div>
+                <p>
+                  <tail>
+                    <link href="testlink2" />
+                  </tail>
+                </p>
+              </div>
+
+              <p>Thingies</p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          mockReq
+        )
+
+      (result \ "body" \ "_").takeRight(3) must_== (Seq(
+        <script src="testscript2"></script>,
+        <link href="testlink" />,
+        <link href="testlink2" />
+      ): NodeSeq)
+    }
+
+    "not merge tail segments in the head" in new WithRules(testRules) {
+      val result =
+        testSession.merge(
+          <html>
+            <head>
+              <tail>
+                <script src="testscript"></script>
+              </tail>
+            </head>
+            <body>
+              <tail>
+                <script src="testscript2"></script>
+                <link href="testlink" />
+              </tail>
+              <div>
+                <p>
+                  <tail>
+                    <link href="testlink2" />
+                  </tail>
+                </p>
+              </div>
+
+              <p>Thingies</p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          mockReq
+        )
+
+      (result \ "body" \ "_").takeRight(3) must_== (Seq(
+        <script src="testscript2"></script>,
+        <link href="testlink" />,
+        <link href="testlink2" />
+      ): NodeSeq)
+    }
+
+    "normalize absolute link hrefs everywhere" in new WithLiftContext(testRules, testSession) {
+      val result =
+        testSession.merge(
+          <html>
+            <head>
+              <script src="testscript"></script>
+              <link href="/testlink" />
+            </head>
+            <body>
+              <head>
+                <script src="testscript2"></script>
+                <link href="/testlink2" />
+              </head>
+              <div>
+                <p>
+                  <tail>
+                    <link href="/testlink3" />
+                  </tail>
+                </p>
+              </div>
+
+              <p>Thingies</p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          mockReq
+        )
+
+      (result \\ "link").map(_ \@ "href") must_== 
+        "/context-path/testlink" ::
+        "/context-path/testlink2" ::
+        "/context-path/testlink3" :: Nil
+    }
+
+    "normalize absolute script srcs everywhere" in new WithLiftContext(testRules, testSession) {
+      val result =
+        testSession.merge(
+          <html>
+            <head>
+              <script src="/testscript"></script>
+              <link href="testlink" />
+            </head>
+            <body>
+              <head>
+                <script src="/testscript2"></script>
+                <link href="testlink2" />
+              </head>
+              <div>
+                <p>
+                  <tail>
+                    <link href="testlink3" />
+                  </tail>
+                </p>
+              </div>
+
+              <p>Thingies</p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          mockReq
+        )
+
+      (result \\ "script").map(_ \@ "src") must_== 
+        "/context-path/testscript" ::
+        "/context-path/testscript2" :: Nil
+    }
+
+    "normalize absolute a hrefs everywhere" in new WithLiftContext(testRules, testSession) {
+      val result =
+        testSession.merge(
+          <html>
+            <head>
+              <a href="/testa1">Booyan</a>
+            </head>
+            <body>
+              <a href="/testa2">Booyan</a>
+              <head>
+                <a href="testa3">Booyan</a>
+              </head>
+              <div>
+                <a href="testa4">Booyan</a>
+                <p>
+                  <tail>
+                    <a href="/testa5">Booyan</a>
+                  </tail>
+                </p>
+              </div>
+
+              <p>Thingies <a href="/testa6">Booyan</a></p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          mockReq
+        )
+
+      (result \\ "a").map(_ \@ "href") must_== 
+        "/context-path/testa1" ::
+        "testa3" ::
+        "/context-path/testa2" ::
+        "testa4" ::
+        "/context-path/testa6" ::
+        "/context-path/testa5" :: Nil
+    }
+
+    "normalize absolute form actions everywhere" in new WithLiftContext(testRules, testSession) {
+      val result =
+        testSession.merge(
+          <html>
+            <head>
+              <form action="/testform1">Booyan</form>
+            </head>
+            <body>
+              <form action="/testform2">Booyan</form>
+              <head>
+                <form action="testform3">Booyan</form>
+              </head>
+              <div>
+                <form action="testform4">Booyan</form>
+                <p>
+                  <tail>
+                    <form action="/testform5">Booyan</form>
+                  </tail>
+                </p>
+              </div>
+
+              <p>Thingies <form action="/testform6">Booyan</form></p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          mockReq
+        )
+
+      (result \\ "form").map(_ \@ "action") must_== 
+        "/context-path/testform1" ::
+        "testform3" ::
+        "/context-path/testform2" ::
+        "testform4" ::
+        "/context-path/testform6" ::
+        "/context-path/testform5" :: Nil
+    }
+
+    "not rewrite script srcs anywhere" in new WithLiftContext(testRules, testSession) {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          testSession.merge(
+            <html>
+              <head>
+                <script src="testscript"></script>
+              </head>
+              <body>
+                <head>
+                  <script src="testscript2"></script>
+                </head>
+                <div>
+                  <p>
+                    <tail>
+                      <script src="testscript3" />
+                    </tail>
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            mockReq
+          )
+        }
+
+      (result \\ "script").map(_ \@ "src") must_== 
+        "testscript" ::
+        "testscript2" ::
+        "testscript3" :: Nil
+    }
+
+    "not rewrite link hrefs anywhere" in new WithLiftContext(testRules, testSession) {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          testSession.merge(
+            <html>
+              <head>
+                <link href="testlink" />
+              </head>
+              <body>
+                <head>
+                  <link href="testlink2" />
+                </head>
+                <div>
+                  <p>
+                    <tail>
+                      <link href="testlink3" />
+                    </tail>
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            mockReq
+          )
+        }
+
+      (result \\ "link").map(_ \@ "href") must_== 
+        "testlink" ::
+        "testlink2" ::
+        "testlink3" :: Nil
+    }
+
+    "rewrite a hrefs everywhere" in new WithLiftContext(testRules, testSession) {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          testSession.merge(
+            <html>
+              <head>
+                <a href="testa"></a>
+              </head>
+              <body>
+                <head>
+                  <a href="testa2"></a>
+                </head>
+                <div>
+                  <p>
+                    <tail>
+                      <a href="testa3" />
+                    </tail>
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            mockReq
+          )
+        }
+
+      (result \\ "a").map(_ \@ "href") must_== 
+        "rewritten" ::
+        "rewritten" ::
+        "rewritten" :: Nil
+    }
+
+    "rewrite form actions everywhere" in new WithLiftContext(testRules, testSession) {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          testSession.merge(
+            <html>
+              <head>
+                <form action="testform" />
+              </head>
+              <body>
+                <head>
+                  <form action="testform2" />
+                </head>
+                <div>
+                  <p>
+                    <tail>
+                      <form action="testform3" />
+                    </tail>
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            mockReq
+          )
+        }
+
+      (result \\ "form").map(_ \@ "action") must_== 
+        "rewritten" ::
+        "rewritten" ::
+        "rewritten" :: Nil
+    }
+  }
+}


### PR DESCRIPTION
Abstract out extraction of HTML event attributes into JS via
a common `HtmlNormalizer` singleton that also handles URL
normalization (prefixing of context path, rewriting, etc). This
extracts some functionality that was mostly in `LiftMerge`, and
allows for extensible invocations that let `LiftMerge` do the
additional things it needs to do to properly render a full page
(like HTML head and tail merging).

The merging functionality in `LiftMerge` is now covered by a test, as
is the new `HtmlNormalizer` that acts as a common spot for HTML
normalization that `LiftMerge` and AJAX stuff both need to do. I'm
satisfied with this approach, so I'm down to hear any and all criticism
of it as it currently stands.

Of note: things are a little different than they were in the first
PR; in particular, `HtmlNormalizer` is now structured so you can
call its sub-parts and do stuff around them, which is what `LiftMerge`
does, instead of having a callback-based extensibility approach.

This fixes #1700.