### PR TITLE
Req and LiftSession - aware Futures / LAFutures

### DIFF
--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -113,10 +113,13 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler, context: Box[LAFutur
     onComplete(v => v match {
       case Full(v) =>
         Box.tryo(contextFn(v)) match {
-          case Full(successfullyComputedFuture) => successfullyComputedFuture.onComplete(v2 => result.complete(v2))
-          case e: EmptyBox => result.complete(e)
+          case Full(successfullyComputedFuture) =>
+            successfullyComputedFuture.onComplete(v2 => result.complete(v2))
+          case e: EmptyBox =>
+            result.complete(e)
         }
-      case e: EmptyBox => result.complete(e)
+      case e: EmptyBox =>
+        result.complete(e)
     })
     result
   }

--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -426,7 +426,7 @@ object LAFuture {
     *
     * This is similar to [[net.liftweb.common.CommonLoanWrapper]], however, it decorates the
     * function eagerly. This way, you can access current thread's state which is essential
-    * to set up e.g. HTTP session wrapper.
+    * to do things like set up a HTTP session wrapper
     */
   trait Context {
     def around[T](fn: () => T): () => T

--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -176,7 +176,7 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler, context: Box[LAFutur
     synchronized {
       if (satisfied) {LAFuture.executeWithObservers(scheduler, () => contextFn(item))} else
       if (!aborted) {
-        toDo ::= f
+        toDo ::= contextFn
       }
     }
   }

--- a/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/FutureWithSession.scala
@@ -1,0 +1,128 @@
+package net.liftweb.http
+
+import net.liftweb.common.Full
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{CanAwait, ExecutionContext, Future}
+import scala.util.Try
+
+/**
+  * Decorates `Future` instance to allow access to session and request resources. Should be created with
+  * `FutureWithSession.withCurrentSession` that takes the current Lift request and session and make it available
+  * to all transformation methods and initial `Future` execution body. Each transformation method returns
+  * `FutureWithSession`, thus, they can be all chained together.
+  *
+  * It's important to bear in mind that each chained method requires current thread's `LiftSession` to be available.
+  * `FutureWithSession` does _not_ propagate initial session or request to all chained methods.
+  *
+  * @see FutureWithSession.withCurrentSession
+  *
+  * @param delegate original `Future` instance that will be enriched with session and request access
+  */
+private[http] class FutureWithSession[T](private[this] val delegate: Future[T]) extends Future[T] {
+
+  import FutureWithSession.withCurrentSession
+
+  override def isCompleted: Boolean = delegate.isCompleted
+
+  override def value: Option[Try[T]] = delegate.value
+
+  override def result(atMost: Duration)(implicit permit: CanAwait): T = delegate.result(atMost)
+
+  override def ready(atMost: Duration)(implicit permit: CanAwait) = {
+    delegate.ready(atMost)
+    this
+  }
+
+  override def onComplete[U](f: (Try[T]) => U)(implicit executor:ExecutionContext): Unit = {
+    val sessionFn = withCurrentSession(f)
+    delegate.onComplete(sessionFn)
+  }
+
+  override def map[S](f: T => S)(implicit executor: ExecutionContext): FutureWithSession[S] = {
+    val sessionFn = withCurrentSession(f)
+    new FutureWithSession(delegate.map(sessionFn))
+  }
+
+  override def flatMap[S](f: T => Future[S])(implicit executor: ExecutionContext): FutureWithSession[S] = {
+    val sessionFn = withCurrentSession(f)
+    new FutureWithSession(delegate.flatMap(sessionFn))
+  }
+
+  override def andThen[U](pf: PartialFunction[Try[T], U])(implicit executor: ExecutionContext): FutureWithSession[T] = {
+    val sessionFn = withCurrentSession(pf)
+    new FutureWithSession(delegate.andThen {
+      case t => sessionFn(t)
+    })
+  }
+
+  override def failed: FutureWithSession[Throwable] = {
+    new FutureWithSession(delegate.failed)
+  }
+
+  override def fallbackTo[U >: T](that: Future[U]): FutureWithSession[U] = {
+    new FutureWithSession[U](delegate.fallbackTo(that))
+  }
+
+  override def recover[U >: T](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): FutureWithSession[U] = {
+    val sessionFn = withCurrentSession(pf)
+    new FutureWithSession(delegate.recover {
+      case t => sessionFn(t)
+    })
+  }
+
+  override def recoverWith[U >: T](pf: PartialFunction[Throwable, Future[U]])(implicit executor: ExecutionContext): FutureWithSession[U] = {
+    val sessionFn = withCurrentSession(pf)
+    new FutureWithSession(delegate.recoverWith {
+      case t => sessionFn(t)
+    })
+  }
+
+  override def transform[S](s: T => S, f: Throwable => Throwable)(implicit executor: ExecutionContext): Future[S] = {
+    val sessionSuccessFn = withCurrentSession(s)
+    val sessionFailureFn = withCurrentSession(f)
+
+    new FutureWithSession(delegate.transform(s => sessionSuccessFn(s), f => sessionFailureFn(f)))
+  }
+
+  override def zip[U](that: Future[U]): Future[(T, U)] = {
+    new FutureWithSession(delegate.zip(that))
+  }
+}
+
+object FutureWithSession {
+
+  /**
+    * Creates `Future` instance aware of current request and session. Each `Future` returned by chained
+    * transformation method (e.g. `map`, `flatMap`) will be also request/session-aware. However, it's
+    * important to bear in mind that initial request and session are not propagated to chained methods.
+    * It's required that current execution thread for chained method has its own request/session available
+    * if reading/writing some data to it as a part of chained method execution.
+    */
+  def withCurrentSession[T](task: => T)(implicit executionContext: ExecutionContext): Future[T] = {
+    FutureWithSession(task)
+  }
+
+  private def apply[T](task: => T)(implicit executionContext: ExecutionContext): FutureWithSession[T] = {
+    S.session match {
+      case Full(_) =>
+        val sessionFn = withCurrentSession(() => task)
+        new FutureWithSession(Future[T](sessionFn()))
+
+      case _ =>
+        new FutureWithSession(Future.failed[T](
+          new IllegalStateException("LiftSession not available in this thread context")
+        ))
+    }
+  }
+
+  private def withCurrentSession[T](task: () => T): () => T = {
+    val session = S.session openOrThrowException "LiftSession not available in this thread context"
+    session.buildDeferredFunction(task)
+  }
+
+  private def withCurrentSession[A,T](task: (A)=>T): (A)=>T = {
+    val session = S.session openOrThrowException "LiftSession not available in this thread context"
+    session.buildDeferredFunction(task)
+  }
+}

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -1,0 +1,48 @@
+package net.liftweb.http
+
+import net.liftweb.actor.{LAFuture, LAScheduler}
+import net.liftweb.common.{EmptyBox, Failure, Full}
+
+
+object LAFutureWithSession {
+
+  /**
+    * Creates `LAFuture` instance aware of current request and session. Each `LAFuture` returned by chained
+    * transformation method (e.g. `map`, `flatMap`) will be also request/session-aware. However, it's
+    * important to bear in mind that initial session or request are not propagated to chained methods. It's required
+    * that current execution thread for chained method has its own request or session available if reading/writing
+    * some data to it as a part of chained method execution.
+    */
+  def withCurrentSession[T](task: => T, scheduler: LAScheduler = LAScheduler): LAFuture[T] = {
+    S.session match {
+      case Full(session) =>
+        withSession(task, scheduler)
+
+      case empty: EmptyBox =>
+        withFailure(empty ?~! "LiftSession not available in this thread context", scheduler)
+    }
+  }
+
+  private[this] def withSession[T](task: => T, scheduler: LAScheduler): LAFuture[T] = {
+    val sessionContext = new LAFuture.Context {
+
+      def around[S](fn: () => S): () => S = {
+        val session = S.session openOrThrowException "LiftSession not available in this thread context"
+        session.buildDeferredFunction(fn)
+      }
+
+      def around[A, S](fn: (A) => S): (A) => S = {
+        val session = S.session openOrThrowException "LiftSession not available in this thread context"
+        session.buildDeferredFunction(fn)
+      }
+    }
+
+    LAFuture.build(task, scheduler, Full(sessionContext))
+  }
+
+  private[this] def withFailure[T](failure: Failure, scheduler: LAScheduler): LAFuture[T] = {
+    val future = new LAFuture[T](scheduler)
+    future.complete(failure)
+    future
+  }
+}

--- a/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LAFutureWithSession.scala
@@ -7,10 +7,10 @@ import net.liftweb.common.{EmptyBox, Failure, Full}
 object LAFutureWithSession {
 
   /**
-    * Creates `LAFuture` instance aware of current request and session. Each `LAFuture` returned by chained
+    * Creates `LAFuture` instance aware of the current request and session. Each `LAFuture` returned by chained
     * transformation method (e.g. `map`, `flatMap`) will be also request/session-aware. However, it's
     * important to bear in mind that initial session or request are not propagated to chained methods. It's required
-    * that current execution thread for chained method has its own request or session available if reading/writing
+    * that current execution thread for chained method has request or session available in scope if reading/writing
     * some data to it as a part of chained method execution.
     */
   def withCurrentSession[T](task: => T, scheduler: LAScheduler = LAScheduler): LAFuture[T] = {

--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -17,13 +17,12 @@
 package net.liftweb
 package http
 
-import java.util.{Locale, TimeZone, ResourceBundle}
+import java.util.{Locale, ResourceBundle, TimeZone}
 
 import scala.collection.mutable.{HashMap, ListBuffer}
 import xml._
-
 import common._
-import actor.LAFuture
+import actor.{LAFuture, LAScheduler}
 import util._
 import Helpers._
 import js._
@@ -1403,6 +1402,16 @@ trait S extends HasParams with Loggable with UserAgentCalculator {
    * The current LiftSession.
    */
   def session: Box[LiftSession] = Box.legacyNullTest(_sessionInfo.value)
+
+  /**
+    * Creates `LAFuture` instance aware of the current request and session. Each `LAFuture` returned by chained
+    * transformation method (e.g. `map`, `flatMap`) will be also request/session-aware. However, it's
+    * important to bear in mind that initial session or request are not propagated to chained methods. It's required
+    * that current execution thread for chained method has request or session available in scope if reading/writing
+    * some data to it as a part of chained method execution.
+    */
+  def sessionFuture[T](task: => T, scheduler: LAScheduler = LAScheduler): LAFuture[T] =
+    LAFutureWithSession.withCurrentSession(task, scheduler)
 
   /**
    * Log a query for the given request.  The query log can be tested to see

--- a/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
@@ -65,6 +65,10 @@ class FutureWithSessionSpec extends WebSpec with ThrownMessages {
     }
 
     "have access to request variables in onComplete()" withSFor "/" in {
+      // workaround for a possible race condition in AnyVarTrait
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      ReqVar1.is
+
       val future = FutureWithSession.withCurrentSession("thor")
       future.onComplete {
         case Success(v) => ReqVar1(v)
@@ -119,7 +123,7 @@ class FutureWithSessionSpec extends WebSpec with ThrownMessages {
     }
 
     "have access to session variables in chains of andThen()" withSFor "/" in {
-      // workaround for a possible race condition in SessionVar
+      // workaround for a possible race condition in AnyVarTrait
       // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
       SessionVar1.is
       SessionVar2.is
@@ -134,6 +138,11 @@ class FutureWithSessionSpec extends WebSpec with ThrownMessages {
     }
 
     "have access to request variables in chains of andThen()" withSFor "/" in {
+      // workaround for a possible race condition in AnyVarTrait
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      ReqVar1.is
+      ReqVar2.is
+
       val future = FutureWithSession.withCurrentSession("conan")
         .andThen { case Success(v) => ReqVar1(v) }
         .andThen { case Success(v) => ReqVar2(v) }

--- a/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
@@ -104,8 +104,14 @@ class FutureWithSessionSpec extends WebSpec with ThrownMessages {
 
       val future = FutureWithSession.withCurrentSession("d")
       val mapped = future
-        .flatMap { s => val out = s + SessionVar1.is; Future(out) }
-        .flatMap { s => val out = s + SessionVar2.is; Future(out) }
+        .flatMap { s =>
+          val out = s + SessionVar1.is
+          Future(out)
+        }
+        .flatMap { s =>
+          val out = s + SessionVar2.is
+          Future(out)
+        }
 
       mapped.value must eventually(beEqualTo(Some(Success("def"))))
     }
@@ -116,8 +122,14 @@ class FutureWithSessionSpec extends WebSpec with ThrownMessages {
 
       val future = FutureWithSession.withCurrentSession("d")
       val mapped = future
-        .flatMap { s => val out = s + ReqVar1.is; Future(out) }
-        .flatMap { s => val out = s + ReqVar2.is; Future(out) }
+        .flatMap { s =>
+          val out = s + ReqVar1.is
+          Future(out)
+        }
+        .flatMap { s =>
+          val out = s + ReqVar2.is
+          Future(out)
+        }
 
       mapped.value must eventually(beEqualTo(Some(Success("def"))))
     }
@@ -217,7 +229,10 @@ class FutureWithSessionSpec extends WebSpec with ThrownMessages {
       SessionVar2("j")
 
       val future = FutureWithSession.withCurrentSession(throw new Exception("failed"))
-        .recoverWith { case e: Exception => val out = e.getMessage + " " + SessionVar1.is; Future(out) }
+        .recoverWith { case e: Exception =>
+          val out = e.getMessage + " " + SessionVar1.is
+          Future(out)
+        }
         .map(_ + SessionVar2.is)
 
       future.value must eventually(beEqualTo(Some(Success("failed ij"))))
@@ -228,7 +243,10 @@ class FutureWithSessionSpec extends WebSpec with ThrownMessages {
       ReqVar2("l")
 
       val future = FutureWithSession.withCurrentSession(throw new Exception("failed"))
-        .recoverWith { case e: Exception => val out = e.getMessage + " " + ReqVar1.is; Future(out) }
+        .recoverWith { case e: Exception =>
+          val out = e.getMessage + " " + ReqVar1.is
+          Future(out)
+        }
         .map(_ + ReqVar2.is)
 
       future.value must eventually(beEqualTo(Some(Success("failed kl"))))

--- a/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/FutureWithSessionSpec.scala
@@ -1,0 +1,290 @@
+package net.liftweb.http
+
+import net.liftweb.common.Empty
+import net.liftweb.mockweb.WebSpec
+import org.specs2.matcher.ThrownMessages
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
+
+class FutureWithSessionSpec extends WebSpec with ThrownMessages {
+
+  sequential
+
+  object SessionVar1 extends SessionVar[String]("Uninitialized1")
+  object SessionVar2 extends SessionVar[String]("Uninitialized2")
+
+  object ReqVar1 extends RequestVar[String]("Uninitialized1")
+  object ReqVar2 extends RequestVar[String]("Uninitialized2")
+
+  "FutureWithSession" should {
+
+    "fail if session is not available" in {
+      val future = FutureWithSession.withCurrentSession("kaboom")
+
+      future.value must eventually(beSome(beFailedTry[String].withThrowable[IllegalStateException](
+        "LiftSession not available in this thread context"
+      )))
+    }
+
+    "succeed with original value if session is available" withSFor "/" in {
+      val future = FutureWithSession.withCurrentSession("works!")
+
+      future.value must eventually(beEqualTo(Some(Success("works!"))))
+    }
+
+    "have access to session variables in Future task" withSFor "/" in {
+      SessionVar1("dzien dobry")
+
+      val future = FutureWithSession.withCurrentSession(SessionVar1.is)
+
+      future.value must eventually(beEqualTo(Some(Success("dzien dobry"))))
+    }
+
+    "have access to request variables in Future task" withSFor "/" in {
+      ReqVar1("guten tag")
+
+      val future = FutureWithSession.withCurrentSession(ReqVar1.is)
+
+      future.value must eventually(beEqualTo(Some(Success("guten tag"))))
+    }
+
+    "have access to session variables in onComplete()" withSFor "/" in {
+      // workaround for a possible race condition in SessionVar
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      SessionVar1.is
+
+      val future = FutureWithSession.withCurrentSession("thorgal")
+      future.onComplete {
+        case Success(v) => SessionVar1(v)
+        case Failure(reason) => ko("Future execution failed: " + reason)
+      }
+
+      SessionVar1.is must eventually(beEqualTo("thorgal"))
+    }
+
+    "have access to request variables in onComplete()" withSFor "/" in {
+      val future = FutureWithSession.withCurrentSession("thor")
+      future.onComplete {
+        case Success(v) => ReqVar1(v)
+        case Failure(reason) => ko("Future execution failed: " + reason)
+      }
+
+      ReqVar1.is must eventually(beEqualTo("thor"))
+    }
+
+    "have access to session variables in chains of map()" withSFor "/" in {
+      SessionVar1("b")
+      SessionVar2("c")
+
+      val future = FutureWithSession.withCurrentSession("a")
+      val mapped = future.map(_ + SessionVar1.is).map(_ + SessionVar2.is)
+
+      mapped.value must eventually(beEqualTo(Some(Success("abc"))))
+    }
+
+    "have access to request variables in chains of map()" withSFor "/" in {
+      ReqVar1("b")
+      ReqVar2("c")
+
+      val future = FutureWithSession.withCurrentSession("a")
+      val mapped = future.map(_ + ReqVar1.is).map(_ + ReqVar2.is)
+
+      mapped.value must eventually(beEqualTo(Some(Success("abc"))))
+    }
+
+    "have access to session variables in chains of flatMap()" withSFor "/" in {
+      SessionVar1("e")
+      SessionVar2("f")
+
+      val future = FutureWithSession.withCurrentSession("d")
+      val mapped = future
+        .flatMap { s => val out = s + SessionVar1.is; Future(out) }
+        .flatMap { s => val out = s + SessionVar2.is; Future(out) }
+
+      mapped.value must eventually(beEqualTo(Some(Success("def"))))
+    }
+
+    "have access to request variables in chains of flatMap()" withSFor "/" in {
+      ReqVar1("e")
+      ReqVar2("f")
+
+      val future = FutureWithSession.withCurrentSession("d")
+      val mapped = future
+        .flatMap { s => val out = s + ReqVar1.is; Future(out) }
+        .flatMap { s => val out = s + ReqVar2.is; Future(out) }
+
+      mapped.value must eventually(beEqualTo(Some(Success("def"))))
+    }
+
+    "have access to session variables in chains of andThen()" withSFor "/" in {
+      // workaround for a possible race condition in SessionVar
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      SessionVar1.is
+      SessionVar2.is
+
+      val future = FutureWithSession.withCurrentSession("rambo")
+        .andThen { case Success(v) => SessionVar1(v) }
+        .andThen { case Success(v) => SessionVar2(v) }
+
+      SessionVar1.is must eventually(beEqualTo("rambo"))
+      SessionVar2.is must eventually(beEqualTo("rambo"))
+      future.value must eventually(beEqualTo(Some(Success("rambo"))))
+    }
+
+    "have access to request variables in chains of andThen()" withSFor "/" in {
+      val future = FutureWithSession.withCurrentSession("conan")
+        .andThen { case Success(v) => ReqVar1(v) }
+        .andThen { case Success(v) => ReqVar2(v) }
+
+      ReqVar1.is must eventually(beEqualTo("conan"))
+      ReqVar2.is must eventually(beEqualTo("conan"))
+      future.value must eventually(beEqualTo(Some(Success("conan"))))
+    }
+
+    "have access to session variables in failed projection" withSFor "/" in {
+      SessionVar1("on purpose")
+
+      val future = FutureWithSession.withCurrentSession(throw new Exception("failed")).failed.collect {
+        case e: Exception => e.getMessage + " " + SessionVar1.is
+      }
+
+      future.value must eventually(beEqualTo(Some(Success("failed on purpose"))))
+    }
+
+    "have access to request variables in failed projection" withSFor "/" in {
+      ReqVar1("on purpose")
+
+      val future = FutureWithSession.withCurrentSession(throw new Exception("failed")).failed.collect {
+        case e: Exception => e.getMessage + " " + ReqVar1.is
+      }
+
+      future.value must eventually(beEqualTo(Some(Success("failed on purpose"))))
+    }
+
+    "have access to session variables in fallbackTo() result" withSFor "/" in {
+      SessionVar1("result")
+
+      val future = FutureWithSession.withCurrentSession(throw new Exception("failed"))
+        .fallbackTo(Future("fallback")).map(_ + " " + SessionVar1.is)
+
+      future.value must eventually(beEqualTo(Some(Success("fallback result"))))
+    }
+
+    "have access to request variables in fallbackTo() result" withSFor "/" in {
+      ReqVar1("result")
+
+      val future = FutureWithSession.withCurrentSession(throw new Exception("failed"))
+        .fallbackTo(Future("fallback")).map(_ + " " + ReqVar1.is)
+
+      future.value must eventually(beEqualTo(Some(Success("fallback result"))))
+    }
+
+    "have access to session variables with recover()" withSFor "/" in {
+      SessionVar1("g")
+      SessionVar2("h")
+
+      val future = FutureWithSession.withCurrentSession(throw new Exception("failed"))
+        .recover { case e: Exception => e.getMessage + " " + SessionVar1.is }
+        .map(_ + SessionVar2.is)
+
+      future.value must eventually(beEqualTo(Some(Success("failed gh"))))
+    }
+
+    "have access to request variables with recover()" withSFor "/" in {
+      ReqVar1("g")
+      ReqVar2("h")
+
+      val future = FutureWithSession.withCurrentSession(throw new Exception("failed"))
+        .recover { case e: Exception => e.getMessage + " " + ReqVar1.is }
+        .map(_ + ReqVar2.is)
+
+      future.value must eventually(beEqualTo(Some(Success("failed gh"))))
+    }
+
+    "have access to session variables with recoverWith()" withSFor "/" in {
+      SessionVar1("i")
+      SessionVar2("j")
+
+      val future = FutureWithSession.withCurrentSession(throw new Exception("failed"))
+        .recoverWith { case e: Exception => val out = e.getMessage + " " + SessionVar1.is; Future(out) }
+        .map(_ + SessionVar2.is)
+
+      future.value must eventually(beEqualTo(Some(Success("failed ij"))))
+    }
+
+    "have access to request variables with recoverWith()" withSFor "/" in {
+      ReqVar1("k")
+      ReqVar2("l")
+
+      val future = FutureWithSession.withCurrentSession(throw new Exception("failed"))
+        .recoverWith { case e: Exception => val out = e.getMessage + " " + ReqVar1.is; Future(out) }
+        .map(_ + ReqVar2.is)
+
+      future.value must eventually(beEqualTo(Some(Success("failed kl"))))
+    }
+
+    "have access to session variables with transform()" withSFor "/" in {
+      SessionVar1("john")
+      SessionVar2("rambo")
+
+      val future = FutureWithSession.withCurrentSession("something")
+        .transform(s => throw new Exception(SessionVar1.is), identity[Throwable])
+        .transform(identity[String], t => new Exception(t.getMessage + " " + SessionVar2.is))
+        .recover { case e: Exception => e.getMessage }
+
+      future.value must eventually(beEqualTo(Some(Success("john rambo"))))
+    }
+
+    "have access to request variables with transform()" withSFor "/" in {
+      ReqVar1("chuck")
+      ReqVar2("norris")
+
+      val future = FutureWithSession.withCurrentSession("something")
+        .transform(s => throw new Exception(ReqVar1.is), identity[Throwable])
+        .transform(identity[String], t => new Exception(t.getMessage + " " + ReqVar2.is))
+        .recover { case e: Exception => e.getMessage }
+
+      future.value must eventually(beEqualTo(Some(Success("chuck norris"))))
+    }
+
+    "yield another session aware future with zip()" withSFor "/" in {
+      ReqVar1("a")
+      SessionVar1("hero")
+
+      val future = FutureWithSession.withCurrentSession("gotham")
+        .zip(Future("needs"))
+        .collect { case (one, two) => one + two + ReqVar1.is + SessionVar1.is }
+
+      future.value must eventually(beEqualTo(Some(Success("gothamneedsahero"))))
+    }
+
+    "not leak out initial session between threads with their own sessions" in {
+      val session1 = new LiftSession("Test session 1", "", Empty)
+      val session2 = new LiftSession("Test session 2", "", Empty)
+      val session3 = new LiftSession("Test session 3", "", Empty)
+
+      S.initIfUninitted(session1)(SessionVar1("one"))
+      S.initIfUninitted(session2)(SessionVar1("two"))
+      S.initIfUninitted(session3)(SessionVar1("three"))
+
+      val future = S.initIfUninitted(session1)(FutureWithSession.withCurrentSession("zero"))
+
+      S.initIfUninitted(session2) {
+        val mapped = future.map(v => SessionVar1.is)
+        mapped.value must eventually(beEqualTo(Some(Success("two"))))
+      }
+
+      S.initIfUninitted(session3) {
+        val mapped = future.map(v => SessionVar1.is)
+        mapped.value must eventually(beEqualTo(Some(Success("three"))))
+      }
+
+      S.initIfUninitted(session1) {
+        val mapped = future.map(v => SessionVar1.is)
+        mapped.value must eventually(beEqualTo(Some(Success("one"))))
+      }
+    }
+  }
+}

--- a/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
@@ -235,8 +235,14 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
 
       val future = LAFutureWithSession.withCurrentSession("d")
       val mapped = future
-        .flatMap { s => val out = s + SessionVar1.is; LAFuture.build(out) }
-        .flatMap { s => val out = s + SessionVar2.is; LAFuture.build(out) }
+        .flatMap { s =>
+          val out = s + SessionVar1.is
+          LAFuture.build(out)
+        }
+        .flatMap { s =>
+          val out = s + SessionVar2.is
+          LAFuture.build(out)
+        }
 
       mapped.get(timeout) must_== Full("def")
     }
@@ -247,8 +253,14 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
 
       val future = LAFutureWithSession.withCurrentSession("d")
       val mapped = future
-        .flatMap { s => val out = s + ReqVar1.is; LAFuture.build(out) }
-        .flatMap { s => val out = s + ReqVar2.is; LAFuture.build(out) }
+        .flatMap { s =>
+          val out = s + ReqVar1.is
+          LAFuture.build(out)
+        }
+        .flatMap { s =>
+          val out = s + ReqVar2.is
+          LAFuture.build(out)
+        }
 
       mapped.get(timeout) must_== Full("def")
     }

--- a/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
@@ -48,7 +48,7 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
     }
 
     "have access to session variables in onComplete()" withSFor "/" in {
-      // workaround for a possible race condition in SessionVar
+      // workaround for a possible race condition in AnyVarTrait
       // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
       SessionVar1.is
 
@@ -63,6 +63,10 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
     }
 
     "have access to request variables in onComplete()" withSFor "/" in {
+      // workaround for a possible race condition in AnyVarTrait
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      ReqVar1.is
+
       val future = LAFutureWithSession.withCurrentSession("thor")
       future.onComplete {
         case Full(v) => ReqVar1(v)
@@ -89,6 +93,10 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
     }
 
     "have access to request variables on onFail()" withSFor "/" in {
+      // workaround for a possible race condition in AnyVarTrait
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      ReqVar1.is
+
       val future = LAFutureWithSession.withCurrentSession("geralt")
       future.fail(new Exception("nope!"))
 
@@ -101,6 +109,10 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
     }
 
     "have access to session variables in onSuccess()" withSFor "/" in {
+      // workaround for a possible race condition in AnyVarTrait
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      SessionVar1.is
+
       val future = LAFutureWithSession.withCurrentSession("cookie monster")
       future.satisfy("done")
 
@@ -110,6 +122,10 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
     }
 
     "have access to request variables in onSuccess()" withSFor "/" in {
+      // workaround for a possible race condition in AnyVarTrait
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      ReqVar1.is
+
       val future = LAFutureWithSession.withCurrentSession("gollum")
       future.satisfy("my precious")
 
@@ -211,6 +227,10 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
     }
 
     "have access to session variables in foreach()" withSFor "/" in {
+      // workaround for a possible race condition in AnyVarTrait
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      SessionVar1.is
+
       val future = LAFutureWithSession.withCurrentSession("cookie")
       future.foreach(SessionVar1(_))
 
@@ -218,6 +238,10 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
     }
 
     "have access to request variables in foreach()" withSFor "/" in {
+      // workaround for a possible race condition in AnyVarTrait
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      ReqVar1.is
+
       val future = LAFutureWithSession.withCurrentSession("monster")
       future.foreach(ReqVar1(_))
 

--- a/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
@@ -1,0 +1,251 @@
+package net.liftweb.http
+
+import net.liftweb.actor.LAFuture
+import net.liftweb.common.{Empty, Failure, Full}
+import net.liftweb.mockweb.WebSpec
+import org.specs2.matcher.ThrownMessages
+
+class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
+
+  sequential
+
+  object SessionVar1 extends SessionVar[String]("Uninitialized1")
+  object SessionVar2 extends SessionVar[String]("Uninitialized2")
+
+  object ReqVar1 extends RequestVar[String]("Uninitialized1")
+  object ReqVar2 extends RequestVar[String]("Uninitialized2")
+
+  val timeout = 10000L
+
+  "LAFutureWithSession" should {
+
+    "fail if session is not available" in {
+      val future = LAFutureWithSession.withCurrentSession("kaboom")
+
+      future.get(timeout) must_== Failure("LiftSession not available in this thread context", Empty, Empty)
+    }
+
+    "succeed with original value if session is available" withSFor "/" in {
+      val future = LAFutureWithSession.withCurrentSession("works!")
+
+      future.get(timeout) must_== Full("works!")
+    }
+
+    "have access to session variables in LAFuture task" withSFor "/" in {
+      SessionVar1("dzien dobry")
+
+      val future = LAFutureWithSession.withCurrentSession(SessionVar1.is)
+
+      future.get(timeout) must_== Full("dzien dobry")
+    }
+
+    "have access to request variables in LAFuture task" withSFor "/" in {
+      ReqVar1("guten tag")
+
+      val future = LAFutureWithSession.withCurrentSession(ReqVar1.is)
+
+      future.get(timeout) must_== Full("guten tag")
+    }
+
+    "have access to session variables in onComplete()" withSFor "/" in {
+      // workaround for a possible race condition in SessionVar
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      SessionVar1.is
+
+      val future = LAFutureWithSession.withCurrentSession("thorgal")
+
+      future.onComplete {
+        case Full(v) => SessionVar1(v)
+        case problem => ko("Future computation failed: " + problem)
+      }
+
+      SessionVar1.is must eventually(beEqualTo("thorgal"))
+    }
+
+    "have access to request variables in onComplete()" withSFor "/" in {
+      val future = LAFutureWithSession.withCurrentSession("thor")
+      future.onComplete {
+        case Full(v) => ReqVar1(v)
+        case problem => ko("Future computation failed: " + problem)
+      }
+
+      ReqVar1.is must eventually(beEqualTo("thor"))
+    }
+
+    "have access to session variables in onFail()" withSFor "/" in {
+      // workaround for a possible race condition in SessionVar
+      // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
+      SessionVar1.is
+
+      val future = LAFutureWithSession.withCurrentSession("geralt")
+      future.fail(new Exception("kaboom!"))
+
+      future.onFail {
+        case f: Failure => SessionVar1(f.msg)
+        case _ => fail("The Future should have failed")
+      }
+
+      SessionVar1.is must eventually(beEqualTo("kaboom!"))
+    }
+
+    "have access to request variables on onFail()" withSFor "/" in {
+      val future = LAFutureWithSession.withCurrentSession("geralt")
+      future.fail(new Exception("nope!"))
+
+      future.onFail {
+        case f: Failure => ReqVar1(f.msg)
+        case _ => fail("The Future should have failed")
+      }
+
+      ReqVar1.is must eventually(beEqualTo("nope!"))
+    }
+
+    "have access to session variables in onSuccess()" withSFor "/" in {
+      val future = LAFutureWithSession.withCurrentSession("cookie monster")
+      future.satisfy("done")
+
+      future.onSuccess(SessionVar1(_))
+
+      SessionVar1.is must eventually(beEqualTo("done"))
+    }
+
+    "have access to request variables in onSuccess()" withSFor "/" in {
+      val future = LAFutureWithSession.withCurrentSession("gollum")
+      future.satisfy("my precious")
+
+      future.onSuccess(ReqVar1(_))
+
+      ReqVar1.is must eventually(beEqualTo("my precious"))
+    }
+
+    "have access to session variables in chains of filter()" withSFor "/" in {
+      SessionVar1("see")
+      SessionVar2("me")
+
+      val future = LAFutureWithSession.withCurrentSession("they see me rollin")
+      val filtered = future
+        .filter(_.contains(SessionVar1.is))
+        .filter(_.contains(SessionVar2.is))
+
+      filtered.get(timeout) must eventually(beEqualTo(Full("they see me rollin")))
+    }
+
+    "have access to request variables in chains of filter()" withSFor "/" in {
+      ReqVar1("see")
+      ReqVar2("me")
+
+      val future = LAFutureWithSession.withCurrentSession("they see me rollin")
+      val filtered = future
+        .filter(_.contains(ReqVar1.is))
+        .filter(_.contains(ReqVar2.is))
+
+      filtered.get(timeout) must eventually(beEqualTo("they see me rollin"))
+    }
+
+    "have access to session variables in chains of withFilter()" withSFor "/" in {
+      SessionVar1("come")
+      SessionVar2("prey")
+
+      val future = LAFutureWithSession.withCurrentSession("do not come between the nazgul and his prey")
+      val filtered = future
+        .withFilter(_.contains(SessionVar1.is))
+        .withFilter(_.contains(SessionVar2.is))
+
+      filtered.get(timeout) must eventually(beEqualTo("do not come between the nazgul and his prey"))
+    }
+
+    "have access to request variables in chains of withFilter()" withSFor "/" in {
+      ReqVar1("hurt")
+      ReqVar2("precious")
+
+      val future = LAFutureWithSession.withCurrentSession("mustn't go that way, mustn't hurt the precious!")
+      val filtered = future
+        .withFilter(_.contains(ReqVar1.is))
+        .withFilter(_.contains(ReqVar2.is))
+
+      filtered.get(timeout) must eventually(beEqualTo("mustn't go that way, mustn't hurt the precious!"))
+    }
+
+    "have access to session variables in chains of map()" withSFor "/" in {
+      SessionVar1("b")
+      SessionVar2("c")
+
+      val future = LAFutureWithSession.withCurrentSession("a")
+      val mapped = future.map(_ + SessionVar1.is).map(_ + SessionVar2.is)
+
+      mapped.get(timeout) must_== Full("abc")
+    }
+
+    "have access to request variables in chains of map()" withSFor "/" in {
+      ReqVar1("b")
+      ReqVar2("c")
+
+      val future = LAFutureWithSession.withCurrentSession("a")
+      val mapped = future.map(_ + ReqVar1.is).map(_ + ReqVar2.is)
+
+      mapped.get(timeout) must_== Full("abc")
+    }
+
+    "have access to session variables in chains of flatMap()" withSFor "/" in {
+      SessionVar1("e")
+      SessionVar2("f")
+
+      val future = LAFutureWithSession.withCurrentSession("d")
+      val mapped = future
+        .flatMap { s => val out = s + SessionVar1.is; LAFuture.build(out) }
+        .flatMap { s => val out = s + SessionVar2.is; LAFuture.build(out) }
+
+      mapped.get(timeout) must_== Full("def")
+    }
+
+    "have access to request variables in chains of flatMap()" withSFor "/" in {
+      ReqVar1("e")
+      ReqVar2("f")
+
+      val future = LAFutureWithSession.withCurrentSession("d")
+      val mapped = future
+        .flatMap { s => val out = s + ReqVar1.is; LAFuture.build(out) }
+        .flatMap { s => val out = s + ReqVar2.is; LAFuture.build(out) }
+
+      mapped.get(timeout) must_== Full("def")
+    }
+
+    "have access to session variables in foreach()" withSFor "/" in {
+      val future = LAFutureWithSession.withCurrentSession("cookie")
+      future.foreach(SessionVar1(_))
+
+      SessionVar1.is must eventually(beEqualTo("cookie"))
+    }
+
+    "have access to request variables in foreach()" withSFor "/" in {
+      val future = LAFutureWithSession.withCurrentSession("monster")
+      future.foreach(ReqVar1(_))
+
+      ReqVar1.is must eventually(beEqualTo("monster"))
+    }
+
+    "not leak out initial session between threads with their own sessions" in {
+      val session1 = new LiftSession("Test session 1", "", Empty)
+      val session2 = new LiftSession("Test session 2", "", Empty)
+      val session3 = new LiftSession("Test session 3", "", Empty)
+
+      S.initIfUninitted(session1)(SessionVar1("one"))
+      S.initIfUninitted(session2)(SessionVar1("two"))
+      S.initIfUninitted(session3)(SessionVar1("three"))
+
+      val future = S.initIfUninitted(session1)(LAFutureWithSession.withCurrentSession("zero"))
+
+      S.initIfUninitted(session2) {
+        future.map(v => SessionVar1.is).get(timeout) must eventually(beEqualTo("two"))
+      }
+
+      S.initIfUninitted(session3) {
+        future.map(v => SessionVar1.is).get(timeout) must eventually(beEqualTo("three"))
+      }
+
+      S.initIfUninitted(session1) {
+        future.map(v => SessionVar1.is).get(timeout) must eventually(beEqualTo("one"))
+      }
+    }
+  }
+}

--- a/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LAFutureWithSessionSpec.scala
@@ -52,12 +52,17 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
       // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
       SessionVar1.is
 
-      val future = LAFutureWithSession.withCurrentSession("thorgal")
+      val future = LAFutureWithSession.withCurrentSession {
+        Thread.sleep(Long.MaxValue)
+        "292 billion years"
+      }
 
       future.onComplete {
         case Full(v) => SessionVar1(v)
         case problem => ko("Future computation failed: " + problem)
       }
+
+      future.satisfy("thorgal")
 
       SessionVar1.is must eventually(beEqualTo("thorgal"))
     }
@@ -67,11 +72,17 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
       // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
       ReqVar1.is
 
-      val future = LAFutureWithSession.withCurrentSession("thor")
+      val future = LAFutureWithSession.withCurrentSession {
+        Thread.sleep(Long.MaxValue)
+        "292 billion years"
+      }
+
       future.onComplete {
         case Full(v) => ReqVar1(v)
         case problem => ko("Future computation failed: " + problem)
       }
+
+      future.satisfy("thor")
 
       ReqVar1.is must eventually(beEqualTo("thor"))
     }
@@ -81,29 +92,37 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
       // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
       SessionVar1.is
 
-      val future = LAFutureWithSession.withCurrentSession("geralt")
-      future.fail(new Exception("kaboom!"))
+      val future = LAFutureWithSession.withCurrentSession {
+        Thread.sleep(Long.MaxValue)
+        "292 billion years"
+      }
 
       future.onFail {
         case f: Failure => SessionVar1(f.msg)
         case _ => fail("The Future should have failed")
       }
 
+      future.fail(new Exception("kaboom!"))
+
       SessionVar1.is must eventually(beEqualTo("kaboom!"))
     }
 
-    "have access to request variables on onFail()" withSFor "/" in {
+    "have access to request variables in onFail()" withSFor "/" in {
       // workaround for a possible race condition in AnyVarTrait
       // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
       ReqVar1.is
 
-      val future = LAFutureWithSession.withCurrentSession("geralt")
-      future.fail(new Exception("nope!"))
+      val future = LAFutureWithSession.withCurrentSession {
+        Thread.sleep(Long.MaxValue)
+        "292 billion years"
+      }
 
       future.onFail {
         case f: Failure => ReqVar1(f.msg)
         case _ => fail("The Future should have failed")
       }
+
+      future.fail(new Exception("nope!"))
 
       ReqVar1.is must eventually(beEqualTo("nope!"))
     }
@@ -113,10 +132,14 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
       // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
       SessionVar1.is
 
-      val future = LAFutureWithSession.withCurrentSession("cookie monster")
-      future.satisfy("done")
+      val future = LAFutureWithSession.withCurrentSession {
+        Thread.sleep(Long.MaxValue)
+        "292 billion years"
+      }
 
       future.onSuccess(SessionVar1(_))
+
+      future.satisfy("done")
 
       SessionVar1.is must eventually(beEqualTo("done"))
     }
@@ -126,12 +149,16 @@ class LAFutureWithSessionSpec extends WebSpec with ThrownMessages {
       // https://groups.google.com/forum/#!topic/liftweb/V1pWy14Wl3A
       ReqVar1.is
 
-      val future = LAFutureWithSession.withCurrentSession("gollum")
-      future.satisfy("my precious")
+      val future = LAFutureWithSession.withCurrentSession {
+        Thread.sleep(Long.MaxValue)
+        "292 billion years"
+      }
 
       future.onSuccess(ReqVar1(_))
 
-      ReqVar1.is must eventually(beEqualTo("my precious"))
+      future.satisfy("my preciousss")
+
+      ReqVar1.is must eventually(beEqualTo("my preciousss"))
     }
 
     "have access to session variables in chains of filter()" withSFor "/" in {


### PR DESCRIPTION
Session-aware futures seems to be a recurring pain point in many projects. In the one I work, we often use `Future`s to lazy-load some part of a page, e.g. retrieve a list of users from a database and then apply Lift bindings on them. 

In Lift3 `Future` template binding is straightforward but one thing is still missing: you can’t access session from them which is not so crazy as it might sound. 

Continuing with users from database example, say that we retrieved a `Future[Seq]` of users and now we want to `.map` it to produce bindings that will be later bound to element. In that bindings, we’d like to use `S.?` to render localised user type text. Currently it’s not possible, because session will not be available in thread doing `.map` call.

We already have a PR addressing this issue https://github.com/lift/framework/pull/1730 but there are few things missing there in my opinion:
- lack of `ReqVar` access. I think that we should offer the same access scope as `LazyLoad` that we already have in Lift
- lack of session access in `Future` / `LAFuture` body
- We shouldn’t use `CommonLoanWrapper` for session context wrapping, because `CommonLoanWrapper` acts lazily which may lead to session wrapping to be done in separate thread which is too late. We need to enrich function with session access eagerly. 

Sample usage of feature implemented in this PR can be:

```
<div id="main" data-lift="HelloWorld.render">
  Future: <span id="scala-future">Time goes here</span><br/>
  LAFuture: <span id="lift-future">Time goes here</span>
</div>
```

```
class HelloWorld {

  def render = {
    "#lift-future *" #> LAFutureWithSession.withCurrentSession {
      Thread.sleep(3000);
      S ? ("general-futureCompleted", date)
    }.map(s => s"$s in request from = ${S.request.map(_.userAgent).openOrThrowException("No request!")}") &
    "#scala-future *" #> FutureWithSession.withCurrentSession {
      Thread.sleep(1000);
      S ? ("general-futureCompleted", date)
    }.map(s => s"$s in request from = ${S.request.map(_.userAgent).openOrThrowException("No request!")}")
  }

  private def date: String = {
    new SimpleDateFormat("yyyy/MM/dd HH:mm:ss").format(new Date())
  }
}
```

Mailing list reference: https://groups.google.com/forum/#!topic/liftweb/qXDBuSTfWnw
