### PR TITLE
Convert \\ to return a JObject

### DIFF
--- a/core/json/README.md
+++ b/core/json/README.md
@@ -1,7 +1,7 @@
 Parsing and formatting utilities for JSON.
 
 A central concept in lift-json library is Json AST which models the structure of
-a JSON document as a syntax tree. 
+a JSON document as a syntax tree.
 
     sealed abstract class JValue
     case object JNothing extends JValue // 'zero' for JValue
@@ -10,7 +10,7 @@ a JSON document as a syntax tree.
     case class JDouble(num: Double) extends JValue
     case class JInt(num: BigInt) extends JValue
     case class JBool(value: Boolean) extends JValue
-    case class JObject(obj: List[JField]) extends JValue 
+    case class JObject(obj: List[JField]) extends JValue
     case class JArray(arr: List[JValue]) extends JValue
 
     case class JField(String, JValue)
@@ -83,7 +83,7 @@ Migration from older versions
 
 JField is no longer a JValue. This means more type safety since it is no longer possible
 to create invalid JSON where JFields are added directly into JArrays for instance. Most
-noticeable consequence of this change is that map, transform, find and filter come in 
+noticeable consequence of this change is that map, transform, find and filter come in
 two versions:
 
     def map(f: JValue => JValue): JValue
@@ -100,7 +100,7 @@ in the name to traverse values in the JSON.
 2.2 ->
 ------
 
-Path expressions were changed after 2.2 version. Previous versions returned JField which 
+Path expressions were changed after 2.2 version. Previous versions returned JField which
 unnecessarily complicated the use of the expressions. If you have used path expressions
 with pattern matching like:
 
@@ -117,7 +117,7 @@ Any valid json can be parsed into internal AST format.
 
     scala> import net.liftweb.json._
     scala> parse(""" { "numbers" : [1, 2, 3, 4] } """)
-    res0: net.liftweb.json.JsonAST.JValue = 
+    res0: net.liftweb.json.JsonAST.JValue =
           JObject(List(JField(numbers,JArray(List(JInt(1), JInt(2), JInt(3), JInt(4))))))
 
 Producing JSON
@@ -178,7 +178,7 @@ Example
       val winners = List(Winner(23, List(2, 45, 34, 23, 3, 5)), Winner(54, List(52, 3, 12, 11, 18, 22)))
       val lotto = Lotto(5, List(2, 45, 34, 23, 7, 5, 3), winners, None)
 
-      val json = 
+      val json =
         ("lotto" ->
           ("lotto-id" -> lotto.id) ~
           ("winning-numbers" -> lotto.winningNumbers) ~
@@ -233,17 +233,17 @@ Please see more examples in src/test/scala/net/liftweb/json/MergeExamples.scala 
            }""")
 
     scala> val lotto2 = parse("""{
-             "lotto":{ 
+             "lotto":{
                "winners":[{
                  "winner-id":54,
                  "numbers":[52,3,12,11,18,22]
                }]
              }
            }""")
-    
+
     scala> val mergedLotto = lotto1 merge lotto2
     scala> pretty(render(mergedLotto))
-    res0: String = 
+    res0: String =
     {
       "lotto":{
         "lotto-id":5,
@@ -294,10 +294,10 @@ Please see more examples in src/test/scala/net/liftweb/json/JsonQueryExamples.sc
     scala> for { JObject(o) <- json; JField("age", JInt(age)) <- o } yield age
     res0: List[BigInt] = List(5, 3)
 
-    scala> for { 
+    scala> for {
              JObject(child) <- json
-             JField("name", JString(name)) <- child 
-             JField("age", JInt(age)) <- child 
+             JField("name", JString(name)) <- child
+             JField("age", JInt(age)) <- child
              if age > 4
            } yield (name, age)
     res1: List[(String, BigInt)] = List((Mary,5))
@@ -305,12 +305,12 @@ Please see more examples in src/test/scala/net/liftweb/json/JsonQueryExamples.sc
 XPath + HOFs
 ------------
 
-Json AST can be queried using XPath like functions. Following REPL session shows the usage of 
-'\\', '\\\\', 'find', 'filter', 'transform', 'remove' and 'values' functions. 
+Json AST can be queried using XPath like functions. Following REPL session shows the usage of
+'\\', '\\\\', 'find', 'filter', 'transform', 'remove' and 'values' functions.
 
     The example json is:
 
-    { 
+    {
       "person": {
         "name": "Joe",
         "age": 35,
@@ -328,12 +328,12 @@ Json AST can be queried using XPath like functions. Following REPL session shows
     scala> import net.liftweb.json._
     scala> import net.liftweb.json.JsonDSL._
 
-    scala> val json = 
+    scala> val json =
       ("person" ->
         ("name" -> "Joe") ~
         ("age" -> 35) ~
-        ("spouse" -> 
-          ("person" -> 
+        ("spouse" ->
+          ("person" ->
             ("name" -> "Marilyn") ~
             ("age" -> 33)
           )
@@ -341,8 +341,7 @@ Json AST can be queried using XPath like functions. Following REPL session shows
       )
 
     scala> json \\ "spouse"
-    res0: net.liftweb.json.JsonAST.JValue = JObject(List(
-          JField(person,JObject(List((name,JString(Marilyn)), (age,JInt(33)))))))
+    res0: net.liftweb.json.JsonAST.JValue = JObject(List(JField(person,JObject(List((name,JString(Marilyn)), (age,JInt(33)))))))
 
     scala> compact(render(res0))
     res1: String = {"person":{"name":"Marilyn","age":33}}
@@ -444,11 +443,11 @@ Please see more examples in src/test/scala/net/liftweb/json/ExtractionExamplesSp
              }
            """)
 
-    scala> json.extract[Person] 
+    scala> json.extract[Person]
     res0: Person = Person(joe,Address(Bulevard,Helsinki),List(Child(Mary,5,Some(Sat Sep 04 18:06:22 EEST 2004)), Child(Mazy,3,None)))
 
-By default the constructor parameter names must match json field names. However, sometimes json 
-field names contain characters which are not allowed characters in Scala identifiers. There's two 
+By default the constructor parameter names must match json field names. However, sometimes json
+field names contain characters which are not allowed characters in Scala identifiers. There's two
 solutions for this (see src/test/scala/net/liftweb/json/LottoExample.scala for bigger example).
 
 Use back ticks.
@@ -562,7 +561,7 @@ To enable serialization of fields, a FieldSerializer can be added for some type:
 
     implicit val formats = DefaultFormats + FieldSerializer[WildDog]()
 
-Now the type WildDog (and all subtypes) gets serialized with all its fields (+ constructor parameters). 
+Now the type WildDog (and all subtypes) gets serialized with all its fields (+ constructor parameters).
 FieldSerializer takes two optional parameters which can be used to intercept the field serialization:
 
     case class FieldSerializer[A: Manifest](
@@ -570,7 +569,7 @@ FieldSerializer takes two optional parameters which can be used to intercept the
       deserializer: PartialFunction[JField, JField] = Map()
     )
 
-Those PartialFunctions are called just before a field is serialized or deserialized. Some useful PFs to 
+Those PartialFunctions are called just before a field is serialized or deserialized. Some useful PFs to
 rename and ignore fields are provided:
 
     val dogSerializer = FieldSerializer[WildDog](
@@ -592,14 +591,14 @@ by providing following serializer.
            }
 
     scala> class IntervalSerializer extends CustomSerializer[Interval](format => (
-             { 
-               case JObject(JField("start", JInt(s)) :: JField("end", JInt(e)) :: Nil) => 
-                 new Interval(s.longValue, e.longValue) 
+             {
+               case JObject(JField("start", JInt(s)) :: JField("end", JInt(e)) :: Nil) =>
+                 new Interval(s.longValue, e.longValue)
              },
-             { 
+             {
                case x: Interval =>
-                 JObject(JField("start", JInt(BigInt(x.startTime))) :: 
-                         JField("end",   JInt(BigInt(x.endTime))) :: Nil) 
+                 JObject(JField("start", JInt(BigInt(x.startTime))) ::
+                         JField("end",   JInt(BigInt(x.endTime))) :: Nil)
              }
            ))
 

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -168,7 +168,7 @@ object JsonAST {
      * res2: JValue = JObject(List(JField(name,JString(Joe)), JField(name,JString(Alabama Cheer))))
      * }}}
      */
-    def \\(nameToFind: String): List[JField] = {
+    def \\(nameToFind: String): JObject = {
       def find(json: JValue): List[JField] = json match {
         case JObject(fields) =>
           fields.foldLeft(List[JField]()) {
@@ -187,7 +187,7 @@ object JsonAST {
           Nil
       }
 
-      find(this)
+      JObject(find(this))
     }
 
     /**

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -168,7 +168,7 @@ object JsonAST {
      * res2: JValue = JObject(List(JField(name,JString(Joe)), JField(name,JString(Alabama Cheer))))
      * }}}
      */
-    def \\(nameToFind: String): JValue = {
+    def \\(nameToFind: String): List[JField] = {
       def find(json: JValue): List[JField] = json match {
         case JObject(fields) =>
           fields.foldLeft(List[JField]()) {
@@ -187,13 +187,10 @@ object JsonAST {
           Nil
       }
 
-      find(this) match {
-        case JField(_, x) :: Nil => x
-        case xs => JObject(xs)
-      }
+      find(this)
     }
 
-    /** 
+    /**
      * Find immediate children of this `[[JValue]]` that match a specific `JValue` subclass.
      *
      * This methid will search a `[[JObject]]` or `[[JArray]]` for values of a specific type and
@@ -357,8 +354,8 @@ object JsonAST {
     def foldField[A](z: A)(f: (A, JField) => A): A = {
       def rec(acc: A, v: JValue) = {
         v match {
-          case JObject(l) => l.foldLeft(acc) { 
-            case (a, field@JField(name, value)) => value.foldField(f(a, field))(f) 
+          case JObject(l) => l.foldLeft(acc) {
+            case (a, field@JField(name, value)) => value.foldField(f(a, field))(f)
           }
           case JArray(l) => l.foldLeft(acc)((a, e) => e.foldField(a)(f))
           case _ => acc
@@ -419,7 +416,7 @@ object JsonAST {
 
     /** Return a new `JValue` resulting from applying the given partial function `f``
      * to each field in JSON.
-     * 
+     *
      * Example:
      * {{{
      * JObject(("age", JInt(10)) :: Nil) transformField {
@@ -440,7 +437,7 @@ object JsonAST {
      *
      * If this is a `JObject`, this means we will transform the value of each
      * field of the object and the object in turn and return an updated object.
-     * 
+     *
      * If this is another type of `JValue`, the value is transformed directly.
      *
      * Note that this happens recursively, so you will receive both each value
@@ -590,7 +587,7 @@ object JsonAST {
      * @return A `List` of `JField`s that match the given predicate `p`, or `Nil`
      *         if this `JValue` is not a `JObject`.
      */
-    def filterField(p: JField => Boolean): List[JField] = 
+    def filterField(p: JField => Boolean): List[JField] =
       foldField(List[JField]())((acc, e) => if (p(e)) e :: acc else acc).reverse
 
     /**
@@ -618,19 +615,19 @@ object JsonAST {
     def filter(p: JValue => Boolean): List[JValue] =
       fold(List[JValue]())((acc, e) => if (p(e)) e :: acc else acc).reverse
 
-    /** 
+    /**
      * Create a new instance of `[[WithFilter]]` for Scala to use when using
      * this `JValue` in a for comprehension.
      */
     def withFilter(p: JValue => Boolean) = new WithFilter(this, p)
-    
+
     final class WithFilter(self: JValue, p: JValue => Boolean) {
       def map[A](f: JValue => A): List[A] = self filter p map f
       def flatMap[A](f: JValue => List[A]) = self filter p flatMap f
       def withFilter(q: JValue => Boolean): WithFilter = new WithFilter(self, x => p(x) && q(x))
       def foreach[U](f: JValue => U): Unit = self filter p foreach f
     }
-    
+
     /**
      * Concatenate this `JValue` with another `JValue`.
      *
@@ -784,7 +781,7 @@ object JsonAST {
     type Values = Boolean
     def values = value
   }
-  
+
   case class JObject(obj: List[JField]) extends JValue {
     type Values = Map[String, Any]
     def values = {

--- a/core/json/src/test/scala/net/liftweb/json/JsonAstSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonAstSpec.scala
@@ -198,12 +198,11 @@ object JsonAstSpec extends Specification with JValueGen with ScalaCheck {
       Nil
     )
 
-    subject \\ "alpha" must_== JObject(
+    subject \\ "alpha" must_==
       JField("alpha", JString("apple")) ::
       JField("alpha", JString("bacon")) ::
       Nil
-    )
-    subject \\ "charlie" must_== JString("i'm a masseuse")
+    subject \\ "charlie" must_== List(JField("charlie", JString("i'm a masseuse")))
   }
 
   private def reorderFields(json: JValue) = json map {

--- a/core/json/src/test/scala/net/liftweb/json/JsonAstSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonAstSpec.scala
@@ -187,6 +187,25 @@ object JsonAstSpec extends Specification with JValueGen with ScalaCheck {
     x.## must_== y.##
   }
 
+  "find all children" in {
+    val subject = JObject(
+      JField("alpha", JString("apple")) ::
+      JField("beta", JObject(
+        JField("alpha", JString("bacon")) ::
+        JField("charlie", JString("i'm a masseuse")) ::
+        Nil
+      )) ::
+      Nil
+    )
+
+    subject \\ "alpha" must_== JObject(
+      JField("alpha", JString("apple")) ::
+      JField("alpha", JString("bacon")) ::
+      Nil
+    )
+    subject \\ "charlie" must_== JString("i'm a masseuse")
+  }
+
   private def reorderFields(json: JValue) = json map {
     case JObject(xs) => JObject(xs.reverse)
     case x => x

--- a/core/json/src/test/scala/net/liftweb/json/JsonAstSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonAstSpec.scala
@@ -199,10 +199,12 @@ object JsonAstSpec extends Specification with JValueGen with ScalaCheck {
     )
 
     subject \\ "alpha" must_==
-      JField("alpha", JString("apple")) ::
-      JField("alpha", JString("bacon")) ::
-      Nil
-    subject \\ "charlie" must_== List(JField("charlie", JString("i'm a masseuse")))
+      JObject(
+        JField("alpha", JString("apple")) ::
+        JField("alpha", JString("bacon")) ::
+        Nil
+      )
+    subject \\ "charlie" must_== JObject(List(JField("charlie", JString("i'm a masseuse"))))
   }
 
   private def reorderFields(json: JValue) = json map {


### PR DESCRIPTION
This PR closes #1518.

I tried to be clever in an earlier implementation of this by leaving the old version in place. Unfortunately, doing so proved tricker than I'd have liked with the compiler. So unless someone comes up with Clever Ideas™ or manages to make it work, this is my proposed solution. :)

Until now, \\ returned a JValue, and could vary between returning
the value inside a field or a JObject with multiple matching values
depending on what was matched. This led to inconsistencies in the
API and unpredictable inconsistencies for the consumer of the API
(typically, if there was only one field that matched, you would get the
field's value, while multiple fields would produce a JObject with the
matching fields).

We now always return a JObject, and never return a matching field's
value directly.