### PR TITLE
use proper form of specs2 dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ scalaVersion in ThisBuild          := "2.11.7"
 
 crossScalaVersions in ThisBuild    := Seq("2.11.7")
 
-libraryDependencies in ThisBuild <++= scalaVersion {sv => Seq(specs2, scalacheck, scalatest) }
+libraryDependencies in ThisBuild <++= scalaVersion {sv => Seq(specs2, specs2Matchers, specs2Mock, scalacheck, scalatest) }
 
 // Settings for Sonatype compliance
 pomIncludeRepository in ThisBuild  := { _ => false }

--- a/contributors.md
+++ b/contributors.md
@@ -227,3 +227,9 @@ Arek Burdach
 
 ### Email: ###
 arek.burdach at gmail dot com
+
+### Name: ###
+Seth Tisue
+
+### Email: ###
+seth at tisue dot net

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -134,7 +134,7 @@ object BuildDef extends Build {
         .settings(description := "Webkit Library",
                   parallelExecution in Test := false,
                   libraryDependencies <++= scalaVersion { sv =>
-                    Seq(commons_fileupload, rhino, servlet_api, specs2.copy(configurations = Some("provided")), jetty6,
+                    Seq(commons_fileupload, rhino, servlet_api, specs2.copy(configurations = Some("provided")), specs2Matchers.copy(configurations = Some("provided")), jetty6,
                       jwebunit)
                   },
                   initialize in Test <<= (sourceDirectory in Test) { src =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,6 +81,8 @@ object Dependencies {
   lazy val mockito_all = "org.mockito"                 % "mockito-all"              % "1.9.0"   % "test"
   lazy val scalacheck  = "org.specs2"                 %% "specs2-scalacheck"        % "3.7"  % "test"
   lazy val specs2      = "org.specs2"                 %% "specs2-core"              % "3.7"  % "test"
+  lazy val specs2Matchers = "org.specs2"              %% "specs2-matcher-extra"     % "3.7"  % "test"
+  lazy val specs2Mock  = "org.specs2"                 %% "specs2-mock"              % "3.7"  % "test"
   lazy val scalatest   = "org.scalatest"              %% "scalatest"                % "2.1.3"   % "test"
   lazy val junit       = "junit"                       % "junit"                    % "4.8.2"   % "test"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -80,7 +80,7 @@ object Dependencies {
   lazy val jwebunit    = "net.sourceforge.jwebunit"    % "jwebunit-htmlunit-plugin" % "2.5"     % "test"
   lazy val mockito_all = "org.mockito"                 % "mockito-all"              % "1.9.0"   % "test"
   lazy val scalacheck  = "org.specs2"                 %% "specs2-scalacheck"        % "3.7"  % "test"
-  lazy val specs2      = "org.specs2"                 %% "specs2"                   % "3.7"  % "test"
+  lazy val specs2      = "org.specs2"                 %% "specs2-core"              % "3.7"  % "test"
   lazy val scalatest   = "org.scalatest"              %% "scalatest"                % "2.1.3"   % "test"
   lazy val junit       = "junit"                       % "junit"                    % "4.8.2"   % "test"
 


### PR DESCRIPTION
required for compatibility with Scala 2.12 community build.
and it's the recommended thing anyway
