### PR TITLE
Filter out empty lines in CmdPair.toJsCmd

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -798,7 +798,7 @@ object JsCmds {
     def toJsCmd: String = {
       val acc = new ListBuffer[JsCmd]()
       appendDo(acc, left :: right :: Nil)
-      acc.map(_.toJsCmd).filterNot(_.isEmpty).mkString("\n")
+      acc.map(_.toJsCmd).mkString("\n")
     }
 
     @scala.annotation.tailrec
@@ -806,6 +806,7 @@ object JsCmds {
       cmds match {
         case Nil =>
         case CmdPair(l, r) :: rest => appendDo(acc, l :: r :: rest)
+        case `_Noop` :: rest => appendDo(acc, rest)
         case a :: rest => acc.append(a); appendDo(acc, rest)
       }
     }

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -793,12 +793,12 @@ object JsCmds {
   implicit def jsExpToJsCmd(in: JsExp) = in.cmd
 
   case class CmdPair(left: JsCmd, right: JsCmd) extends JsCmd {
-    import scala.collection.mutable.ListBuffer;
+    import scala.collection.mutable.ListBuffer
 
     def toJsCmd: String = {
       val acc = new ListBuffer[JsCmd]()
       appendDo(acc, left :: right :: Nil)
-      acc.map(_.toJsCmd).mkString("\n")
+      acc.map(_.toJsCmd).filterNot(_.isEmpty).mkString("\n")
     }
 
     @scala.annotation.tailrec

--- a/web/webkit/src/test/scala/net/liftweb/http/HtmlNormalizerSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/HtmlNormalizerSpec.scala
@@ -117,10 +117,7 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
         )
 
       html must ==/(<myelement id="testid" />)
-      js.toJsCmd must_== """|
-        |
-        |lift.onEvent("testid","event",function(event) {doStuff;});
-        |""".stripMargin('|')
+      js.toJsCmd must_== """lift.onEvent("testid","event",function(event) {doStuff;});"""
     }
 
     "generate ids for elements with events if they don't have one" in {
@@ -134,10 +131,7 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
       val id = html \@ "id"
 
       id must not be empty
-      js.toJsCmd must_== s"""|
-        |
-        |lift.onEvent("$id","event",function(event) {doStuff;});
-        |""".stripMargin('|')
+      js.toJsCmd must_== s"""lift.onEvent("$id","event",function(event) {doStuff;});"""
     }
 
     "extract event js correctly for multiple elements" in {
@@ -152,22 +146,9 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
           false
         )
 
-      js.toJsCmd must be matching(s"""|(?ms)
-        |
-        |
-        |
-        |
-        |lift\\.onEvent\\("lift-event-js-[^"]+","event",function\\(event\\) \\{doStuff;\\}\\);
-        |
-        |
-        |
-        |lift\\.onEvent\\("hello","event",function\\(event\\) \\{doStuff2;\\}\\);
-        |
-        |
-        |
-        |lift\\.onEvent\\("lift-event-js-[^"]+","event",function\\(event\\) \\{doStuff3;\\}\\);
-        |
-        |""".stripMargin('|').r
+      js.toJsCmd must be matching("""(?s)\Qlift.onEvent("lift-event-js-\E[^"]+\Q","event",function(event) {doStuff;});
+        |lift.onEvent("hello","event",function(event) {doStuff2;});
+        |lift.onEvent("lift-event-js-\E[^"]+\Q","event",function(event) {doStuff3;});\E""".stripMargin('|').lines.mkString("\n").r
       )
     }
 
@@ -189,26 +170,10 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
 
       (html \ "myelement").map(_ \@ "href").filter(_.nonEmpty) must beEmpty
       (html \ "myelement").map(_ \@ "action").filter(_.nonEmpty) must beEmpty
-      js.toJsCmd must be matching(s"""|(?ms)
-        |
-        |
-        |
-        |
-        |lift\\.onEvent\\("lift-event-js-[^"]+","click",function\\(event\\) \\{doStuff; event.preventDefault\\(\\);\\}\\);
-        |
-        |
-        |
-        |lift\\.onEvent\\("hello","submit",function\\(event\\) \\{doStuff2; event.preventDefault\\(\\);\\}\\);
-        |
-        |
-        |
-        |lift\\.onEvent\\("hello2","click",function\\(event\\) \\{doStuff3; event.preventDefault\\(\\);\\}\\);
-        |
-        |
-        |
-        |lift\\.onEvent\\("lift-event-js-[^"]+","submit",function\\(event\\) \\{/doStuff4; event.preventDefault\\(\\);\\}\\);
-        |
-        |""".stripMargin('|').r
+      js.toJsCmd must be matching("""(?s)\Qlift.onEvent("lift-event-js-\E[^"]+\Q","click",function(event) {doStuff; event.preventDefault();});
+        |lift.onEvent("hello","submit",function(event) {doStuff2; event.preventDefault();});
+        |lift.onEvent("hello2","click",function(event) {doStuff3; event.preventDefault();});
+        |lift.onEvent("lift-event-js-\E[^"]+\Q","submit",function(event) {/doStuff4; event.preventDefault();});\E""".stripMargin('|').lines.mkString("\n").r
       )
     }
 


### PR DESCRIPTION
This PR filters out all empty lines in `CmdPair.toJsCmd`.  The `CmdPair` case class is what is used when combining `JsCmd`s with `&`.  The extra empty lines are particularly noticeable when we produce the page-specific JS.  In a simple test page, I observed that we produced a 155-line JS file with only 4 non-empty lines.  While this will be slightly more performant, the biggest gains IMO are when we need to examine any JS produced while developing.

Per this [ML thread](https://groups.google.com/forum/#!topic/liftweb/ojR6TfrZhIQ), we decided that rather than write [a lot of code](https://github.com/lift/framework/pull/1771) for only the page-specific JS case, we would always toss out empty lines in this PR.