### PR TITLE
Bump our snapshot build back to Java 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
 services:
   - mongodb
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
 script: ./travis.sh
 


### PR DESCRIPTION
Now that M8 is out the door and we've announced the change in
supported Java version, we can bump the snapshot to Java 8.