### PR TITLE
JZoom: 2x-10x lift-json performance improvements in some cases

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -171,34 +171,32 @@ object JsonParser {
     else d.doubleValue
   }
 
+  private[this] case class IntermediateJObject(fields: scala.collection.mutable.ListBuffer[JField])
+  private[this] case class IntermediateJArray(bits: scala.collection.mutable.ListBuffer[JValue])
+
   private val astParser = (p: Parser) => {
     val vals = new ValStack(p)
     var token: Token = null
     var root: Option[JValue] = None
 
-    // This is a slightly faster way to correct order of fields and arrays than using 'map'.
-    def reverse(v: JValue): JValue = v match {
-      case JObject(l) => JObject((l.map { field => field.copy(value = reverse(field.value)) }).reverse)
-      case JArray(l) => JArray(l.map(reverse).reverse)
-      case x => x
-    }
-
     def closeBlock(v: Any) {
       @inline def toJValue(x: Any) = x match {
         case json: JValue => json
+        case other: IntermediateJObject => JObject(other.fields.result)
+        case other: IntermediateJArray => JArray(other.bits.result)
         case _ => p.fail("unexpected field " + x)
       }
 
       vals.peekOption match {
         case Some(JField(name: String, value)) =>
           vals.pop(classOf[JField])
-          val obj = vals.peek(classOf[JObject])
-          vals.replace(JObject(JField(name, toJValue(v)) :: obj.obj))
-        case Some(o: JObject) => 
-          vals.replace(JObject(vals.peek(classOf[JField]) :: o.obj))
-        case Some(a: JArray) => vals.replace(JArray(toJValue(v) :: a.arr))
+          val obj = vals.peek(classOf[IntermediateJObject])
+          obj.fields.append(JField(name, toJValue(v)))
+        case Some(o: IntermediateJObject) => 
+          o.fields.append(vals.peek(classOf[JField]))
+        case Some(a: IntermediateJArray) => a.bits.append(toJValue(v))
         case Some(x) => p.fail("expected field, array or object but got " + x)
-        case None => root = Some(reverse(toJValue(v)))
+        case None => root = Some(toJValue(v))
       }
     }
 
@@ -207,9 +205,9 @@ object JsonParser {
         vals.peekAny match {
           case JField(name, value) =>
             vals.pop(classOf[JField])
-            val obj = vals.peek(classOf[JObject])
-            vals.replace(JObject(JField(name, v) :: obj.obj))
-          case a: JArray => vals.replace(JArray(v :: a.arr))
+            val obj = vals.peek(classOf[IntermediateJObject])
+            obj.fields.append(JField(name,v))
+          case a: IntermediateJArray => a.bits.append(v)
           case other => p.fail("expected field or array but got " + other)
       } else {
         vals.push(v)
@@ -220,7 +218,7 @@ object JsonParser {
     do {
       token = p.nextToken
       token match {
-        case OpenObj          => vals.push(JObject(Nil))
+        case OpenObj          => vals.push(IntermediateJObject(scala.collection.mutable.ListBuffer()))
         case FieldStart(name) => vals.push(JField(name, null))
         case StringVal(x)     => newValue(JString(x))
         case IntVal(x)        => newValue(JInt(x))
@@ -228,8 +226,8 @@ object JsonParser {
         case BoolVal(x)       => newValue(JBool(x))
         case NullVal          => newValue(JNull)
         case CloseObj         => closeBlock(vals.popAny)
-        case OpenArr          => vals.push(JArray(Nil))
-        case CloseArr         => closeBlock(vals.pop(classOf[JArray]))
+        case OpenArr          => vals.push(IntermediateJArray(scala.collection.mutable.ListBuffer()))
+        case CloseArr         => closeBlock(vals.popAny)
         case End              =>
       }
     } while (token != End)

--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -162,9 +162,11 @@ object JsonParser {
       }
     }
     buf.eofIsFailure = false
-    forcedReturn match {
-      case null => new String(buf.substring())
-      case _ => forcedReturn
+
+    if (forcedReturn == null) {
+      new String(buf.substring())
+    } else {
+      forcedReturn
     }
   }
 
@@ -408,7 +410,7 @@ object JsonParser {
 
     // Mark the current point so that future substring calls will extract the
     // value from this point to whatever point the buffer has advanced to.
-    final def mark = {
+    def mark = {
       if (curSegmentIdx > 0) {
         segments(0) = segments.remove(curSegmentIdx)
         curSegmentIdx = 0
@@ -417,11 +419,11 @@ object JsonParser {
       curMark = cur
       curMarkSegment = curSegmentIdx
     }
-    final def back = cur = cur-1
-    final def forward = cur = cur+1
+    def back = cur = cur-1
+    def forward = cur = cur+1
 
     // Read the next character; reads new data from the reader if necessary.
-    final def next: Char = {
+    def next: Char = {
       if (cur >= offset && read < 0) {
         if (eofIsFailure) throw new ParseException("unexpected eof", null) else EOF
       } else {

--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -162,13 +162,8 @@ object JsonParser {
     }
   }
 
-  // FIXME fail fast to prevent infinite loop, see 
-  // http://www.exploringbinary.com/java-hangs-when-converting-2-2250738585072012e-308/
-  private val BrokenDouble = BigDecimal("2.2250738585072012e-308")
   private[json] def parseDouble(s: String) = {
-    val d = BigDecimal(s)
-    if (d == BrokenDouble) sys.error("Error parsing 2.2250738585072012e-308")
-    else d.doubleValue
+    s.toDouble
   }
 
   private[this] case class IntermediateJObject(fields: scala.collection.mutable.ListBuffer[JField])
@@ -305,7 +300,7 @@ object JsonParser {
         buf.back
         (doubleVal: @switch) match {
           case true =>
-            DoubleVal(BigDecimal(new String(value)).doubleValue)
+            DoubleVal(parseDouble(new String(value)))
           case false =>
             IntVal(BigInt(new String(value)))
         }

--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -271,7 +271,14 @@ object JsonParser {
     /** Parse next Token from stream.
      */
     def nextToken: Token = {
-      def isDelimiter(c: Char) = c == ' ' || c == '\n' || c == ',' || c == '\r' || c == '\t' || c == '}' || c == ']'
+      def isDelimiter(c: Char) = {
+        (c: @switch) match {
+          case ' ' | '\n' | ',' | '\r' | '\t' | '}' | ']' =>
+            true
+          case _ =>
+            false
+        }
+      }
 
       def parseString: String = 
         try {

--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -180,7 +180,7 @@ object JsonParser {
     // object or array, gather up all their component parts and create the final
     // object or array.
     def closeBlock(v: Any) {
-      @inline def toJValue(x: Any) = x match {
+      def toJValue(x: Any) = x match {
         case json: JValue => json
         case other: IntermediateJObject => JObject(other.fields.result)
         case other: IntermediateJArray => JArray(other.bits.result)

--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -266,7 +266,7 @@ object JsonParser {
     private[this] val blocks = new ArrayDeque[BlockMode](32)
     private[this] var fieldNameMode = true
 
-    def fail(msg: String) = throw new ParseException(msg + "\nNear: " + buf.near, null)
+    def fail(msg: String, cause: Exception = null) = throw new ParseException(msg + "\nNear: " + buf.near, cause)
 
     /** Parse next Token from stream.
      */
@@ -276,7 +276,7 @@ object JsonParser {
           unquote(buf)
         } catch {
           case p: ParseException => throw p
-          case _: Exception => fail("unexpected string end")
+          case cause: Exception => fail("unexpected string end", cause)
         }
 
       def parseValue(first: Char) = {

--- a/core/json/src/test/scala/net/liftweb/json/JsonParserSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonParserSpec.scala
@@ -42,12 +42,6 @@ object JsonParserSpec extends Specification with JValueGen with ScalaCheck {
     forAll(genJValue)(parsing)
   }
 
-  "Buffer size does not change parsing result" in {
-    val bufSize = Gen.choose(2, 64)
-    val parsing = (x: JValue, s1: Int, s2: Int) => { parseVal(x, s1) == parseVal(x, s2) }
-    forAll(genObject, bufSize, bufSize)(parsing)
-  }
-
   "Parsing is thread safe" in {
     import java.util.concurrent._
 
@@ -90,6 +84,14 @@ object JsonParserSpec extends Specification with JValueGen with ScalaCheck {
 
     val json = JsonParser.parse(new StingyReader(""" ["hello"] """))
     json mustEqual JArray(JString("hello") :: Nil)
+  }
+
+  sequential
+
+  "Segment size does not change parsing result" in {
+    val bufSize = Gen.choose(2, 64)
+    val parsing = (x: JValue, s1: Int, s2: Int) => { parseVal(x, s1) == parseVal(x, s2) }
+    forAll(genObject, bufSize, bufSize)(parsing)
   }
 
   implicit def arbJValue: Arbitrary[JValue] = Arbitrary(genObject)

--- a/core/json/src/test/scala/net/liftweb/json/ParserBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ParserBugs.scala
@@ -26,11 +26,6 @@ object ParserBugs extends Specification {
     parseOpt(""" {"x":"\uffff"} """).isDefined mustEqual true
   }
 
-  "Does not hang when parsing 2.2250738585072012e-308" in {
-    (allCatch.opt(parse(""" [ 2.2250738585072012e-308 ] """)) mustEqual None) and
-      (allCatch.opt(parse(""" [ 22.250738585072012e-309 ] """)) mustEqual None)
-  }
-
   "Does not allow colon at start of array (1039)" in {
     parseOpt("""[:"foo", "bar"]""") mustEqual None
   }


### PR DESCRIPTION
At @elemica we've been using the jawn parser to produce the
lift-json AST due to performance issues in the lift-json parser.
I looked at this a little more deeply over the past few months as
I'm loath to depend on additional libraries if it isn't necessary. The
result has been some work that improves lift-json's performance
2x-10x in several of jawn's benchmarks, as well as an additional
one that involves some large JSON that we've seen at work, bringing
us to the same general performance level as jawn. The benchmarks:

```
Benchmark                           Score      Error      Units        Score     Error
Bla25Bench.jawnStringParse         25.240 ±    2.339      ms/op       25.203 ±   3.041
Bla25Bench.liftParse               44.065 ±    1.594      ms/op       25.772 ±   2.963
                                                                                       
CountriesBench.jawnStringParse      3.854 ±    0.223      ms/op        4.050 ±   0.057
CountriesBench.liftParse            7.122 ±    0.137      ms/op        7.247 ±   0.122
                                                                                       
FlipbookBench.jawnStringParse    1233.372 ±  605.274      ms/op     1187.654 ± 538.381
FlipbookBench.liftParse         20308.247 ± 1467.681      ms/op     1267.820 ± 553.363
                                                                                       
Qux2Bench.jawnStringParse          10.817 ±    0.203      ms/op       11.000 ±   0.353
Qux2Bench.liftParse                19.298 ±    0.516      ms/op       11.413 ±   0.171
                                                                                       
Ugh10kBench.jawnStringParse       307.833 ±   24.139      ms/op      321.164 ±  38.761
Ugh10kBench.liftParse            2024.546 ±   89.060      ms/op      337.198 ±  14.643
```

On the left is the original performance, on the right the performance
with this branch.

The main change here is that we aggressively use mutable state and
aggressively reuse data structures and objects wherever possible to
minimize allocation overhead. Additionally, we rework some of the
conditional logic to be compiled down to switch statements that can
turn into jumps or table lookups in JVM bytecode.

Lastly, we drop the fix for the Java 6 double-parsing vulnerability, since
Lift 3 isn't built for Java 6, Java 7+ are patched, and Java 6 itself has
also been patched.

The changes are a bit gnarly, but ultimately 100% worth it.