### PR TITLE
Trim page-specific javascript

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -57,7 +57,7 @@ private[http] trait LiftMerge {
       S.jsToAppend() ++
       List(eventJs)
 
-    allJs.foldLeft(js.JsCmds.Noop)(_ & _)
+    js.JsCmds.trimNoops(js.JsCmds.seqJsToJs(allJs))
   }
 
   private def pageScopedScriptFileWith(cmd: JsCmd) = {

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -668,9 +668,15 @@ object JsCmds {
     * @param js
     * @return
     */
-  def toList(js:JsCmd):List[JsCmd] = js match {
-    case CmdPair(l, r) => toList(l) ++ toList(r)
-    case _ => List(js)
+  def toList(js:JsCmd):List[JsCmd] = {
+    @scala.annotation.tailrec
+    def recToList(cmds:List[JsCmd], acc:List[JsCmd]):List[JsCmd] = cmds match {
+      case CmdPair(l, r) :: t => recToList(l :: r :: t, acc)
+      case h :: t => recToList(t, h :: acc)  // Use :: because it's most efficient for building lists, BUT...
+      case Nil => acc
+    }
+
+    recToList(js :: Nil, Nil).reverse // Gotta reverse it back
   }
 
   /**

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -663,6 +663,26 @@ object JsCmd {
 object JsCmds {
   implicit def seqJsToJs(in: Seq[JsCmd]): JsCmd = in.foldLeft[JsCmd](Noop)(_ & _)
 
+  /**
+    * Breaks a JsCmd down into its individual parts in a list
+    * @param js
+    * @return
+    */
+  def toList(js:JsCmd):List[JsCmd] = js match {
+    case CmdPair(l, r) => toList(l) ++ toList(r)
+    case _ => List(js)
+  }
+
+  /**
+    * Reduces the JsCmd by removing all unnecessary Noops.  Contains a Noop iff the JsCmd contains zero non-Noop cmds.
+    * @param js
+    * @return
+    */
+  def trimNoops(js:JsCmd):JsCmd = seqJsToJs(toList(js).filterNot(_ == _Noop)) match {
+    case CmdPair(`_Noop`, rest) => rest  // Since seqJsToJs folds with a leading Noop, strip it
+    case other => other
+  }
+
   object Script {
     def apply(script: JsCmd): Node = <script type="text/javascript">{Unparsed("""
 // <![CDATA[

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -678,9 +678,9 @@ object JsCmds {
     * @param js
     * @return
     */
-  def trimNoops(js:JsCmd):JsCmd = seqJsToJs(toList(js).filterNot(_ == _Noop)) match {
-    case CmdPair(`_Noop`, rest) => rest  // Since seqJsToJs folds with a leading Noop, strip it
-    case other => other
+  def trimNoops(js:JsCmd):JsCmd = toList(js).filterNot(_ == Noop) match {
+    case h :: t => t.foldLeft(h)(_ & _)
+    case _ => Noop
   }
 
   object Script {

--- a/web/webkit/src/test/scala/net/liftweb/http/js/JsCmdsFnSpecs.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/js/JsCmdsFnSpecs.scala
@@ -1,0 +1,45 @@
+package net.liftweb.http.js
+
+import org.specs2.mutable.Specification
+import net.liftweb.http.js.JsCmds._
+
+object JsCmdsFnSpecs extends Specification {
+  sequential
+  "JsCmds functions Specification".title
+
+  "JsCmds.toList()" should {
+    "return a single JsCmd in a List() if it is not a cmd pair" in {
+      toList(Noop) must_== List(Noop)
+    }
+
+    "return a List of 2 JsCmd instances if joined as a pair" in {
+      toList(Noop & Reload) must_== List(Noop, Reload)
+    }
+
+    "return a List of 3 JsCmd instances when left-associatively joining the triplet" in {
+      toList((JsBreak & Noop) & Reload) must_== List(JsBreak, Noop, Reload)
+    }
+
+    "return a List of 3 JsCmd instances when right-associatively joining the triplet" in {
+      toList(JsBreak & (Noop & Reload)) must_== List(JsBreak, Noop, Reload)
+    }
+  }
+
+  "JsCmds.trimNoops()" should {
+    "return Noop if the JsCmd is in fact a Noop" in {
+      trimNoops(Noop) must_== Noop
+    }
+
+    "return Noop if all of the JsCmds are Noops" in {
+      trimNoops(Noop & Noop & Noop) must_== Noop
+    }
+
+    "remove leading Noops" in {
+      trimNoops(Noop & Noop & Reload) must_== Reload
+    }
+
+    "remove trailing Noops" in {
+      trimNoops(Reload & Noop & Noop) must_== Reload
+    }
+  }
+}

--- a/web/webkit/src/test/scala/net/liftweb/http/js/JsCmdsFnSpecs.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/js/JsCmdsFnSpecs.scala
@@ -41,5 +41,9 @@ object JsCmdsFnSpecs extends Specification {
     "remove trailing Noops" in {
       trimNoops(Reload & Noop & Noop) must_== Reload
     }
+
+    "remove Noops among multiple non-Noops" in {
+      trimNoops(Noop & Reload & Noop & Noop & JsBreak & JsContinue & Noop) must_== (Reload & JsBreak & JsContinue)
+    }
   }
 }


### PR DESCRIPTION
This PR defines `JsCmds.trimNoops(JsCmd):JsCmd` along with helper function `JsCmds.toList(JsCmd):List[JsCmd]` which is now called when we assemble the page-specific JS to remove a large number of unnecessary newlines.

See ML thread [here](https://groups.google.com/forum/#!topic/liftweb/ojR6TfrZhIQ).