### PR TITLE
Parse CSP report as JSON

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SecurityRules.scala
@@ -339,7 +339,7 @@ object ContentSecurityPolicyViolation extends LazyLoggable {
     case request @ Req(start :: "content-security-policy-report" :: Nil, _, _) if start == LiftRules.liftContextRelativePath =>
       val violation =
         for {
-          requestJson <- request.json
+          requestJson <- request.forcedBodyAsJson
           camelCasedJson = requestJson.transformField {
             case JField("document-uri", content) =>
               JField("documentUri", content)


### PR DESCRIPTION
Chrome sends csp-report as application/csp-report, which breaks default json parsing.

As discussed: https://groups.google.com/forum/#!topic/liftweb/WP-csyV0Vbs

-Austen