### PR TITLE
Fix cross compiling between 2.11 and 2.12.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -56,7 +56,12 @@ object BuildDef extends Build {
   lazy val framework =
     liftProject("lift-framework", file("."))
       .aggregate(liftProjects: _*)
-      .settings(scalacOptions in (Compile, doc) += "-no-java-comments") //workaround for scala/scala-dev#249
+      .settings(scalacOptions in (Compile, doc) ++= Seq(scalaVersion.value).flatMap {
+        case v if v.startsWith("2.12") =>
+          Seq("-no-java-comments")
+        case _ =>
+          Seq()
+      }) //workaround for scala/scala-dev#249
       .settings(aggregatedSetting(sources in(Compile, doc)),
                 aggregatedSetting(dependencyClasspath in(Compile, doc)),
                 publishArtifact := false)
@@ -75,7 +80,12 @@ object BuildDef extends Build {
   lazy val actor =
     coreProject("actor")
         .dependsOn(common)
-        .settings(scalacOptions in (Compile, doc) += "-no-java-comments") //workaround for scala/scala-dev#249
+        .settings(scalacOptions in (Compile, doc) ++= Seq(scalaVersion.value).flatMap {
+          case v if v.startsWith("2.12") =>
+            Seq("-no-java-comments")
+          case _ =>
+            Seq()
+        }) //workaround for scala/scala-dev#249
         .settings(description := "Simple Actor",
                   parallelExecution in Test := false)
 
@@ -131,7 +141,12 @@ object BuildDef extends Build {
   lazy val webkit =
     webProject("webkit")
         .dependsOn(util, testkit % "provided")
-        .settings(scalacOptions in (Compile, doc) += "-no-java-comments") //workaround for scala/scala-dev#249
+        .settings(scalacOptions in (Compile, doc) ++= Seq(scalaVersion.value).flatMap {
+          case v if v.startsWith("2.12") =>
+            Seq("-no-java-comments")
+          case _ =>
+            Seq()
+        }) //workaround for scala/scala-dev#249
         .settings(libraryDependencies ++= Seq(mockito_all, jquery, jasmineCore, jasmineAjax))
         .settings(yuiCompressor.Plugin.yuiSettings: _*)
         .settings(description := "Webkit Library",


### PR DESCRIPTION
Cross-compiling between Scala 2.11 and 2.12 should now work. Looks like the flag we need to work around scala/scala-dev#249 didn't exist in 2.11.

So **hopefully** this finally gets us compiling again!