### PR TITLE
Upgrade mongo-java-driver to v3.4.0

### DIFF
--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoMapField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoMapField.scala
@@ -91,7 +91,7 @@ class MongoMapField[OwnerType <: BsonRecord[OwnerType], MapValueType](rec: Owner
   def asDBObject: DBObject = {
     val dbo = new BasicDBObject
     value.keys.foreach { k =>
-      dbo.put(k.toString, value.getOrElse(k, ""))
+      value.get(k).foreach(v => dbo.put(k.toString, v.asInstanceOf[Object]))
     }
     dbo
   }

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoMapField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoMapField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2013 WorldWide Conferencing, LLC
+ * Copyright 2010-2016 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,8 +90,10 @@ class MongoMapField[OwnerType <: BsonRecord[OwnerType], MapValueType](rec: Owner
   */
   def asDBObject: DBObject = {
     val dbo = new BasicDBObject
-    value.keys.foreach { k =>
-      value.get(k).foreach(v => dbo.put(k.toString, v.asInstanceOf[Object]))
+    value.keys.foreach { key =>
+      value.get(key).foreach { innerValue =>
+        dbo.put(key.toString, innerValue.asInstanceOf[Object])
+      }
     }
     dbo
   }

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Mongo.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Mongo.scala
@@ -33,23 +33,12 @@ object MongoDB {
   /**
     * HashMap of Mongo instance and db name tuples, keyed by ConnectionIdentifier
     */
-  private val dbs = new ConcurrentHashMap[ConnectionIdentifier, (Mongo, String)]
+  private val dbs = new ConcurrentHashMap[ConnectionIdentifier, (MongoClient, String)]
 
   /**
     * Define a MongoClient db using a MongoClient instance.
     */
   def defineDb(name: ConnectionIdentifier, mngo: MongoClient, dbName: String) {
-    dbs.put(name, (mngo, dbName))
-  }
-
-  /**
-    * Define and authenticate a Mongo db using a MongoClient instance.
-    */
-  @deprecated("Credentials are now passed in via MongoClient", "3.0")
-  def defineDbAuth(name: ConnectionIdentifier, mngo: MongoClient, dbName: String, username: String, password: String) {
-    if (!mngo.getDB(dbName).authenticate(username, password.toCharArray))
-      throw new MongoException("Authorization failed: "+mngo.toString)
-
     dbs.put(name, (mngo, dbName))
   }
 
@@ -119,53 +108,6 @@ object MongoDB {
     }
 
     f(coll)
-  }
-
-  /**
-    * Executes function {@code f} with the mongo db named {@code name}. Uses the same socket
-    * for the entire function block. Allows multiple operations on the same thread/socket connection
-    * and the use of getLastError.
-    * See: http://docs.mongodb.org/ecosystem/drivers/java-concurrency/
-    */
-  @deprecated("No longer needed. See mongo-java-drivers's JavaDocs for details", "3.0")
-  def useSession[T](name: ConnectionIdentifier)(f: (DB) => T): T = {
-
-    val db = getDb(name) match {
-      case Some(mongo) => mongo
-      case _ => throw new MongoException("Mongo not found: "+name.toString)
-    }
-
-    // start the request
-    db.requestStart
-    try {
-      f(db)
-    }
-    finally {
-      // end the request
-      db.requestDone
-    }
-  }
-
-  /**
-    * Same as above except uses DefaultConnectionIdentifier
-    */
-  @deprecated("No longer needed. See mongo-java-drivers's JavaDocs for details", "3.0")
-  def useSession[T](f: (DB) => T): T = {
-
-    val db = getDb(DefaultConnectionIdentifier) match {
-      case Some(mongo) => mongo
-      case _ => throw new MongoException("Mongo not found: "+DefaultConnectionIdentifier.toString)
-    }
-
-    // start the request
-    db.requestStart
-    try {
-      f(db)
-    }
-    finally {
-      // end the request
-      db.requestDone
-    }
   }
 
   /**

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoMeta.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoMeta.scala
@@ -117,41 +117,15 @@ trait MongoMeta[BaseDocument] extends JsonFormats {
   /* drop this document collection */
   def drop: Unit =  useColl { coll => coll.drop }
 
-  /*
-  * Ensure an index exists
-  */
-  @deprecated("use createIndex(JObject) instead.", "2.6")
-  def ensureIndex(keys: JObject): Unit =
-    useColl { coll => coll.createIndex(JObjectParser.parse(keys)) }
-
-  /*
-  * Ensure an index exists and make unique
-  */
-  @deprecated("use createIndex(JObject, Boolean) instead.", "2.6")
-  def ensureIndex(keys: JObject, unique: Boolean): Unit = {
-    val options = new BasicDBObject
-    if (unique) options.put("unique", true)
-    useColl { coll =>
-      coll.createIndex(JObjectParser.parse(keys), options)
-    }
-  }
-
   def createIndex(keys: JObject, unique: Boolean = false): Unit = {
     val options = new BasicDBObject
-    if (unique) options.put("unique", true)
+    if (unique) {
+      options.put("unique", true: java.lang.Boolean)
+    }
     useColl { coll =>
       coll.createIndex(JObjectParser.parse(keys), options)
     }
   }
-
-  /*
-  * Ensure an index exists with options
-  */
-  @deprecated("use createIndex(JObject, JObject) instead.", "2.6")
-  def ensureIndex(keys: JObject, opts: JObject): Unit =
-    useColl { coll =>
-      coll.createIndex(JObjectParser.parse(keys), JObjectParser.parse(opts))
-    }
 
   def createIndex(keys: JObject, opts: JObject): Unit =
     useColl { coll =>

--- a/persistence/mongodb/src/test/resources/logging.properties
+++ b/persistence/mongodb/src/test/resources/logging.properties
@@ -13,4 +13,4 @@ java.util.logging.ConsoleHandler.level = INFO
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
 # Set the default logging level for the named logger
-com.mongodb.level = SEVERE
+org.mongodb.driver.level = WARNING

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectMongoClient.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectMongoClient.scala
@@ -50,15 +50,15 @@ class MongoDirectMongoClientSpec extends Specification with MongoTestKit {
 
       doc.put("name", "MongoSession")
       doc.put("type", "db")
-      doc.put("count", 1)
+      doc.put("count", 1: java.lang.Integer)
 
       doc2.put("name", "MongoSession")
       doc2.put("type", "db")
-      doc2.put("count", 1)
+      doc2.put("count", 1: java.lang.Integer)
 
       doc3.put("name", "MongoDB")
       doc3.put("type", "db")
-      doc3.put("count", 1)
+      doc3.put("count", 1: java.lang.Integer)
 
       // save the docs to the db
       coll.save(doc)

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectSpec.scala
@@ -47,12 +47,12 @@ class MongoDirectSpec extends Specification with MongoTestKit {
 
     doc.put("name", "MongoDB")
     doc.put("type", "database")
-    doc.put("count", 1)
+    doc.put("count", 1: java.lang.Integer)
 
     val info = new BasicDBObject
 
-    info.put("x", 203)
-    info.put("y", 102)
+    info.put("x", 203: java.lang.Integer)
+    info.put("y", 102: java.lang.Integer)
 
     doc.put("info", info)
 
@@ -68,7 +68,7 @@ class MongoDirectSpec extends Specification with MongoTestKit {
 
       // upsert
       doc.put("type", "document")
-      doc.put("count", 2)
+      doc.put("count", 2: java.lang.Integer)
       val q = new BasicDBObject("name", "MongoDB") // the query to select the document(s) to update
       val o = doc // the new object to update with, replaces the entire document, except possibly _id
       val upsert = false // if the database should create the element if it does not exist
@@ -128,8 +128,7 @@ class MongoDirectSpec extends Specification with MongoTestKit {
       cur.count must_== 100
 
       // get a single document with a query ( i = 71 )
-      val query = new BasicDBObject
-      query.put("i", 71)
+      val query = new BasicDBObject("i", 71)
       val cur2 = coll.find(query)
 
       cur2.count must_== 1
@@ -218,15 +217,15 @@ class MongoDirectSpec extends Specification with MongoTestKit {
 
       doc.put("name", "MongoSession")
       doc.put("type", "db")
-      doc.put("count", 1)
+      doc.put("count", 1: java.lang.Integer)
 
       doc2.put("name", "MongoSession")
       doc2.put("type", "db")
-      doc2.put("count", 1)
+      doc2.put("count", 1: java.lang.Integer)
 
       doc3.put("name", "MongoDB")
       doc3.put("type", "db")
-      doc3.put("count", 1)
+      doc3.put("count", 1: java.lang.Integer)
 
       // save the docs to the db
       Helpers.tryo(coll.save(doc, WriteConcern.SAFE)).toOption must beSome

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
   lazy val joda_time              = "joda-time"                  % "joda-time"          % "2.9.2"
   lazy val joda_convert           = "org.joda"                   % "joda-convert"       % "1.8.1"
   lazy val htmlparser             = "nu.validator.htmlparser"    % "htmlparser"         % "1.4"
-  lazy val mongo_java_driver      = "org.mongodb"                % "mongo-java-driver"  % "2.14.0"
+  lazy val mongo_java_driver      = "org.mongodb"                % "mongo-java-driver"  % "3.4.0"
   lazy val paranamer              = "com.thoughtworks.paranamer" % "paranamer"          % "2.8"
   lazy val scalajpa               = "org.scala-libs"             % "scalajpa"           % "1.5"     cross CVMappingAll
   lazy val scalap: ModuleMap      = "org.scala-lang"             % "scalap"             % _


### PR DESCRIPTION
Closes #1814 

I had to remove some functions that were deprecated in Lift 3.0, but I think it's justified here because otherwise, we'd fall pretty far behind on the version of mongo we supported.