### PR TITLE
Drop 'small fix' requirement from contributing doc.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,11 @@ all of the following criteria:
 * The request handles an issue that has been discussed on the Lift mailing list
   and whose solution has been requested by the committers (and in general adheres
   to the spirit of the issue guidelines above).
-* The request represents one or more of the following:
-  * Documentation including ScalaDoc comments in code
-  * Example code
-  * Small changes, enhancements, or bug fixes to Lift’s code
 * The request includes a signature at the bottom of the /contributors.md file.
+
+Note that only Lift committers can merge a pull request, and accepting or rejecting
+a pull request is entirely at the discretion of the Lift committers. By merging a
+pull request, the Lift committers are taking responsibility for maintaining that code,
+and there are many reasons why this might not be desirable for certain features. We
+will strive to communicate clearly why pull requests are not accepted if we decide
+not to accept them.


### PR DESCRIPTION
Until now, we required that contributions be small fixes or
documentation fixes. We've decided to drop that limitation
and open Lift to wider contributions, though only committers
can merge.

Looking for a +1 or 3 (or suggestions for changes!) and will
post an announcement to the Lift ML once this is merged, with
similar verbiage.