### PR TITLE
Server comm failure callbacks

### DIFF
--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -104,11 +104,12 @@
 
     // Notify all functions in arr, passing any extra args
     function notifyAll(arr) {
-      var args = [].shift.call(arguments);  // Every arg but the passed array
+      var args = [].slice.call(arguments, 1);  // Every arg but the passed arr
       for(var i = 0; i < arr.length; i++) try {
         arr[i].apply(this, args);
       } catch (e) {
-        // Do nothing, just keep stuff from crapping out
+        settings.logError("Server communication callback failed!");
+        settings.logError(e);
       }
     }
 
@@ -243,7 +244,7 @@
             if (aboutToSend.onSuccess) {
               aboutToSend.onSuccess(data);
             }
-            notifyAll(ajaxOnCommFailures, data);
+            notifyAll(ajaxOnCommSuccesses);
             doCycleQueueCnt++;
             doAjaxCycle();
           };

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -617,9 +617,13 @@
       ajaxOnSessionLost: function() {
         settings.ajaxOnSessionLost();
       },
+      // Pass a callback function to be notified when an attempt to contact the server for an ajax call fails
+      // The first argument to the function will be the ajax request data.
       addAjaxOnCommFailure: function(callback) {
         ajaxOnCommFailures.push(callback);
       },
+      // Pass a callback function to be notified when an attempt to contact the server for an ajax call succeeds
+      // The first argument to the function will be the ajax request data.
       addAjaxOnCommSuccess: function(callback) {
         ajaxOnCommSuccesses.push(callback);
       },
@@ -631,9 +635,11 @@
       cometOnError: function(e) {
         settings.cometOnError(e);
       },
+      // Pass a callback function to be notified when an attempt to contact the server for comet fails
       addCometOnCommFailure: function(callback) {
         cometOnCommFailures.push(callback);
       },
+      // Pass a callback function to be notified when an attempt to contact the server for comet succeeds
       addCometOnCommSuccess: function(callback) {
         cometOnCommSuccesses.push(callback);
       },

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -108,7 +108,7 @@
       for(var i = 0; i < arr.length; i++) try {
         arr[i].apply(this, args);
       } catch (e) {
-        settings.logError("Server communication callback failed!");
+        settings.logError("Server communication status callback failed!");
         settings.logError(e);
       }
     }

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -103,7 +103,7 @@
     }
 
     // Notify all functions in arr, passing any extra args
-    function notifyAll(arr) {
+    var notifyAll = function(arr) {
       var args = [].slice.call(arguments, 1);  // Every arg but the passed arr
       for(var i = 0; i < arr.length; i++) {
         try {
@@ -113,7 +113,7 @@
           settings.logError(e);
         }
       }
-    }
+    };
 
     ////////////////////////////////////////////////
     ///// Ajax /////////////////////////////////////

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -105,11 +105,13 @@
     // Notify all functions in arr, passing any extra args
     function notifyAll(arr) {
       var args = [].slice.call(arguments, 1);  // Every arg but the passed arr
-      for(var i = 0; i < arr.length; i++) try {
-        arr[i].apply(this, args);
-      } catch (e) {
-        settings.logError("Server communication status callback failed!");
-        settings.logError(e);
+      for(var i = 0; i < arr.length; i++) {
+        try {
+          arr[i].apply(this, args);
+        } catch (e) {
+          settings.logError("Server communication status callback failed!");
+          settings.logError(e);
+        }
       }
     }
 


### PR DESCRIPTION
In this PR I added front-end hooks for applications to be notified of possible server communication problems.  There are 4 new public methods on `lift`:

```javascript
lift.addAjaxOnCommFailure()
lift.addAjaxOnCommSuccess()
lift.addCometOnCommFailure()
lift.addCometOnCommSuccess()
```

With these in place, it is possible for an app to show the user that server communication has potentially been lost after some threshold number of failure events for instance.

See relevant [ML thread](https://groups.google.com/forum/#!topic/liftweb/0z6SV0ucEW4).