### PR TITLE
Ajax retry configuration

### DIFF
--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -58,6 +58,9 @@
       ajaxOnEnd: function() {
         // noop
       },
+      ajaxAddMeta: function(toSend) {
+        // noop
+      },
       ajaxOnSessionLost: function() {
         window.location.reload();
       },
@@ -113,6 +116,7 @@
         onUploadProgress: onUploadProgress,
         version: ajaxVersion++
       };
+      settings.ajaxAddMeta(toSend);
 
       // Make sure we wrap when we hit JS max int.
       var version = ajaxVersion;
@@ -597,6 +601,9 @@
       startGc: successRegisterGC,
       ajaxOnSessionLost: function() {
         settings.ajaxOnSessionLost();
+      },
+      addAjaxMetaForOrderedRetry: function(toSend) {
+        toSend.submitted = toSend.when
       },
       calcAjaxUrl: calcAjaxUrl,
       registerComets: registerComets,

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -61,6 +61,9 @@
       ajaxAddMeta: function(toSend) {
         // noop
       },
+      ajaxQueueSort: function(ajaxQueue) {
+        ajaxQueueSortDefault(ajaxQueue)
+      },
       ajaxOnSessionLost: function() {
         window.location.reload();
       },
@@ -132,7 +135,7 @@
       }
 
       ajaxQueue.push(toSend);
-      ajaxQueueSort();
+      settings.ajaxQueueSort(ajaxQueue);
 
       if (initialized) {
         doCycleQueueCnt++;
@@ -142,7 +145,7 @@
       return false; // buttons in forms don't trigger the form
     }
 
-    function ajaxQueueSort() {
+    function ajaxQueueSortDefault(ajaxQueue) {
       ajaxQueue.sort(function (a, b) { return a.when - b.when; });
     }
 
@@ -250,7 +253,7 @@
               var now = (new Date()).getTime();
               aboutToSend.when = now + (1000 * Math.pow(2, cnt));
               queue.push(aboutToSend);
-              ajaxQueueSort();
+              settings.ajaxQueueSort(queue);
             }
             else {
               if (aboutToSend.onFailure) {
@@ -604,6 +607,10 @@
       },
       addAjaxMetaForOrderedRetry: function(toSend) {
         toSend.submitted = toSend.when
+      },
+      ajaxQueueSortDefault: ajaxQueueSortDefault,
+      ajaxQueueSortOrderedRetry: function(ajaxQueue){
+        ajaxQueue.sort(function (a, b) { return a.submitted - b.submitted; })
       },
       calcAjaxUrl: calcAjaxUrl,
       registerComets: registerComets,

--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -64,6 +64,9 @@
       ajaxQueueSort: function(ajaxQueue) {
         ajaxQueueSortDefault(ajaxQueue)
       },
+      ajaxCalcRetryTime: function(toSend) {
+        return ajaxCalcRetryTimeDefault(toSend)
+      },
       ajaxOnSessionLost: function() {
         window.location.reload();
       },
@@ -147,6 +150,10 @@
 
     function ajaxQueueSortDefault(ajaxQueue) {
       ajaxQueue.sort(function (a, b) { return a.when - b.when; });
+    }
+
+    function ajaxCalcRetryTimeDefault(toSend) {
+      return 1000 * Math.pow(2, toSend.retryCnt);
     }
 
     function startAjax() {
@@ -249,9 +256,9 @@
             }
 
             if (cnt < settings.ajaxRetryCount) {
-              aboutToSend.retryCnt = cnt + 1;
               var now = (new Date()).getTime();
-              aboutToSend.when = now + (1000 * Math.pow(2, cnt));
+              aboutToSend.when = now + settings.ajaxCalcRetryTime(aboutToSend);
+              aboutToSend.retryCnt = cnt + 1;
               queue.push(aboutToSend);
               settings.ajaxQueueSort(queue);
             }
@@ -612,6 +619,7 @@
       ajaxQueueSortOrderedRetry: function(ajaxQueue){
         ajaxQueue.sort(function (a, b) { return a.submitted - b.submitted; })
       },
+      ajaxCalcRetryTimeDefault: ajaxCalcRetryTimeDefault,
       calcAjaxUrl: calcAjaxUrl,
       registerComets: registerComets,
       cometOnSessionLost: function() {

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -922,6 +922,11 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
     else Full(toSend => Noop)
   ) {}
 
+  val ajaxQueueSortFunc: FactoryMaker[Box[JsVar => JsCmd]] = new FactoryMaker[Box[JsVar => JsCmd]](() =>
+    if (ajaxRetryInOrderReceived.vend) Full(ajaxQueue => JE.Call("lift.ajaxQueueSortOrderedRetry", ajaxQueue))
+    else Full(ajaxQueue => JE.Call("lift.ajaxQueueSortDefault", ajaxQueue))
+  ) {}
+
   /**
    * An XML header is inserted at the very beginning of returned XHTML pages.
    * This function defines the cases in which such a header is inserted.  The

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -924,8 +924,10 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
 
   val ajaxQueueSortFunc: FactoryMaker[Box[JsVar => JsCmd]] = new FactoryMaker[Box[JsVar => JsCmd]](() =>
     if (ajaxRetryInOrderReceived.vend) Full(ajaxQueue => JE.Call("lift.ajaxQueueSortOrderedRetry", ajaxQueue))
-    else Full(ajaxQueue => JE.Call("lift.ajaxQueueSortDefault", ajaxQueue))
+    else Full(ajaxQueueSortDefaultFunc)
   ) {}
+  private [http] val ajaxQueueSortDefaultFunc:JsVar => JsCmd =
+    ajaxQueue => JE.Call("lift.ajaxQueueSortDefault", ajaxQueue)
 
   /**
    * An XML header is inserted at the very beginning of returned XHTML pages.

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -915,25 +915,117 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
     ajaxEnd = Full(f: () => JsCmd)
   }
 
-  val ajaxRetryInOrderReceived:FactoryMaker[Boolean] = new FactoryMaker[Boolean](() => false){}
+  private [http] val ajaxAddMetaDefaultFunc:JsVar => JsCmd = toSend => Noop
+  private [http] val ajaxQueueSortDefaultFunc:JsVar => JsCmd = ajaxQueue => JE.Call("lift.ajaxQueueSortDefault", ajaxQueue)
 
-  val ajaxAddMetaFunc: FactoryMaker[Box[JsVar => JsCmd]] = new FactoryMaker[Box[JsVar => JsCmd]](() =>
-    if (ajaxRetryInOrderReceived.vend) Full(toSend => JE.Call("lift.addAjaxMetaForOrderedRetry", toSend))
-    else Full(toSend => Noop)
+  /**
+    * Sets the `ajaxAddMeta()` and `ajaxQueueSort()` javascript functions, allowing the application's ajax
+    * retry logic to be configured.
+    *
+    * By default, Lift will retry failed ajax requests with an exponential backoff (see `LiftRules.ajaxCalcRetryTimeFunc`),
+    * allowing messages to arrive at the server in a shuffled order during periods of failed communications with the server.
+    *
+    * Alternatively, you can have Lift never send messages out of order:
+    * {{{
+    * LiftRules.ajaxAddMetaAndQueueSortFuncs.default.set(() => LiftRules.ajaxAddMetaAndQueueSortInOrderReceivedFuncs)
+    * }}}
+    *
+    * You could also define your own message ordering policy.
+    *
+    * Note: The function you provide is run in the context of a request, allowing you to have conditional logic for
+    * setting these functions.  For instance, you could have on URL which serves an application requiring ordered
+    * messages, while others do not.  Example:
+    * {{{
+    * LiftRules.ajaxAddMetaAndQueueSortFuncs.default.set { () =>
+    *   S.request match {
+    *     case Full(Req("ordered" :: Nil, _, _)) => LiftRules.ajaxAddMetaAndQueueSortInOrderReceivedFuncs
+    *     case _ => LiftRules.ajaxAddMetaAndQueueSortDefaultFuncs
+    *   }
+    * }
+    * }}}
+    *
+    */
+  val ajaxAddMetaAndQueueSortFuncs: FactoryMaker[Box[(JsVar => JsCmd, JsVar => JsCmd)]] = new FactoryMaker[Box[(JsVar => JsCmd, JsVar => JsCmd)]]( () =>
+    Full((ajaxAddMetaDefaultFunc, ajaxQueueSortDefaultFunc))
   ) {}
 
-  val ajaxQueueSortFunc: FactoryMaker[Box[JsVar => JsCmd]] = new FactoryMaker[Box[JsVar => JsCmd]](() =>
-    if (ajaxRetryInOrderReceived.vend) Full(ajaxQueue => JE.Call("lift.ajaxQueueSortOrderedRetry", ajaxQueue))
-    else Full(ajaxQueueSortDefaultFunc)
-  ) {}
-  private [http] val ajaxQueueSortDefaultFunc:JsVar => JsCmd =
-    ajaxQueue => JE.Call("lift.ajaxQueueSortDefault", ajaxQueue)
+  /**
+    * Set `LiftRules.ajaxAddMetaAndQueueSortFuncs` to this value to force Lift to not send messages out of order in
+    * the event of an ajax error.
+    *
+    * Example:
+    * `LiftRules.ajaxAddMetaAndQueueSortFuncs.default.set(() => LiftRules.ajaxAddMetaAndQueueSortInOrderReceivedFuncs)`
+    *
+    * Note: an ajax error is not necessarily a network error, as throwing an exception
+    * in a server-side ajax function will raise an ajax error.  If you choose this ajax retry policy, it is advisable
+    * to try/catch all of your ajax function logic.
+    *
+    * Note: the default for `LiftRules.ajaxRetryCount` is 3.  If retries are ordered and the retries are exhausted,
+    * then Lift will drop the failed request and pick up the next.  You will need to adjust this setting if it is
+    * not acceptable for your ajax messages to ever be received by the server in the event a request is lost.
+    *
+    * Note: The default retry timeout is exponentially-backed off (see `LiftRules.ajaxCalcRetryTimeFunc`).  Hence
+    * if you set `LiftRules.ajaxRetryCount` to a high number, then you can potentially starve out clients who
+    * experince long periods of errors.
+    */
+  val ajaxAddMetaAndQueueSortInOrderReceivedFuncs: Box[(JsVar => JsCmd, JsVar => JsCmd)] = Full(
+    toSend => JE.Call("lift.addAjaxMetaForOrderedRetry", toSend),
+    ajaxQueue => JE.Call("lift.ajaxQueueSortOrderedRetry", ajaxQueue)
+  )
 
+  /**
+    * The default functions provided to `LiftRules.ajaxAddMetaAndQueueSortFuncs`.
+    *
+    * These are provided in case you need conditional logic that would sometimes result in the default behavior.
+    * Example:
+    * {{{
+    * LiftRules.ajaxAddMetaAndQueueSortFuncs.default.set { () =>
+    *   S.request match {
+    *     case Full(Req("ordered" :: Nil, _, _)) => LiftRules.ajaxAddMetaAndQueueSortInOrderReceivedFuncs
+    *     case _ => LiftRules.ajaxAddMetaAndQueueSortDefaultFuncs
+    *   }
+    * }
+    * }}}
+    */
+  val ajaxAddMetaAndQueueSortDefaultFuncs: Box[(JsVar => JsCmd, JsVar => JsCmd)] = Full(
+    ajaxAddMetaDefaultFunc,
+    ajaxQueueSortDefaultFunc
+  )
+
+  /**
+    * Sets the `ajaxCalcRetryTime()` javascript function.
+    *
+    * By default, Lift will retry failed ajax requests with an exponential backoff.  Use this setting to configure
+    * this behavior according to your application's needs.  For example, you have Lift retry ajax failures every
+    * 1500 milliseconds:
+    * {{{
+    * LiftRules.ajaxCalcRetryTimeFunc.default.set(() => Full(toSend =>
+    *   JsRaw("1500")
+    * ))
+    * }}}
+    *
+    * Note that the `toSend` argument is the ajax request wrapped with some meta data.  Of note is the `retryCnt`
+    * field which the default implementation uses to calculate the exponential backoff.
+    */
   val ajaxCalcRetryTimeFunc: FactoryMaker[Box[JsVar => JsExp]] = new FactoryMaker[Box[JsVar => JsExp]](() =>
     Full(ajaxCalcRetryTimeDefaultFunc)
   ) {}
-  private [http] val ajaxCalcRetryTimeDefaultFunc:JsVar => JsExp =
-    toSend => JE.Call("lift.ajaxCalcRetryTimeDefault", toSend)
+
+  /**
+    * The default function for `LiftRules.ajaxCalcRetryTimeFunc`.
+    *
+    * This is provided in case you need conditional logic which sometimes results in the default bahavior.
+    * Example:
+    * {{{
+    * LiftRules.ajaxCalcRetryTimeFunc.default.set { () =>
+    *   S.request match {
+    *     case Full(Req("constant" :: Nil, _, _)) => Full(toSend => JsRaw("1500")))
+    *     case _ => Full(LiftRules.ajaxCalcRetryTimeDefaultFunc)
+    *   }
+    * }
+    * }}}
+    */
+  val ajaxCalcRetryTimeDefaultFunc:JsVar => JsExp = toSend => JE.Call("lift.ajaxCalcRetryTimeDefault", toSend)
 
   /**
    * An XML header is inserted at the very beginning of returned XHTML pages.

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -915,6 +915,13 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
     ajaxEnd = Full(f: () => JsCmd)
   }
 
+  @volatile var ajaxRetryInOrderReceived:Boolean = false
+
+  @volatile var ajaxAddMetaFunc: FactoryMaker[Box[JsVar => JsCmd]] = new FactoryMaker[Box[JsVar => JsCmd]](() =>
+    if (ajaxRetryInOrderReceived) Full(toSend => JE.Call("lift.addAjaxMetaForOrderedRetry", toSend))
+    else Full(toSend => Noop)
+  ) {}
+
   /**
    * An XML header is inserted at the very beginning of returned XHTML pages.
    * This function defines the cases in which such a header is inserted.  The

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -915,10 +915,10 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
     ajaxEnd = Full(f: () => JsCmd)
   }
 
-  @volatile var ajaxRetryInOrderReceived:Boolean = false
+  val ajaxRetryInOrderReceived:FactoryMaker[Boolean] = new FactoryMaker[Boolean](() => false){}
 
-  @volatile var ajaxAddMetaFunc: FactoryMaker[Box[JsVar => JsCmd]] = new FactoryMaker[Box[JsVar => JsCmd]](() =>
-    if (ajaxRetryInOrderReceived) Full(toSend => JE.Call("lift.addAjaxMetaForOrderedRetry", toSend))
+  val ajaxAddMetaFunc: FactoryMaker[Box[JsVar => JsCmd]] = new FactoryMaker[Box[JsVar => JsCmd]](() =>
+    if (ajaxRetryInOrderReceived.vend) Full(toSend => JE.Call("lift.addAjaxMetaForOrderedRetry", toSend))
     else Full(toSend => Noop)
   ) {}
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -929,6 +929,12 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   private [http] val ajaxQueueSortDefaultFunc:JsVar => JsCmd =
     ajaxQueue => JE.Call("lift.ajaxQueueSortDefault", ajaxQueue)
 
+  val ajaxCalcRetryTimeFunc: FactoryMaker[Box[JsVar => JsExp]] = new FactoryMaker[Box[JsVar => JsExp]](() =>
+    Full(ajaxCalcRetryTimeDefaultFunc)
+  ) {}
+  private [http] val ajaxCalcRetryTimeDefaultFunc:JsVar => JsExp =
+    toSend => JE.Call("lift.ajaxCalcRetryTimeDefault", toSend)
+
   /**
    * An XML header is inserted at the very beginning of returned XHTML pages.
    * This function defines the cases in which such a header is inserted.  The

--- a/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
@@ -58,6 +58,7 @@ object LiftJavaScript {
 
   def settings: JsObj = {
     val jsCometServer = LiftRules.cometServer().map(Str(_)).getOrElse(JsNull)
+    val (ajaxAddMeta, ajaxQueueSort) = LiftRules.ajaxAddMetaAndQueueSortFuncs.vend.openOr((LiftRules.ajaxAddMetaDefaultFunc, LiftRules.ajaxQueueSortDefaultFunc))
     JsObj(
       "liftPath" -> LiftRules.liftPath,
       "ajaxRetryCount" -> Num(LiftRules.ajaxRetryCount.openOr(3)),
@@ -71,8 +72,8 @@ object LiftJavaScript {
       "ajaxOnFailure" -> LiftRules.ajaxDefaultFailure.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
       "ajaxOnStart" -> LiftRules.ajaxStart.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
       "ajaxOnEnd" -> LiftRules.ajaxEnd.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
-      "ajaxAddMeta" -> LiftRules.ajaxAddMetaFunc.vend.map(fnc => AnonFunc("toSend", fnc(JsVar("toSend")))).openOr(AnonFunc("toSend", Noop)),
-      "ajaxQueueSort" -> AnonFunc("ajaxQueue", LiftRules.ajaxQueueSortFunc.vend.openOr(LiftRules.ajaxQueueSortDefaultFunc).apply(JsVar("ajaxQueue"))),
+      "ajaxAddMeta" -> AnonFunc("toSend", ajaxAddMeta(JsVar("toSend"))),
+      "ajaxQueueSort" -> AnonFunc("ajaxQueue", ajaxQueueSort(JsVar("ajaxQueue"))),
       "ajaxCalcRetryTime" -> AnonFunc("toSend", JsReturn(LiftRules.ajaxCalcRetryTimeFunc.vend.openOr(LiftRules.ajaxCalcRetryTimeDefaultFunc).apply(JsVar("toSend"))))
     )
   }

--- a/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
@@ -72,7 +72,8 @@ object LiftJavaScript {
       "ajaxOnStart" -> LiftRules.ajaxStart.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
       "ajaxOnEnd" -> LiftRules.ajaxEnd.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
       "ajaxAddMeta" -> LiftRules.ajaxAddMetaFunc.vend.map(fnc => AnonFunc("toSend", fnc(JsVar("toSend")))).openOr(AnonFunc("toSend", Noop)),
-      "ajaxQueueSort" -> AnonFunc("ajaxQueue", LiftRules.ajaxQueueSortFunc.vend.openOr(LiftRules.ajaxQueueSortDefaultFunc).apply(JsVar("ajaxQueue")))
+      "ajaxQueueSort" -> AnonFunc("ajaxQueue", LiftRules.ajaxQueueSortFunc.vend.openOr(LiftRules.ajaxQueueSortDefaultFunc).apply(JsVar("ajaxQueue"))),
+      "ajaxCalcRetryTime" -> AnonFunc("toSend", JsReturn(LiftRules.ajaxCalcRetryTimeFunc.vend.openOr(LiftRules.ajaxCalcRetryTimeDefaultFunc).apply(JsVar("toSend"))))
     )
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
@@ -72,7 +72,7 @@ object LiftJavaScript {
       "ajaxOnStart" -> LiftRules.ajaxStart.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
       "ajaxOnEnd" -> LiftRules.ajaxEnd.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
       "ajaxAddMeta" -> LiftRules.ajaxAddMetaFunc.vend.map(fnc => AnonFunc("toSend", fnc(JsVar("toSend")))).openOr(AnonFunc("toSend", Noop)),
-      "ajaxQueueSort" -> LiftRules.ajaxQueueSortFunc.vend.map(fnc => AnonFunc("ajaxQueue", fnc(JsVar("ajaxQueue")))).openOr(AnonFunc("ajaxQueue", Noop))
+      "ajaxQueueSort" -> AnonFunc("ajaxQueue", LiftRules.ajaxQueueSortFunc.vend.openOr(LiftRules.ajaxQueueSortDefaultFunc).apply(JsVar("ajaxQueue")))
     )
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
@@ -71,7 +71,8 @@ object LiftJavaScript {
       "ajaxOnFailure" -> LiftRules.ajaxDefaultFailure.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
       "ajaxOnStart" -> LiftRules.ajaxStart.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
       "ajaxOnEnd" -> LiftRules.ajaxEnd.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
-      "ajaxAddMeta" -> LiftRules.ajaxAddMetaFunc.vend.map(fnc => AnonFunc("toSend", fnc(JsVar("toSend")))).openOr(AnonFunc("toSend", Noop))
+      "ajaxAddMeta" -> LiftRules.ajaxAddMetaFunc.vend.map(fnc => AnonFunc("toSend", fnc(JsVar("toSend")))).openOr(AnonFunc("toSend", Noop)),
+      "ajaxQueueSort" -> LiftRules.ajaxQueueSortFunc.vend.map(fnc => AnonFunc("ajaxQueue", fnc(JsVar("ajaxQueue")))).openOr(AnonFunc("ajaxQueue", Noop))
     )
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
@@ -70,7 +70,8 @@ object LiftJavaScript {
       "logError" -> LiftRules.jsLogFunc.map(fnc => AnonFunc("msg", fnc(JsVar("msg")))).openOr(AnonFunc("msg", Noop)),
       "ajaxOnFailure" -> LiftRules.ajaxDefaultFailure.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
       "ajaxOnStart" -> LiftRules.ajaxStart.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
-      "ajaxOnEnd" -> LiftRules.ajaxEnd.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop))
+      "ajaxOnEnd" -> LiftRules.ajaxEnd.map(fnc => AnonFunc(fnc())).openOr(AnonFunc(Noop)),
+      "ajaxAddMeta" -> LiftRules.ajaxAddMetaFunc.vend.map(fnc => AnonFunc("toSend", fnc(JsVar("toSend")))).openOr(AnonFunc("toSend", Noop))
     )
   }
 

--- a/web/webkit/src/test/scala/net/liftweb/http/js/LiftJavaScriptSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/js/LiftJavaScriptSpec.scala
@@ -43,58 +43,174 @@ object LiftJavaScriptSpec extends Specification  {
     "create default settings" in withEnglishLocale {
       S.initIfUninitted(session) {
         val settings = LiftJavaScript.settings
-        settings.toJsCmd must_== """{"liftPath": "/lift", "ajaxRetryCount": 3, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": null, "logError": function(msg) {}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}}"""
+        settings.toJsCmd must_== formatjs(
+          """{"liftPath": "/lift",
+            |"ajaxRetryCount": 3,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": null,
+            |"logError": function(msg) {},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {},
+            |"ajaxAddMeta": function(toSend) {},
+            |"ajaxQueueSort": function(ajaxQueue) {lift.ajaxQueueSortDefault(ajaxQueue);},
+            |"ajaxCalcRetryTime": function(toSend) {return lift.ajaxCalcRetryTimeDefault(toSend)}}"""
+        )
       }
     }
     "create internationalized default settings" in withPolishLocale {
       S.initIfUninitted(session) {
         val settings = LiftJavaScript.settings
         val internationalizedMessage = "Nie mo\\u017cna skontaktowa\\u0107 si\\u0119 z serwerem"
-        settings.toJsCmd must_== s"""{"liftPath": "/lift", "ajaxRetryCount": 3, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": null, "logError": function(msg) {}, "ajaxOnFailure": function() {alert("$internationalizedMessage");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}}"""
+        settings.toJsCmd must_== formatjs(
+          s"""{"liftPath": "/lift",
+             |"ajaxRetryCount": 3,
+             |"ajaxPostTimeout": 5000,
+             |"gcPollingInterval": 75000,
+             |"gcFailureRetryTimeout": 15000,
+             |"cometGetTimeout": 140000,
+             |"cometFailureRetryTimeout": 10000,
+             |"cometServer": null,
+             |"logError": function(msg) {},
+             |"ajaxOnFailure": function() {alert("$internationalizedMessage");},
+             |"ajaxOnStart": function() {},
+             |"ajaxOnEnd": function() {},
+             |"ajaxAddMeta": function(toSend) {},
+             |"ajaxQueueSort": function(ajaxQueue) {lift.ajaxQueueSortDefault(ajaxQueue);},
+             |"ajaxCalcRetryTime": function(toSend) {return lift.ajaxCalcRetryTimeDefault(toSend)}}"""
+        )
       }
     }
     "create custom static settings" in withEnglishLocale {
       S.initIfUninitted(session) {
         LiftRules.ajaxRetryCount = Full(4)
         val settings = LiftJavaScript.settings
-        settings.toJsCmd must_== """{"liftPath": "/lift", "ajaxRetryCount": 4, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": null, "logError": function(msg) {}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}}"""
+        settings.toJsCmd must_== formatjs(
+          """{"liftPath": "/lift",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": null,
+            |"logError": function(msg) {},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {},
+            |"ajaxAddMeta": function(toSend) {},
+            |"ajaxQueueSort": function(ajaxQueue) {lift.ajaxQueueSortDefault(ajaxQueue);},
+            |"ajaxCalcRetryTime": function(toSend) {return lift.ajaxCalcRetryTimeDefault(toSend)}}"""
+        )
       }
     }
     "create custom dynamic settings" in withEnglishLocale {
       S.initIfUninitted(session) {
         LiftRules.cometServer = () => Some("srvr1")
         val settings = LiftJavaScript.settings
-        settings.toJsCmd must_== """{"liftPath": "/lift", "ajaxRetryCount": 4, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": "srvr1", "logError": function(msg) {}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}}"""
+        settings.toJsCmd must_== formatjs(
+          """{"liftPath": "/lift",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": "srvr1",
+            |"logError": function(msg) {},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {},
+            |"ajaxAddMeta": function(toSend) {},
+            |"ajaxQueueSort": function(ajaxQueue) {lift.ajaxQueueSortDefault(ajaxQueue);},
+            |"ajaxCalcRetryTime": function(toSend) {return lift.ajaxCalcRetryTimeDefault(toSend)}}"""
+        )
       }
     }
     "create custom function settings" in withEnglishLocale {
       S.initIfUninitted(session) {
         LiftRules.jsLogFunc = Full(v => JE.Call("lift.logError", v))
         val settings = LiftJavaScript.settings
-        settings.toJsCmd must_== """{"liftPath": "/lift", "ajaxRetryCount": 4, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": "srvr1", "logError": function(msg) {lift.logError(msg);}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}}"""
+        settings.toJsCmd must_== formatjs(
+          """{"liftPath": "/lift",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": "srvr1",
+            |"logError": function(msg) {lift.logError(msg);},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {},
+            |"ajaxAddMeta": function(toSend) {},
+            |"ajaxQueueSort": function(ajaxQueue) {lift.ajaxQueueSortDefault(ajaxQueue);},
+            |"ajaxCalcRetryTime": function(toSend) {return lift.ajaxCalcRetryTimeDefault(toSend)}}"""
+        )
       }
     }
     "create init command" in withEnglishLocale {
       S.initIfUninitted(session) {
         val init = LiftRules.javaScriptSettings.vend().map(_.apply(session)).map(LiftJavaScript.initCmd(_).toJsCmd)
-        init must_==
-          Full("""var lift_settings = {"liftPath": "/lift", "ajaxRetryCount": 4, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": "srvr1", "logError": function(msg) {lift.logError(msg);}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}};
-            |window.lift.extend(lift_settings,window.liftJQuery);
-            |window.lift.init(lift_settings);""".stripMargin)
+        init must_== Full(formatjs(List(
+          """var lift_settings = {"liftPath": "/lift",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": "srvr1",
+            |"logError": function(msg) {lift.logError(msg);},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {},
+            |"ajaxAddMeta": function(toSend) {},
+            |"ajaxQueueSort": function(ajaxQueue) {lift.ajaxQueueSortDefault(ajaxQueue);},
+            |"ajaxCalcRetryTime": function(toSend) {return lift.ajaxCalcRetryTimeDefault(toSend)}};""",
+          "window.lift.extend(lift_settings,window.liftJQuery);",
+          "window.lift.init(lift_settings);"
+        )))
       }
     }
     "create init command with custom setting" in withEnglishLocale {
       S.initIfUninitted(session) {
         val settings = LiftJavaScript.settings.extend(JsObj("liftPath" -> "liftyStuff", "mysetting" -> 99))
         val init = LiftJavaScript.initCmd(settings)
-        println(init.toJsCmd)
-        init.toJsCmd must_==
-          """var lift_settings = {"liftPath": "liftyStuff", "ajaxRetryCount": 4, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": "srvr1", "logError": function(msg) {lift.logError(msg);}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}, "mysetting": 99};
-            |window.lift.extend(lift_settings,window.liftJQuery);
-            |window.lift.init(lift_settings);""".stripMargin
+        init.toJsCmd must_== formatjs(List(
+          """var lift_settings = {"liftPath": "liftyStuff",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": "srvr1",
+            |"logError": function(msg) {lift.logError(msg);},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {},
+            |"ajaxAddMeta": function(toSend) {},
+            |"ajaxQueueSort": function(ajaxQueue) {lift.ajaxQueueSortDefault(ajaxQueue);},
+            |"ajaxCalcRetryTime": function(toSend) {return lift.ajaxCalcRetryTimeDefault(toSend)},
+            |"mysetting": 99};""",
+          "window.lift.extend(lift_settings,window.liftJQuery);",
+          "window.lift.init(lift_settings);"
+        ))
       }
     }
   }
+
+  def formatjs(line:String):String = formatjs(line :: Nil)
+  def formatjs(lines:List[String]):String = lines.map { _.stripMargin.lines.toList match {
+    case init :+ last => (init.map(_ + " ") :+ last).mkString
+    case Nil => ""
+  }}.mkString("\n")
 
   object withEnglishLocale extends WithLocale(Locale.ENGLISH)
 


### PR DESCRIPTION
This PR is to give Lift applications more control over ajax retries.  With these changes an application can change the ajax queue's sorting logic and retry timeout calculation.  

See [this ML thread](https://groups.google.com/forum/#!topic/liftweb/0z6SV0ucEW4) for some discussion regarding this idea.