### PR TITLE
Escape Call: Add LiftRules.extractInlineJavaScript.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -164,7 +164,7 @@ private[http] trait LiftMerge {
             val bodyTail = childInfo.tailInBodyChild && ! tailInBodyChild
 
             HtmlNormalizer
-              .normalizeNode(node, contextPath, stripComments)
+              .normalizeNode(node, contextPath, stripComments, LiftRules.extractInlineJavaScript)
               .map {
                 case normalized @ NodeAndEventJs(normalizedElement: Elem, _) =>
                   val normalizedChildren =

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -403,6 +403,11 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
 
   /**
    * Holds the JS library specific UI artifacts. By default it uses JQuery's artifacts
+   *
+   * Please note that currently any setting other than `JQueryArtifacts` will switch
+   * you to using Lift's liftVanilla implementation, which is meant to work independent
+   * of any framework. '''This implementation is experimental in Lift 3.0, so use it at
+   * your own risk and make sure you test your application!'''
    */
   @volatile var jsArtifacts: JSArtifacts = JQueryArtifacts
 

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -591,7 +591,7 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    * security policy, you can allow inline scripts and set
    * `extractEventAttributes` to false to disable event extraction.
    */
-  @volatile var extractInlineJavaScript: Boolean = true
+  @volatile var extractInlineJavaScript: Boolean = false
 
   /**
    * The attribute used to expose the names of event attributes that were

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -570,11 +570,31 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   @volatile var displayHelpfulSiteMapMessages_? = true
 
   /**
-   * The attribute used to expose the names of event attributes that
-   * were removed from a given element for separate processing in JS.
-   * By default, Lift removes event attributes and attaches those
-   * behaviors via a separate JS file, to avoid inline JS invocations so
-   * that a restrictive Content-Security-Policy can be used.
+   * Enables or disables event attribute and script element extraction.
+   *
+   * Lift can extract script elements and event attributes like onclick,
+   * onchange, etc, and attach the event handlers in a separate JavaScript file
+   * that is generated per-page. This allows for populating these types of
+   * JavaScript in your snippets via CSS selector transforms, without needing
+   * to allow inline scripts in your content security policy (see
+   * `[[securityRules]]`).
+   *
+   * However, there are certain scenarios where event attribute extraction
+   * cannot provide a 1-to-1 reproduction of the behavior you'd get with inline
+   * attributes or scripts; if your application hits these scenarios and you
+   * would prefer not to adjust them to work with a restrictive content
+   * security policy, you can allow inline scripts and set
+   * `extractEventAttributes` to false to disable event extraction.
+   */
+  @volatile var extractInlineJavaScript: Boolean = true
+
+  /**
+   * The attribute used to expose the names of event attributes that were
+   * removed from a given element for separate processing in JS (when
+   * `extractInlineJavaScript` is `true`). By default, Lift removes event
+   * attributes and attaches those behaviors via a separate JS file, to avoid
+   * inline JS invocations so that a restrictive content security policy can be
+   * used.
    *
    * You can set this variable so that the resulting HTML will have
    * attribute information about the removed attributes, in case you

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -1873,7 +1873,8 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
     HtmlNormalizer.normalizeHtmlAndEventHandlers(
       nodes,
       S.contextPath,
-      LiftRules.stripComments.vend
+      LiftRules.stripComments.vend,
+      LiftRules.extractInlineJavaScript
     )
   }
 

--- a/web/webkit/src/test/scala/net/liftweb/http/HtmlNormalizerSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/HtmlNormalizerSpec.scala
@@ -40,7 +40,8 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
             </body>
           </html>,
           "/context-path",
-          false
+          false,
+          true
         ).nodes
 
       result must ==/(
@@ -85,7 +86,8 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
             </body>
           </html>,
           "/context-path",
-          false
+          false,
+          true
         )
 
       List("testJs1", 
@@ -113,7 +115,8 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
         HtmlNormalizer.normalizeHtmlAndEventHandlers(
           <myelement id="testid" onevent="doStuff" />,
           "/context-path",
-          false
+          false,
+          true
         )
 
       html must ==/(<myelement id="testid" />)
@@ -125,7 +128,8 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
         HtmlNormalizer.normalizeHtmlAndEventHandlers(
           <myelement onevent="doStuff" />,
           "/context-path",
-          false
+          false,
+          true
         )
 
       val id = html \@ "id"
@@ -143,7 +147,8 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
             <myelement onevent="doStuff3" />
           </div>,
           "/context-path",
-          false
+          false,
+          true
         )
 
       js.toJsCmd must be matching("""(?s)\Qlift.onEvent("lift-event-js-\E[^"]+\Q","event",function(event) {doStuff;});
@@ -165,7 +170,8 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
             <myelement action="javascript:/doStuff4" />
           </div>,
           "/context-path",
-          false
+          false,
+          true
         )
 
       (html \ "myelement").map(_ \@ "href").filter(_.nonEmpty) must beEmpty
@@ -187,7 +193,8 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
             <myelement action="doStuff4" />
           </div>,
           "/context-path",
-          false
+          false,
+          true
         )
 
       (html \ "myelement").map(_ \@ "href").filter(_.nonEmpty) must_== List("doStuff", "javascrip://doStuff3")
@@ -216,10 +223,11 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
             </body>
           </html>,
           "/context-path",
-          false
+          false,
+          true
         ).nodes
 
-      (result \\ "link").map(_ \@ "href") must_== 
+      (result \\ "link").map(_ \@ "href") must_==
         "/context-path/testlink" ::
         "/context-path/testlink2" ::
         "/context-path/testlink3" :: Nil
@@ -247,10 +255,11 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
             </body>
           </html>,
           "/context-path",
-          false
+          false,
+          true
         ).nodes
 
-      (result \\ "script").map(_ \@ "src") must_== 
+      (result \\ "script").map(_ \@ "src") must_==
         "/context-path/testscript" ::
         "/context-path/testscript2" :: Nil
     }
@@ -277,10 +286,11 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
             </body>
           </html>,
           "/context-path",
-          false
+          false,
+          true
         ).nodes
 
-      (result \\ "a").map(_ \@ "href") must_== 
+      (result \\ "a").map(_ \@ "href") must_==
         "/context-path/testa1" ::
         "/context-path/testa2" ::
         "testa3" ::
@@ -311,10 +321,11 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
             </body>
           </html>,
           "/context-path",
-          false
+          false,
+          true
         ).nodes
 
-      (result \\ "form").map(_ \@ "action") must_== 
+      (result \\ "form").map(_ \@ "action") must_==
         "/context-path/testform1" ::
         "/context-path/testform2" ::
         "testform3" ::
@@ -344,11 +355,12 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
               </body>
             </html>,
             "/context-path",
-            false
+            false,
+            true
           ).nodes
         }
 
-      (result \\ "script").map(_ \@ "src") must_== 
+      (result \\ "script").map(_ \@ "src") must_==
         "testscript" ::
         "testscript2" ::
         "testscript3" :: Nil
@@ -375,11 +387,12 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
               </body>
             </html>,
             "/context-path",
-            false
+            false,
+            true
           ).nodes
         }
 
-      (result \\ "link").map(_ \@ "href") must_== 
+      (result \\ "link").map(_ \@ "href") must_==
         "testlink" ::
         "testlink2" ::
         "testlink3" :: Nil
@@ -406,11 +419,12 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
               </body>
             </html>,
             "/context-path",
-            false
+            false,
+            true
           ).nodes
         }
 
-      (result \\ "a").map(_ \@ "href") must_== 
+      (result \\ "a").map(_ \@ "href") must_==
         "rewritten" ::
         "rewritten" ::
         "rewritten" :: Nil
@@ -437,11 +451,330 @@ class HtmlNormalizerSpec extends Specification with XmlMatchers with Mockito {
               </body>
             </html>,
             "/context-path",
+            false,
+            true
+          ).nodes
+        }
+
+      (result \\ "form").map(_ \@ "action") must_==
+        "rewritten" ::
+        "rewritten" ::
+        "rewritten" :: Nil
+    }
+  }
+
+  "HtmlNormalizer when normalizing HTML and event handlers with event extract disabled" should {
+    "not extract events from any elements at any depth" in {
+      val startingHtml =
+        <html onevent="testJs1">
+          <head onresult="testJs2">
+            <script src="testscript" onmagic="testJs3"></script>
+            <link href="testlink" onthing="testJs4" />
+          </head>
+          <body onclick="testJs5">
+            <link href="testlink2" onclick="testJs5" />
+            <form action="booyan" onsubmit="testJs6">
+              <p onmouseover="testJs7">
+                <link href="testlink3" onslippetydip="testJs8" />
+              </p>
+            </form>
+
+            <p onkeyup="testJs9">Thingies</p>
+            <p ondragstart="testJs10">More thingies</p>
+          </body>
+        </html>
+
+      val NodesAndEventJs(html, js) =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          startingHtml,
+          "/context-path",
+          false,
+          false
+        )
+
+      html.toString must_== startingHtml.toString
+      js.toJsCmd.length must_== 0
+    }
+
+    "not extract events from hrefs and actions" in {
+      val startingHtml =
+          <div>
+            <myelement href="javascript:doStuff" />
+            <myelement id="hello" action="javascript:doStuff2" />
+            <myelement id="hello2" href="javascript://doStuff3" />
+            // Note here we have the same behavior as browsers: javascript:/
+            // is *processed as JavaScript* but it is *invalid JavaScript*
+            // (i.e., it corresponds to a JS expression that starts with `/`).
+            <myelement action="javascript:/doStuff4" />
+          </div>
+
+      val NodesAndEventJs(html, js) =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          startingHtml,
+          "/context-path",
+          false,
+          false
+        )
+
+      html.toString must_== startingHtml.toString
+      js.toJsCmd.length must_== 0
+    }
+
+    "normalize absolute link hrefs everywhere" in {
+      val result =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <html>
+            <head>
+              <script src="testscript"></script>
+              <link href="/testlink" />
+            </head>
+            <body>
+              <link href="/testlink2" />
+              <div>
+                <p>
+                  <link href="/testlink3" />
+                </p>
+              </div>
+
+              <p>Thingies</p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          "/context-path",
+          false,
+          false
+        ).nodes
+
+      (result \\ "link").map(_ \@ "href") must_==
+        "/context-path/testlink" ::
+        "/context-path/testlink2" ::
+        "/context-path/testlink3" :: Nil
+    }
+
+    "normalize absolute script srcs everywhere" in {
+      val result =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <html>
+            <head>
+              <script src="/testscript"></script>
+              <link href="testlink" />
+            </head>
+            <body>
+              <script src="/testscript2"></script>
+              <link href="testlink2" />
+              <div>
+                <p>
+                  <link href="testlink3" />
+                </p>
+              </div>
+
+              <p>Thingies</p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          "/context-path",
+          false,
+          false
+        ).nodes
+
+      (result \\ "script").map(_ \@ "src") must_==
+        "/context-path/testscript" ::
+        "/context-path/testscript2" :: Nil
+    }
+
+    "normalize absolute a hrefs everywhere" in {
+      val result =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <html>
+            <head>
+              <a href="/testa1">Booyan</a>
+            </head>
+            <body>
+              <a href="/testa2">Booyan</a>
+              <a href="testa3">Booyan</a>
+              <div>
+                <a href="testa4">Booyan</a>
+                <p>
+                  <a href="/testa5">Booyan</a>
+                </p>
+              </div>
+
+              <p>Thingies <a href="/testa6">Booyan</a></p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          "/context-path",
+          false,
+          false
+        ).nodes
+
+      (result \\ "a").map(_ \@ "href") must_==
+        "/context-path/testa1" ::
+        "/context-path/testa2" ::
+        "testa3" ::
+        "testa4" ::
+        "/context-path/testa5" ::
+        "/context-path/testa6" :: Nil
+    }
+
+    "normalize absolute form actions everywhere" in {
+      val result =
+        HtmlNormalizer.normalizeHtmlAndEventHandlers(
+          <html>
+            <head>
+              <form action="/testform1">Booyan</form>
+            </head>
+            <body>
+              <form action="/testform2">Booyan</form>
+              <form action="testform3">Booyan</form>
+              <div>
+                <form action="testform4">Booyan</form>
+                <p>
+                  <form action="/testform5">Booyan</form>
+                </p>
+              </div>
+
+              <p>Thingies <form action="/testform6">Booyan</form></p>
+              <p>More thingies</p>
+            </body>
+          </html>,
+          "/context-path",
+          false,
+          false
+        ).nodes
+
+      (result \\ "form").map(_ \@ "action") must_==
+        "/context-path/testform1" ::
+        "/context-path/testform2" ::
+        "testform3" ::
+        "testform4" ::
+        "/context-path/testform5" ::
+        "/context-path/testform6" :: Nil
+    }
+
+    "not rewrite script srcs anywhere" in {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          HtmlNormalizer.normalizeHtmlAndEventHandlers(
+            <html>
+              <head>
+                <script src="testscript"></script>
+              </head>
+              <body>
+                <script src="testscript2"></script>
+                <div>
+                  <p>
+                    <script src="testscript3" />
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            "/context-path",
+            false,
             false
           ).nodes
         }
 
-      (result \\ "form").map(_ \@ "action") must_== 
+      (result \\ "script").map(_ \@ "src") must_==
+        "testscript" ::
+        "testscript2" ::
+        "testscript3" :: Nil
+    }
+
+    "not rewrite link hrefs anywhere" in {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          HtmlNormalizer.normalizeHtmlAndEventHandlers(
+            <html>
+              <head>
+                <link href="testlink" />
+              </head>
+              <body>
+                <link href="testlink2" />
+                <div>
+                  <p>
+                    <link href="testlink3" />
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            "/context-path",
+            false,
+            false
+          ).nodes
+        }
+
+      (result \\ "link").map(_ \@ "href") must_==
+        "testlink" ::
+        "testlink2" ::
+        "testlink3" :: Nil
+    }
+
+    "rewrite a hrefs everywhere" in {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          HtmlNormalizer.normalizeHtmlAndEventHandlers(
+            <html>
+              <head>
+                <a href="testa"></a>
+              </head>
+              <body>
+                <a href="testa2"></a>
+                <div>
+                  <p>
+                    <a href="testa3" />
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            "/context-path",
+            false,
+            false
+          ).nodes
+        }
+
+      (result \\ "a").map(_ \@ "href") must_==
+        "rewritten" ::
+        "rewritten" ::
+        "rewritten" :: Nil
+    }
+
+    "rewrite form actions everywhere" in {
+      val result =
+        URLRewriter.doWith((_: String) => "rewritten") {
+          HtmlNormalizer.normalizeHtmlAndEventHandlers(
+            <html>
+              <head>
+                <form action="testform" />
+              </head>
+              <body>
+                <form action="testform2" />
+                <div>
+                  <p>
+                    <form action="testform3" />
+                  </p>
+                </div>
+
+                <p>Thingies</p>
+                <p>More thingies</p>
+              </body>
+            </html>,
+            "/context-path",
+            false,
+            false
+          ).nodes
+        }
+
+      (result \\ "form").map(_ \@ "action") must_==
         "rewritten" ::
         "rewritten" ::
         "rewritten" :: Nil


### PR DESCRIPTION
Enabled by default, this can be set to `false` in cases where event extraction
is causing poor or undesirable behavior.

Should be fairly self-explanatory… The only question is whether to default it
to `true` or `false`. Given the major version bump and the desirable aspects
of having this enabled, I'd suggest we go `true` by default. However, if we
prioritize the potentially breaking nature of having it enabled, we could make
a good argument for `false` by default.

I can also post to the list and get input from there if we think that's the best
way to go.