### PR TITLE
JS settings override

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
@@ -75,13 +75,13 @@ object LiftJavaScript {
   }
 
   def initCmd(settings: JsObj): JsCmd = {
-    val extendJqOrVanilla = LiftRules.jsArtifacts match {
+    val extendJsHelpersCmd = LiftRules.jsArtifacts match {
       case JQueryArtifacts => Call("window.lift.extend", JsVar("lift_settings"), JsVar("window", "liftJQuery"))
       case _ => Call("window.lift.extend", JsVar("lift_settings"), JsVar("window", "liftVanilla"))
     }
 
     JsCrVar("lift_settings", JsObj()) &
-    extendJqOrVanilla &
+    extendJsHelpersCmd &
     Call("window.lift.extend", JsVar("lift_settings"), settings) &
     Call("window.lift.init", JsVar("lift_settings"))
   }

--- a/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/LiftJavaScript.scala
@@ -75,20 +75,14 @@ object LiftJavaScript {
   }
 
   def initCmd(settings: JsObj): JsCmd = {
-    val extendCmd = LiftRules.jsArtifacts match {
-      case jsa: JQueryArtifacts => Call("window.lift.extend", JsVar("lift_settings"), JsVar("window", "liftJQuery"))
+    val extendJqOrVanilla = LiftRules.jsArtifacts match {
+      case JQueryArtifacts => Call("window.lift.extend", JsVar("lift_settings"), JsVar("window", "liftJQuery"))
       case _ => Call("window.lift.extend", JsVar("lift_settings"), JsVar("window", "liftVanilla"))
     }
 
-    JsCrVar("lift_settings", settings) &
-    extendCmd &
+    JsCrVar("lift_settings", JsObj()) &
+    extendJqOrVanilla &
+    Call("window.lift.extend", JsVar("lift_settings"), settings) &
     Call("window.lift.init", JsVar("lift_settings"))
-
-    /*val extendCmd = LiftRules.jsArtifacts match {
-      case jsa: JQueryArtifacts => Call("window.lift.extend", settings, JsVar("window.liftJQuery"))
-      case _ => Call("window.lift.extend", settings, JsVar("window.liftVanilla"))
-    }
-
-    Call("window.lift.init", extendCmd)*/
   }
 }

--- a/web/webkit/src/test/scala/net/liftweb/http/js/LiftJavaScriptSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/js/LiftJavaScriptSpec.scala
@@ -20,6 +20,8 @@ package js
 
 import java.util.Locale
 
+import net.liftweb.http.js.extcore.ExtCoreArtifacts
+import net.liftweb.http.js.jquery.JQueryArtifacts
 import org.specs2.execute.{Result, AsResult}
 import org.specs2.mutable.{Around,  Specification}
 
@@ -161,8 +163,32 @@ object LiftJavaScriptSpec extends Specification  {
         )))
       }
     }
+    "create init command with VanillaJS" in withEnglishLocale {
+      S.initIfUninitted(session) {
+        LiftRules.jsArtifacts = ExtCoreArtifacts
+        val init = LiftRules.javaScriptSettings.vend().map(_.apply(session)).map(LiftJavaScript.initCmd(_).toJsCmd)
+        init must_== Full(formatjs(List(
+          "var lift_settings = {};",
+          "window.lift.extend(lift_settings,window.liftVanilla);",
+          """window.lift.extend(lift_settings,{"liftPath": "/lift",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": "srvr1",
+            |"logError": function(msg) {lift.logError(msg);},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {}});""",
+          "window.lift.init(lift_settings);"
+        )))
+      }
+    }
     "create init command with custom setting" in withEnglishLocale {
       S.initIfUninitted(session) {
+        LiftRules.jsArtifacts = JQueryArtifacts
         val settings = LiftJavaScript.settings.extend(JsObj("liftPath" -> "liftyStuff", "mysetting" -> 99))
         val init = LiftJavaScript.initCmd(settings)
         init.toJsCmd must_== formatjs(List(

--- a/web/webkit/src/test/scala/net/liftweb/http/js/LiftJavaScriptSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/js/LiftJavaScriptSpec.scala
@@ -143,7 +143,9 @@ object LiftJavaScriptSpec extends Specification  {
       S.initIfUninitted(session) {
         val init = LiftRules.javaScriptSettings.vend().map(_.apply(session)).map(LiftJavaScript.initCmd(_).toJsCmd)
         init must_== Full(formatjs(List(
-          """var lift_settings = {"liftPath": "/lift",
+          "var lift_settings = {};",
+          "window.lift.extend(lift_settings,window.liftJQuery);",
+          """window.lift.extend(lift_settings,{"liftPath": "/lift",
             |"ajaxRetryCount": 4,
             |"ajaxPostTimeout": 5000,
             |"gcPollingInterval": 75000,
@@ -154,8 +156,7 @@ object LiftJavaScriptSpec extends Specification  {
             |"logError": function(msg) {lift.logError(msg);},
             |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
             |"ajaxOnStart": function() {},
-            |"ajaxOnEnd": function() {}};""",
-          "window.lift.extend(lift_settings,window.liftJQuery);",
+            |"ajaxOnEnd": function() {}});""",
           "window.lift.init(lift_settings);"
         )))
       }
@@ -165,7 +166,9 @@ object LiftJavaScriptSpec extends Specification  {
         val settings = LiftJavaScript.settings.extend(JsObj("liftPath" -> "liftyStuff", "mysetting" -> 99))
         val init = LiftJavaScript.initCmd(settings)
         init.toJsCmd must_== formatjs(List(
-          """var lift_settings = {"liftPath": "liftyStuff",
+          "var lift_settings = {};",
+          "window.lift.extend(lift_settings,window.liftJQuery);",
+          """window.lift.extend(lift_settings,{"liftPath": "liftyStuff",
             |"ajaxRetryCount": 4,
             |"ajaxPostTimeout": 5000,
             |"gcPollingInterval": 75000,
@@ -177,8 +180,7 @@ object LiftJavaScriptSpec extends Specification  {
             |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
             |"ajaxOnStart": function() {},
             |"ajaxOnEnd": function() {},
-            |"mysetting": 99};""",
-          "window.lift.extend(lift_settings,window.liftJQuery);",
+            |"mysetting": 99});""",
           "window.lift.init(lift_settings);"
         ))
       }

--- a/web/webkit/src/test/scala/net/liftweb/http/js/LiftJavaScriptSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/js/LiftJavaScriptSpec.scala
@@ -31,8 +31,8 @@ import util.Props
 import util.Helpers._
 
 /**
- * System under specification for LiftJavaScript.
- */
+  * System under specification for LiftJavaScript.
+  */
 object LiftJavaScriptSpec extends Specification  {
   sequential
   "LiftJavaScript Specification".title
@@ -43,58 +43,153 @@ object LiftJavaScriptSpec extends Specification  {
     "create default settings" in withEnglishLocale {
       S.initIfUninitted(session) {
         val settings = LiftJavaScript.settings
-        settings.toJsCmd must_== """{"liftPath": "/lift", "ajaxRetryCount": 3, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": null, "logError": function(msg) {}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}}"""
+        settings.toJsCmd must_== formatjs(
+          """{"liftPath": "/lift",
+            |"ajaxRetryCount": 3,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": null,
+            |"logError": function(msg) {},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {}}"""
+        )
       }
     }
     "create internationalized default settings" in withPolishLocale {
       S.initIfUninitted(session) {
         val settings = LiftJavaScript.settings
         val internationalizedMessage = "Nie mo\\u017cna skontaktowa\\u0107 si\\u0119 z serwerem"
-        settings.toJsCmd must_== s"""{"liftPath": "/lift", "ajaxRetryCount": 3, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": null, "logError": function(msg) {}, "ajaxOnFailure": function() {alert("$internationalizedMessage");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}}"""
+        settings.toJsCmd must_== formatjs(
+          s"""{"liftPath": "/lift",
+              |"ajaxRetryCount": 3,
+              |"ajaxPostTimeout": 5000,
+              |"gcPollingInterval": 75000,
+              |"gcFailureRetryTimeout": 15000,
+              |"cometGetTimeout": 140000,
+              |"cometFailureRetryTimeout": 10000,
+              |"cometServer": null,
+              |"logError": function(msg) {},
+              |"ajaxOnFailure": function() {alert("$internationalizedMessage");},
+              |"ajaxOnStart": function() {},
+              |"ajaxOnEnd": function() {}}"""
+        )
       }
     }
     "create custom static settings" in withEnglishLocale {
       S.initIfUninitted(session) {
         LiftRules.ajaxRetryCount = Full(4)
         val settings = LiftJavaScript.settings
-        settings.toJsCmd must_== """{"liftPath": "/lift", "ajaxRetryCount": 4, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": null, "logError": function(msg) {}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}}"""
+        settings.toJsCmd must_== formatjs(
+          """{"liftPath": "/lift",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": null,
+            |"logError": function(msg) {},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {}}"""
+        )
       }
     }
     "create custom dynamic settings" in withEnglishLocale {
       S.initIfUninitted(session) {
         LiftRules.cometServer = () => Some("srvr1")
         val settings = LiftJavaScript.settings
-        settings.toJsCmd must_== """{"liftPath": "/lift", "ajaxRetryCount": 4, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": "srvr1", "logError": function(msg) {}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}}"""
+        settings.toJsCmd must_== formatjs(
+          """{"liftPath": "/lift",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": "srvr1",
+            |"logError": function(msg) {},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {}}"""
+        )
       }
     }
     "create custom function settings" in withEnglishLocale {
       S.initIfUninitted(session) {
         LiftRules.jsLogFunc = Full(v => JE.Call("lift.logError", v))
         val settings = LiftJavaScript.settings
-        settings.toJsCmd must_== """{"liftPath": "/lift", "ajaxRetryCount": 4, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": "srvr1", "logError": function(msg) {lift.logError(msg);}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}}"""
+        settings.toJsCmd must_== formatjs(
+          """{"liftPath": "/lift",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": "srvr1",
+            |"logError": function(msg) {lift.logError(msg);},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {}}"""
+        )
       }
     }
     "create init command" in withEnglishLocale {
       S.initIfUninitted(session) {
         val init = LiftRules.javaScriptSettings.vend().map(_.apply(session)).map(LiftJavaScript.initCmd(_).toJsCmd)
-        init must_==
-          Full("""var lift_settings = {"liftPath": "/lift", "ajaxRetryCount": 4, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": "srvr1", "logError": function(msg) {lift.logError(msg);}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}};
-            |window.lift.extend(lift_settings,window.liftJQuery);
-            |window.lift.init(lift_settings);""".stripMargin)
+        init must_== Full(formatjs(List(
+          """var lift_settings = {"liftPath": "/lift",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": "srvr1",
+            |"logError": function(msg) {lift.logError(msg);},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {}};""",
+          "window.lift.extend(lift_settings,window.liftJQuery);",
+          "window.lift.init(lift_settings);"
+        )))
       }
     }
     "create init command with custom setting" in withEnglishLocale {
       S.initIfUninitted(session) {
         val settings = LiftJavaScript.settings.extend(JsObj("liftPath" -> "liftyStuff", "mysetting" -> 99))
         val init = LiftJavaScript.initCmd(settings)
-        println(init.toJsCmd)
-        init.toJsCmd must_==
-          """var lift_settings = {"liftPath": "liftyStuff", "ajaxRetryCount": 4, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": "srvr1", "logError": function(msg) {lift.logError(msg);}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {}, "ajaxOnEnd": function() {}, "mysetting": 99};
-            |window.lift.extend(lift_settings,window.liftJQuery);
-            |window.lift.init(lift_settings);""".stripMargin
+        init.toJsCmd must_== formatjs(List(
+          """var lift_settings = {"liftPath": "liftyStuff",
+            |"ajaxRetryCount": 4,
+            |"ajaxPostTimeout": 5000,
+            |"gcPollingInterval": 75000,
+            |"gcFailureRetryTimeout": 15000,
+            |"cometGetTimeout": 140000,
+            |"cometFailureRetryTimeout": 10000,
+            |"cometServer": "srvr1",
+            |"logError": function(msg) {lift.logError(msg);},
+            |"ajaxOnFailure": function() {alert("The server cannot be contacted at this time");},
+            |"ajaxOnStart": function() {},
+            |"ajaxOnEnd": function() {},
+            |"mysetting": 99};""",
+          "window.lift.extend(lift_settings,window.liftJQuery);",
+          "window.lift.init(lift_settings);"
+        ))
       }
     }
   }
+
+  def formatjs(line:String):String = formatjs(line :: Nil)
+  def formatjs(lines:List[String]):String = lines.map { _.stripMargin.lines.toList match {
+    case init :+ last => (init.map(_ + " ") :+ last).mkString
+    case Nil => ""
+  }}.mkString("\n")
 
   object withEnglishLocale extends WithLocale(Locale.ENGLISH)
 


### PR DESCRIPTION
Resolving an issue discovered during the discussion in [this ML thread](https://groups.google.com/forum/#!topic/liftweb/0z6SV0ucEW4).  Without this PR, it is not possible to override client settings applied from either `liftJQuery` or `liftVanilla`.  This PR extends the settings object with `liftJQuery` / `liftVanilla` _first_ then apply the usual settings.  This puts the Lift developer back in control and able to provide their own settings.

Here is an example page js after applying this PR:

```javascript
var lift_settings = {};
window.lift.extend(lift_settings,window.liftJQuery);
window.lift.extend(lift_settings,{"liftPath": "/lift", "ajaxRetryCount": 3, "ajaxPostTimeout": 5000, "gcPollingInterval": 75000, "gcFailureRetryTimeout": 15000, "cometGetTimeout": 140000, "cometFailureRetryTimeout": 10000, "cometServer": null, "logError": function(msg) {lift.defaultLogError(msg);}, "ajaxOnFailure": function() {alert("The server cannot be contacted at this time");}, "ajaxOnStart": function() {jQuery('#'+"ajax-loader").show();}, "ajaxOnEnd": function() {jQuery('#'+"ajax-loader").hide();}, "ajaxPost": function() {console.log("hijacked!!");}});
window.lift.init(lift_settings);
```

At the very end of the second extend, you can see where I hijacked the `ajaxPost` function for grins.