### PR TITLE
Add event return normalization to liftVanilla.

### DIFF
--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -707,8 +707,22 @@
       if (typeof elementOrId === 'string') {
         element = document.getElementById(elementOrId);
       }
+      
+      // This is a Lift addition to allow return false to properly do
+      // cross-browser preventDefault/stopPropagation/etc work.
+      function normalizeEventReturn(event) {
+        var result = fn(event);
+        if (result === false) {
+          if (typeof event.preventDefault === "function") {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+        }
+        
+        return result;
+      }
 
-      element[add](pre + eventName, fn, false);
+      element[add](pre + eventName, normalizeEventReturn, false);
     },
     onDocumentReady: function(fn) {
       var settings = this, done = false, top = true,


### PR DESCRIPTION
Before, returning false from an event handler attached with
liftVanilla.onEvent would not prevent default behavior or stop
propagation. We now check for event.preventDefault and trigger
it and stopPropagation if the handler returned false. We also
return that return value for older browsers to work with.
