### PR TITLE
Implement a sendCometActorMessage that works for all comets of a type.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2330,7 +2330,6 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * of the current HTTP request/response cycle.
    *
    * @param theType the type of the CometActor
-   * @param name the optional name of the CometActor
    * @param msg the message to send to the CometActor
    */
   def sendCometActorMessage(theType: String, msg: Any) {

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2341,12 +2341,8 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
   }
 
   /**
-   * This method will send a message to a CometActor, whether or not
-   * the CometActor is instantiated.  If the CometActor already exists
-   * in the session, the message will be sent immediately.  If the CometActor
-   * is not yet instantiated, the message will be sent to the CometActor
-   * as part of setup `[[queueCometMessage]]` if it is created as part
-   * of the current HTTP request/response cycle.
+   * Similar behavior to [[LiftSession#sendCometMessage(theType:String,msg:Any):Unit the main sendCometMessage]],
+   * except that the type argument is taken as a type parameter instead of a string.
    *
    * @param msg the message to send to the CometActor
    */
@@ -2357,13 +2353,9 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
   }
 
   /**
-   * This method will send a message to a CometActor, whether or not
-   * the CometActor is instantiated.  If the CometActor already exists
-   * in the session, the message will be sent immediately.  If the CometActor
-   * is not yet instantiated, the message will be sent to the CometActor
-   * as part of setup `[[queueCometMessage]]` regardless of if it is created as part
-   * of the current HTTP request/response cycle. We plan to restrict this to
-   * the current request/response cycle in the future (as that is the intended beavior).
+   * Similar behavior to [[LiftSession#sendCometMessage(theType:String,msg:Any):Unit the main sendCometMessage]],
+   * except that this version will limit based on the name of the comet. Providing `name` as `Empty`,
+   * will specifically select comets with no name.
    *
    * @param theType the type of the CometActor
    * @param name the optional name of the CometActor
@@ -2379,13 +2371,9 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
   }
 
   /**
-   * This method will send a message to a CometActor, whether or not
-   * the CometActor is instantiated.  If the CometActor already exists
-   * in the session, the message will be sent immediately.  If the CometActor
-   * is not yet instantiated, the message will be sent to the CometActor
-   * as part of setup `[[queueCometMessage]]` regardless of if it is created as part
-   * of the current HTTP request/response cycle. We plan to restrict this to
-   * the current request/response cycle in the future (as that is the intended beavior).
+   * Similar behavior to [[LiftSession#sendCometMessage(theType:String,msg:Any):Unit the main sendCometMessage]],
+   * except that this version will limit based on the name of the comet and it takes its type selector
+   * as a type parameter.
    *
    * @param name the optional name of the CometActor
    * @param msg the message to send to the CometActor

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2327,7 +2327,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * the CometActor is instantiated.  If the CometActor already exists
    * in the session, the message will be sent immediately.  If the CometActor
    * is not yet instantiated, the message will be sent to the CometActor
-   * as part of setup (see queueCometMessage) if it is created as part
+   * as part of setup `[[queueCometMessage]]` if it is created as part
    * of the current HTTP request/response cycle.
    *
    * @param theType the type of the CometActor
@@ -2345,7 +2345,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * the CometActor is instantiated.  If the CometActor already exists
    * in the session, the message will be sent immediately.  If the CometActor
    * is not yet instantiated, the message will be sent to the CometActor
-   * as part of setup (see queueCometMessage) if it is created as part
+   * as part of setup `[[queueCometMessage]]` if it is created as part
    * of the current HTTP request/response cycle.
    *
    * @param msg the message to send to the CometActor
@@ -2361,7 +2361,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * the CometActor is instantiated.  If the CometActor already exists
    * in the session, the message will be sent immediately.  If the CometActor
    * is not yet instantiated, the message will be sent to the CometActor
-   * as part of setup (see queueCometMessage) regardless of if it is created as part
+   * as part of setup `[[queueCometMessage]]` regardless of if it is created as part
    * of the current HTTP request/response cycle. We plan to restrict this to
    * the current request/response cycle in the future (as that is the intended beavior).
    *
@@ -2383,7 +2383,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * the CometActor is instantiated.  If the CometActor already exists
    * in the session, the message will be sent immediately.  If the CometActor
    * is not yet instantiated, the message will be sent to the CometActor
-   * as part of setup (see queueCometMessage) regardless of if it is created as part
+   * as part of setup `[[queueCometMessage]]` regardless of if it is created as part
    * of the current HTTP request/response cycle. We plan to restrict this to
    * the current request/response cycle in the future (as that is the intended beavior).
    *

--- a/web/webkit/src/main/scala/net/liftweb/http/NamedCometActorSnippet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/NamedCometActorSnippet.scala
@@ -49,7 +49,7 @@ trait NamedCometActorSnippet {
    * to add the comet actor to the page
    */
   final def render(xhtml: NodeSeq): NodeSeq = {
-    for (sess <- S.session) sess.sendCometActorMessage(
+    for (sess <- S.session) sess.sendCometMessage(
       cometClass, Full(name), CometName(name)
     )
     <lift:comet type={cometClass} name={name}>{xhtml}</lift:comet>

--- a/web/webkit/src/test/scala/net/liftweb/http/LiftSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LiftSessionSpec.scala
@@ -52,7 +52,7 @@ object LiftSessionSpec extends Specification with BeforeEach {
         val sendingMessages = 1 to 20
 
         sendingMessages.foreach { message =>
-          session.sendCometActorMessage(cometName, Full(cometName), message)
+          session.sendCometMessage(cometName, Full(cometName), message)
         }
 
         session.findOrCreateComet[TestCometActor](Full(cometName), NodeSeq.Empty, Map.empty).map { comet =>
@@ -71,11 +71,11 @@ object LiftSessionSpec extends Specification with BeforeEach {
         val cometName = "Comet1"
 
         // Spin up two comets: one with a name and one without
-        session.sendCometActorMessage(cometType, Full(cometName), NoOp)
-        session.sendCometActorMessage(cometType, Empty, NoOp)
+        session.sendCometMessage(cometType, Full(cometName), NoOp)
+        session.sendCometMessage(cometType, Empty, NoOp)
 
         // Send a message to both
-        session.sendCometActorMessage(cometType, 1)
+        session.sendCometMessage(cometType, 1)
 
         // Ensure both process the message
         session.findOrCreateComet[TestCometActor](Full(cometName), NodeSeq.Empty, Map.empty).map { comet =>

--- a/web/webkit/src/test/scala/net/liftweb/http/LiftSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LiftSessionSpec.scala
@@ -25,7 +25,7 @@ object LiftSessionSpec extends Specification {
 
   private var receivedMessages = Vector[Int]()
   private object NoOp
-  
+
   private class TestCometActor extends CometActor {
     def render = NodeSeq.Empty
 
@@ -41,15 +41,20 @@ object LiftSessionSpec extends Specification {
   "A LiftSession" should {
 
     "Send accumulated messages to a newly-created comet actor in the order in which they arrived" in {
-
       val session = new LiftSession("Test Session", "", Empty)
+
       S.init(Empty, session) {
         val cometName = "TestCometActor"
         val sendingMessages = 1 to 20
-        sendingMessages foreach (message =>
-          session.sendCometActorMessage(cometName, Full(cometName), message))
-        session.findOrCreateComet[TestCometActor](Full(cometName), NodeSeq.Empty, Map.empty).map(comet =>
-          comet !? NoOp /* Block to allow time for all messages to be collected */)
+
+        sendingMessages.foreach { message =>
+          session.sendCometActorMessage(cometName, Full(cometName), message)
+        }
+
+        session.findOrCreateComet[TestCometActor](Full(cometName), NodeSeq.Empty, Map.empty).map { comet =>
+          comet !? NoOp /* Block to allow time for all messages to be collected */
+        }
+
         receivedMessages mustEqual sendingMessages
       }
     }


### PR DESCRIPTION
Closes #1146.

This PR implements a variant of `sendCometActorMessage` that will send to all comets of a particular type, regardless of whether or not they have a name or what their name is. I also chose a better name for `setupComet` and deprecated the version of it that existed prior to this PR.
