### PR TITLE
Party Foul: Fix JsCmd handling of extracted event JS

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1442,8 +1442,9 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * Execute certain functions early in a Stateful Request
    * This is called early in a stateful request (one that's not serviced by a stateless REST request and
    * one that's not marked as a stateless HTML page request).
-   * @dpp strongly recommends that everything that you do related to user state is done with earlyInStateful,
-   * instead of using onBeginServicing.
+   *
+   * DPP strongly recommends that everything that you do related to user state
+   * is done with `earlyInStateful`, instead of using `[[onBeginServicing]]`.
    */
   val earlyInStateful = RulesSeq[Box[Req] => Unit]
 
@@ -1627,9 +1628,9 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   /**
    * Modifies the root relative paths from the css url-s
    *
-   * @param path - the path of the css resource
-   * @prefix - the prefix to be added on the root relative paths. If this is Empty
-   * 	       the prefix will be the application context path.
+   * @param path the path of the css resource
+   * @param prefix the prefix to be added on the root relative paths. If this
+   *               is Empty, the prefix will be the application context path.
    */
   def fixCSS(path: List[String], prefix: Box[String]) {
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftScreen.scala
@@ -692,21 +692,21 @@ trait AbstractScreen extends Factory with Loggable {
   /**
    * Create a field that's added to the Screen
    *
-   * @param theName - the name of the field.  This is call-by-name, so you
+   * @param theName the name of the field.  This is call-by-name, so you
    * can do things like S.?("Dog's Name") such that the string will be
    * localized
    *
-   * @param defaultValue - the starting value for the field.  This is
+   * @param defaultValue the starting value for the field.  This is
    * also call-by-name which is handy for constructs like:
    * <code class="scala">SomeExternalRequestVarOrSessionVar.get</code>
    *
-   * @theToForm - a function to convert the field into a form
+   * @param theToForm a function to convert the field into a form
    *
-   * @otherValue - a handy way include other values in the field.  The other value is
+   * @param otherValue a handy way include other values in the field.  The other value is
    * calcualted when the field is initialized.  You can, for example, put
    * a list of valid options in the field.
    *
-   * @stuff - a list of filters and validations for the field
+   * @param stuff a list of filters and validations for the field
    *
    * @return a newly minted Field
    */

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -588,7 +588,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
 
   /**
    * Removes the function with the given `name`. Note that this will
-   * '''not''' trigger `[[onFunctionOwnersRemoved]]` listeners.
+   * '''not''' trigger `[[LiftSession$.onFunctionOwnersRemoved]]` listeners.
    */
   def removeFunction(name: String) = {
     nmessageCallback.remove(name)
@@ -600,7 +600,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * test.
    *
    * If any function owner is completely absent after going through the
-   * functions, any function registered via `[[onFunctionOwnersRemoved]]`
+   * functions, any function registered via `[[LiftSession$.onFunctionOwnersRemoved]]`
    * will be called with the list of removed owners.
    */
   private def removeFunctionsIf(test: (S.AFuncHolder)=>Boolean) = {
@@ -1852,8 +1852,9 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
   /**
    * Apply HTML specific corrections such as adding the context path etc.
    *
-   * In general, you should heavily consider using `[[normalizeHtmlAndEvents]]`
-   * or its friendliest sibling, `[[normalizeHtmlAndAppendEvents]]`.
+   * In general, you should heavily consider using
+   * `[[normalizeHtmlAndEventHandlers]]` or its friendliest sibling,
+   * `[[normalizeHtmlAndAppendEventHandlers]]`.
    */
   def normalizeHtml(in: NodeSeq): NodeSeq = {
     Req.normalizeHtml(contextPath, in)
@@ -1879,9 +1880,11 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
   /**
    * Runs `[[normalizeHtmlAndEventHandlers]]` to adjust URLs to context paths
    * and extract JS event handlers from the given `NodeSeq` and pull them into
-   * a separate JsCmd, then uses `[[S.appendJs]]` to append that JS to the
-   * response's JavaScript (the page-specific JS file if we are rendering a
-   * page, or the end of the returned JS if this is an AJAX or comet request).
+   * a separate JsCmd, then uses
+   * `[[net.liftweb.http.S!.appendJs(js:net\.liftweb\.http\.js\.JsCmd):Unit*
+   * S.appendJs]]` to append that JS to the response's JavaScript (the
+   * page-specific JS file if we are rendering a page, or the end of the
+   * returned JS if this is an AJAX or comet request).
    */
   def normalizeHtmlAndAppendEventHandlers(in: NodeSeq): NodeSeq = {
     val NodesAndEventJs(normalizedHtml, eventJs) = normalizeHtmlAndEventHandlers(in)

--- a/web/webkit/src/main/scala/net/liftweb/http/Req.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Req.scala
@@ -1333,7 +1333,7 @@ object RewriteResponse {
 
 /**
  * Provides access to a thread-local URL rewriter. Typically uses either an
- * applicable entry in `[[LiftRules.decorateUrl]]` or the container's built-in
+ * applicable entry in `[[LiftRules.urlDecorate]]` or the container's built-in
  * URL decoration which may append the session id to the URL (dependent on
  * `[[LiftRules.encodeJSessionIdInUrl_?]]`).
  */

--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -754,7 +754,7 @@ trait S extends HasParams with Loggable with UserAgentCalculator {
    *
    *
    * @param name A name for the rewrite function so that it can be replaced or deleted later.
-   * @rw The rewrite partial function
+   * @param rw The rewrite partial function
    *
    * @see LiftRules.rewrite
    * @see # sessionRewriter

--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -1020,10 +1020,10 @@ trait SHtml extends Loggable {
   /**
    * create an anchor tag around a body
    *
-   * @to - the target
-   * @param func - the function to invoke when the link is clicked
-   * @param body - the NodeSeq to wrap in the anchor tag
-   * @attrs - the (optional) attributes for the HTML element
+   * @param to the target
+   * @param func the function to invoke when the link is clicked
+   * @param body the NodeSeq to wrap in the anchor tag
+   * @param attrs the (optional) attributes for the HTML element
    */
   def link(to: String, func: () => Any, body: NodeSeq,
            attrs: ElemAttr*): Elem = {

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -646,7 +646,13 @@ trait HtmlFixer {
 }
 
 trait JsCmd extends HtmlFixer with ToJsCmd {
-  def &(other: JsCmd): JsCmd = JsCmds.CmdPair(this, other)
+  def &(other: JsCmd): JsCmd = {
+    if (other == JsCmds.Noop) {
+      this
+    } else {
+      JsCmds.CmdPair(this, other)
+    }
+  }
 
   def toJsCmd: String
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -614,7 +614,12 @@ trait HtmlFixer {
       }
 
     import scala.collection.mutable.ListBuffer
-    val lb = ListBuffer[JsCmd](eventJs)
+    val lb =
+      if (eventJs == JsCmds.Noop) {
+        ListBuffer[JsCmd]()
+      } else {
+        ListBuffer[JsCmd](eventJs)
+      }
 
     val revised = ("script" #> nsFunc(ns => {
       ns match {

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -601,20 +601,20 @@ trait HtmlFixer {
 
     val w = new java.io.StringWriter
 
-    val xhtml =
+    val NodesAndEventJs(xhtml, eventJs) =
       S.session.map { session =>
-        session.normalizeHtmlAndAppendEventHandlers(
+        session.normalizeHtmlAndEventHandlers(
           session.processSurroundAndInclude(
             s"JS SetHTML id: $uid",
             content
           )
         )
       } openOr {
-        content
+        NodesAndEventJs(content, JsCmds.Noop)
       }
 
     import scala.collection.mutable.ListBuffer
-    val lb = new ListBuffer[JsCmd]
+    val lb = ListBuffer[JsCmd](eventJs)
 
     val revised = ("script" #> nsFunc(ns => {
       ns match {

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/HTTPContext.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/HTTPContext.scala
@@ -29,8 +29,8 @@ import net.liftweb.util._
 trait HTTPContext {
 
   /**
-   * @return - the context path. It always comes first in a request URI. It is
-   *           the URI part that represent to context of the request.
+   * @return the context path. It always comes first in a request URI. It is
+   *         the URI part that represent to context of the request.
    */
   def path: String
 
@@ -44,7 +44,7 @@ trait HTTPContext {
   def resource(path: String): URL
 
   /**
-   * Same as <i>resource</i> but returns an InputStream to read the resource.
+   * Same as `[[resource]]` but returns an InputStream to read the resource.
    * @param path - the resource path
    * @return InputStream
    */
@@ -52,27 +52,27 @@ trait HTTPContext {
 
   /**
    * @param path
-   * @return - the mime type mapped to resource determined by this path.
+   * @return the mime type mapped to resource determined by this path.
    */
   def mimeType(path: String): Box[String]
 
   /**
    * @param name
-   * @return - the value of the init parameter identified by then provided name. Note
-   *           that this is not typesfe and you need to explicitely do the casting
-   *           when reading this attribute. Returns Empty if this parameter does not exist.
+   * @return the value of the init parameter identified by then provided name. Note
+   *         that this is not typesfe and you need to explicitely do the casting
+   *         when reading this attribute. Returns Empty if this parameter does not exist.
    */
   def initParam(name: String): Box[String]
 
   /**
-   * @return - a List of Tuple2 consisting of name and value pair of the init parameters
+   * @return a List of Tuple2 consisting of name and value pair of the init parameters
    */
   def initParams: List[(String, String)]
 
   /**
    * @param name
-   * @return - the value of the context attribute identified by then provided name.
-   *           Returns Empty if this parameter does not exist.
+   * @return the value of the context attribute identified by then provided name.
+   *         Returns Empty if this parameter does not exist.
    */
   def attribute(name: String): Box[Any]
 
@@ -82,14 +82,13 @@ trait HTTPContext {
   def attributes: List[(String, Any)]
 
   /**
-   * @param - name
-   * @param - value. Any reference. Note that this is not typesfe and you need to explicitely do
-   *          the casting when reading this attribute.
+   * @param value. Any reference. Note that this is not typesfe and you need to
+   *        explicitely cast when reading this attribute.
    */
   def setAttribute(name: String, value: Any): Unit
 
   /**
-   * @param - name. The name ofthe parameter that needs to be removed.
+   * @param name. The name ofthe parameter that needs to be removed.
    */
   def removeAttribute(name: String): Unit
 }

--- a/web/webkit/src/main/scala/net/liftweb/http/rest/RestHelper.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/rest/RestHelper.scala
@@ -385,7 +385,7 @@ trait RestHelper extends LiftRules.DispatchPF {
   /**
    * Serve a request returning either JSON or XML.
    *
-   * @parama pf -- a Partial Function that converts the request into
+   * @param pf -- a Partial Function that converts the request into
    * Any (note that the response must be convertable into
    * JSON vis Lift JSON Extraction.decompose
    */


### PR DESCRIPTION
From the commit:

Before, we were using a global appendJs for these events. However, `fixHtmlAndJs`
already provides a mechanism for returning additional JS. We now use it.

The previous behavior would result in extracted events being appended to the
response (page or AJAX) even if the `JsCmd` that invoked `fixHtmlAndJs` was never
actually sent down to the client. This behavior correctly makes the extracted
event JS part of the `JsCmd`, so that it can be sent down only with that `JsCmd`.

Also ran into a bunch of scaladoc warnings that I finally got tired of and :facepunch:ed
them.

Fixes #1782 . Tested on the example in the ML post linked from there.