### PR TITLE
RC Fixes

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -395,7 +395,23 @@ private[util] trait Props extends Logger {
     }
   }
 
-  private[this] var providers: List[PropProvider] = List(props)
+  // None before they've first been looked up/modified/whatever, Some after.
+  // We use this to lazy-load `props`, so that `whereToLook` can be updated
+  // by the user.
+  private[this] var providersAccumulator: Option[List[PropProvider]] = None
+
+  private[this] def providers = {
+    providersAccumulator getOrElse {
+      val baseProviders = List(props)
+      providersAccumulator = Some(baseProviders)
+
+      baseProviders
+    }
+  }
+  private[this] def providers_=(newProviders: List[PropProvider]) = {
+    providersAccumulator = Some(newProviders)
+  }
+
   private[this] var interpolationValues: List[InterpolationValues] = Nil
 
   private[this] lazy val lockedProviders = providers

--- a/core/util/src/main/scala/net/liftweb/util/Props.scala
+++ b/core/util/src/main/scala/net/liftweb/util/Props.scala
@@ -222,8 +222,9 @@ private[util] trait Props extends Logger {
   /**
    * The default run-mode auto-detection routine uses this function to infer whether Lift is being run in a test.
    *
-   * This routine can be customised by calling `set` before the run-mode is referenced. (An attempt to customise this
-   * after the run-mode is realised will have no effect and will instead log a warning.)
+   * This routine can be customised by calling `set` '''before''' the run-mode
+   * is referenced. (An attempt to customise this after the run-mode is
+   * realised will have no effect and will instead log a warning.)
    */
   val doesStackTraceContainKnownTestRunner = new RunModeProperty[Array[StackTraceElement] => Boolean]("doesStackTraceContainKnownTestRunner",
     (st: Array[StackTraceElement]) => {
@@ -247,8 +248,9 @@ private[util] trait Props extends Logger {
    * When the `run.mode` environment variable isn't set or recognised, this function is invoked to determine the
    * appropriate mode to use.
    *
-   * This logic can be customised by calling `set` before the run-mode is referenced. (An attempt to customise this
-   * after the run-mode is realised will have no effect and will instead log a warning.)
+   * This logic can be customised by calling `set` '''before''' the run-mode is
+   * referenced. (An attempt to customise this after the run-mode is realised
+   * will have no effect and will instead log a warning.)
    */
   val autoDetectRunModeFn = new RunModeProperty[() => Props.RunModes.Value]("autoDetectRunModeFn", () => {
     val st = Thread.currentThread.getStackTrace
@@ -333,7 +335,7 @@ private[util] trait Props extends Logger {
    * The function returns a List of String -> () => Box[InputStream].
    * So, if you want to consult System.getProperties to look for a properties file or
    * some such, you can set the whereToLook function in your Boot.scala file
-   * <b>before</b> you call anything else in Props.
+   * '''before''' you call anything else in `Props`.
    */
   @volatile var whereToLook: () => List[(String, () => Box[InputStream])] = () => Nil
 

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -102,10 +102,10 @@ object PropsSpec extends Specification {
     "Prefer prepended System.properties to the test.default.props" in {
       val testProps = TestProps()
 
-      System.setProperty("omniauth.baseurl", "http://google.com")
+      System.setProperty("omniauth.baseurl1", "http://google.com")
 
       testProps.prependProvider(sys.props)
-      val baseurl = testProps.get("omniauth.baseurl")
+      val baseurl = testProps.get("omniauth.baseurl1")
 
       baseurl must_== Full("http://google.com")
     }
@@ -113,10 +113,10 @@ object PropsSpec extends Specification {
     "Read through to System.properties, correctly handling mutation" in {
       val testProps = TestProps()
 
-      System.setProperty("omniauth.baseurl", "http://google.com")
+      System.setProperty("omniauth.baseurl2", "http://google.com")
       testProps.prependProvider(sys.props)
-      System.setProperty("omniauth.baseurl", "http://ebay.com")
-      val baseurl = testProps.get("omniauth.baseurl")
+      System.setProperty("omniauth.baseurl2", "http://ebay.com")
+      val baseurl = testProps.get("omniauth.baseurl2")
 
       baseurl must_== Full("http://ebay.com")
     }

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -72,6 +72,7 @@ object PropsSpec extends Specification {
       val testProps = TestProps()
 
       val before = testProps.autoDetectRunModeFn.get
+      testProps.mode // initialize run mode
       testProps.autoDetectRunModeFn.allowModification must_== false
       testProps.autoDetectRunModeFn.set(() => Test) must_== false
       testProps.autoDetectRunModeFn.get must_== before

--- a/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/PropsSpec.scala
@@ -17,9 +17,12 @@
 package net.liftweb
 package util
 
-import net.liftweb.common.Full
+import java.io.ByteArrayInputStream
+
 import org.specs2.mutable.Specification
 import org.specs2.mutable.After
+
+import common._
 import Props.RunModes._
 
 object PropsSpec extends Specification {
@@ -30,6 +33,24 @@ object PropsSpec extends Specification {
   "Props" should {
     "Detect test mode correctly" in {
       TestProps().testMode must_== true
+    }
+
+    "Allow modification of whereToLook before run-mode is set" in {
+      val testProps = TestProps()
+      val originalWtl = testProps.whereToLook
+
+      var wasCalled = false
+      testProps.whereToLook = () => {
+        wasCalled = true
+
+        List(
+          ("test propsters", () => Full(new ByteArrayInputStream("test.prop=value".getBytes("UTF-8"))))
+        )
+      }
+
+      testProps.getInt("jetty.port") must_== Empty
+      testProps.get("test.prop") must_== Full("value")
+      wasCalled must_== true
     }
 
     "Allow modification of run-mode properties before the run-mode is set" in {

--- a/web/testkit/src/main/scala/net/liftweb/http/testing/TestFramework.scala
+++ b/web/testkit/src/main/scala/net/liftweb/http/testing/TestFramework.scala
@@ -208,7 +208,7 @@ trait BaseGetPoster {
 
   implicit def jsonToRequestEntity(body: JValue): RequestEntity =
     new RequestEntity {
-      val bytes = compact(render(body)).toString.getBytes("UTF-8")
+      val bytes = compactRender(body).toString.getBytes("UTF-8")
 
       def getContentLength() = bytes.length
 

--- a/web/testkit/src/main/scala/net/liftweb/mocks/MockHttpServletRequest.scala
+++ b/web/testkit/src/main/scala/net/liftweb/mocks/MockHttpServletRequest.scala
@@ -128,8 +128,9 @@ class MockHttpServletRequest(val url : String = null, var contextPath : String =
    */
   def body_= (jval : JValue, contentType : String) : Unit = {
     import json.JsonDSL._
-    import json.Printer
-    body = Printer.pretty(render(jval)).getBytes(charEncoding)
+    import json.JsonAST
+
+    body = JsonAST.prettyRender(jval).getBytes(charEncoding)
     this.contentType = contentType
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/mockweb/WebSpec.scala
+++ b/web/webkit/src/main/scala/net/liftweb/mockweb/WebSpec.scala
@@ -189,19 +189,24 @@ abstract class WebSpec(boot : () => Any = () => {}) extends Specification with X
   class SessionSpecification (description : String, 
                               val req : HttpServletRequest, 
                               session : Box[LiftSession]) extends ModifiableRequest[SessionSpecification] {
-    def this (description : String, url : String, session : Box[LiftSession], contextPath : String) =
+    def this (description : String, url : String, session : Box[LiftSession], contextPath : String) = {
       this(description, new MockHttpServletRequest(url, contextPath), session)
+    }
 
-    def in(expectations : => Result) =
-      fragmentFactory.example(description, {
-        LiftRulesMocker.devTestLiftRulesInstance.doWith(liftRules) {
-          MockWeb.useLiftRules.doWith(true) {
-            MockWeb.testS(req, session) {
-              expectations
+    def in(expectations : => Result) = {
+      addFragments(
+        fragmentFactory.example(description, {
+          LiftRulesMocker.devTestLiftRulesInstance.doWith(liftRules) {
+            MockWeb.useLiftRules.doWith(true) {
+              MockWeb.testS(req, session) {
+                expectations
+              }
             }
           }
-        }
-      })
+        }) ^
+        fragmentFactory.break
+      )
+    }
   }
 
   /**
@@ -213,14 +218,18 @@ abstract class WebSpec(boot : () => Any = () => {}) extends Specification with X
     def this (description : String, url : String, contextPath : String) =
       this(description, new MockHttpServletRequest(url, contextPath))
 
-    def in(expectations : Req => Result) =
-      fragmentFactory.example(description, {
-        LiftRulesMocker.devTestLiftRulesInstance.doWith(liftRules) {
-          MockWeb.useLiftRules.doWith(true) {
-            MockWeb.testReq(req)(expectations)
+    def in(expectations : Req => Result) = {
+      addFragments(
+        fragmentFactory.example(description, {
+          LiftRulesMocker.devTestLiftRulesInstance.doWith(liftRules) {
+            MockWeb.useLiftRules.doWith(true) {
+              MockWeb.testReq(req)(expectations)
+            }
           }
-        }
-      })
+        }) ^
+        fragmentFactory.break
+      )
+    }
   }
 
   /**
@@ -233,19 +242,23 @@ abstract class WebSpec(boot : () => Any = () => {}) extends Specification with X
     def this (description : String, url : String, session : Box[LiftSession], contextPath : String) =
       this(description, new MockHttpServletRequest(url, contextPath), session)
 
-    def in(expectations : Box[NodeSeq] => Result) =
-      fragmentFactory.example(description, {
-        LiftRulesMocker.devTestLiftRulesInstance.doWith(liftRules) {
-          MockWeb.useLiftRules.doWith(true) {
-            MockWeb.testS(req, session) {
-              S.request match {
-                case Full(sReq) => expectations(S.runTemplate(sReq.path.partPath))
-                case other => failure("Error: withTemplateFor call did not result in " +
-                  "request initialization (S.request = " + other + ")")
+    def in(expectations : Box[NodeSeq] => Result) = {
+      addFragments(
+        fragmentFactory.example(description, {
+          LiftRulesMocker.devTestLiftRulesInstance.doWith(liftRules) {
+            MockWeb.useLiftRules.doWith(true) {
+              MockWeb.testS(req, session) {
+                S.request match {
+                  case Full(sReq) => expectations(S.runTemplate(sReq.path.partPath))
+                  case other => failure("Error: withTemplateFor call did not result in " +
+                    "request initialization (S.request = " + other + ")")
+                }
               }
             }
           }
-        }
-      })
+        }) ^
+        fragmentFactory.break
+      )
+    }
   }
 }

--- a/web/webkit/src/test/scala/net/liftweb/sitemap/FlexMenuBuilderSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/sitemap/FlexMenuBuilderSpec.scala
@@ -36,12 +36,14 @@ object FlexMenuBuilderSpec extends WebSpec(FlexMenuBuilderSpecBoot.boot _) {
       val actual = MenuBuilder.render
       linkToSelf must beEqualToIgnoringSpace(actual)
     }
+
     "expandAll" withSFor(testUrl) in {
       object MenuBuilder extends FlexMenuBuilder { override def expandAll = true}
       val expandAll: NodeSeq = <ul><li><a href="/index">Home</a></li><li><span>Help</span><ul><li><a href="/index1">Home1</a></li><li><a href="/index2">Home2</a></li></ul></li><li><a href="/help2">Help2</a><ul><li><a href="/index3">Home3</a></li><li><a href="/index4">Home4</a></li></ul></li></ul>
       val actual = MenuBuilder.render
       expandAll.toString must_== actual.toString
     }
+
     "Add css class to item in the path" withSFor(testUrlPath) in {
       object MenuBuilder extends FlexMenuBuilder {
         override def updateForPath(nodes: Elem, path: Boolean): Elem = {
@@ -56,6 +58,7 @@ object FlexMenuBuilderSpec extends WebSpec(FlexMenuBuilderSpecBoot.boot _) {
       val actual = MenuBuilder.render
       itemInPath.toString must_== actual.toString
     }
+
     "Add css class to the current item" withSFor(testUrl) in {
       object MenuBuilder extends FlexMenuBuilder {
         override def updateForCurrent(nodes: Elem, current: Boolean): Elem = {


### PR DESCRIPTION
Couple of fixes so we can get the RC out the door:
 - Fix WebSpec's broken fragments (see the tail discussion on #1773).
 - Props respects `whereToLook` again (see #1776) and now has a test
   verifying that this works as expected.

Also some small deprecation, spec, and scaladoc-related fixes.