### PR TITLE
Mongo async support

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -245,3 +245,9 @@ John Marshall
 
 ### Email: ###
 john at themillhousegroup dot com
+
+### Name: ###
+Marek Żebrowski
+
+### Email: ###
+marek.zebrowski at gmail dot com

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoMetaRecord.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoMetaRecord.scala
@@ -305,9 +305,8 @@ trait MongoMetaRecord[BaseRecord <: MongoRecord[BaseRecord]]
       val filter = new Document("_id", doc.get("_id"))
       coll.withWriteConcern(concern).replaceOne(filter, doc, options, new SingleResultCallback[UpdateResult] {
         override def onResult(result: UpdateResult, t: Throwable) = {
-          if (t == null) {
-            val upsertedId = result.getUpsertedId
-            if (upsertedId != null && upsertedId.isObjectId) {
+          if (Option(t).isEmpty) {
+            Option(result.getUpsertedId).filter(_.isObjectId).foreach { upsertedId =>
               inst.fieldByName("_id").foreach(fld => fld.setFromAny(upsertedId.asObjectId().getValue))
             }
             foreachCallback(inst, _.afterSave)

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoMetaRecord.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoMetaRecord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2017 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -296,13 +296,13 @@ trait MongoMetaRecord[BaseRecord <: MongoRecord[BaseRecord]]
     * in similar way as save() from sync api
     *
     */
-  def replaceOneAsync(inst: BaseRecord, upsert: Boolean, concern: WriteConcern) = {
+  def replaceOneAsync(inst: BaseRecord, upsert: Boolean = true, concern: WriteConcern = MongoRules.defaultWriteConcern.vend): Future[BaseRecord] = {
     useCollAsync { coll =>
       val p = Promise[BaseRecord]
       val doc: Document = inst.asDocument
       val options = new UpdateOptions().upsert(upsert)
       foreachCallback(inst, _.beforeSave)
-      val filter = new org.bson.Document("_id", doc.get("_id"))
+      val filter = new Document("_id", doc.get("_id"))
       coll.withWriteConcern(concern).replaceOne(filter, doc, options, new SingleResultCallback[UpdateResult] {
         override def onResult(result: UpdateResult, t: Throwable) = {
           if (t == null) {

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoMetaRecord.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoMetaRecord.scala
@@ -263,7 +263,7 @@ trait MongoMetaRecord[BaseRecord <: MongoRecord[BaseRecord]]
     }
   }
 
-  def insertAsync(inst:BaseRecord): Future[Boolean] = {
+  def insertAsync(inst: BaseRecord): Future[Boolean] = {
     useCollAsync { coll =>
       val cb = new SingleBooleanVoidCallback( () => {
         foreachCallback(inst, _.afterSave)
@@ -304,7 +304,7 @@ trait MongoMetaRecord[BaseRecord <: MongoRecord[BaseRecord]]
       foreachCallback(inst, _.beforeSave)
       val filter = new Document("_id", doc.get("_id"))
       coll.withWriteConcern(concern).replaceOne(filter, doc, options, new SingleResultCallback[UpdateResult] {
-        override def onResult(result: UpdateResult, t: Throwable) = {
+        override def onResult(result: UpdateResult, t: Throwable): Unit = {
           if (Option(t).isEmpty) {
             Option(result.getUpsertedId).filter(_.isObjectId).foreach { upsertedId =>
               inst.fieldByName("_id").foreach(fld => fld.setFromAny(upsertedId.asObjectId().getValue))

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoRecord.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoRecord.scala
@@ -25,6 +25,7 @@ import com.mongodb.{BasicDBObject, DBObject, DBRef, WriteConcern}
 
 import org.bson.types.ObjectId
 import common.{Full, Box}
+import scala.concurrent.Future
 
 trait MongoRecord[MyType <: MongoRecord[MyType]] extends BsonRecord[MyType] {
   self: MyType =>
@@ -51,6 +52,15 @@ trait MongoRecord[MyType <: MongoRecord[MyType]] extends BsonRecord[MyType] {
       meta.save(this, concern)
     }
     this
+  }
+
+  /**
+    * Inserts record and returns Future that completes when mongo driver finishes operation
+    */
+  def insertAsync():Future[Boolean] = {
+    runSafe {
+      meta.insertAsync(this)
+    }
   }
 
  /**

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonRecordField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonRecordField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 WorldWide Conferencing, LLC
+ * Copyright 2011-2017 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class BsonRecordField[OwnerType <: BsonRecord[OwnerType], SubRecordType <: BsonR
 
   def setFromAny(in: Any): Box[SubRecordType] = in match {
     case dbo: DBObject => setBox(Full(valueMeta.fromDBObject(dbo)))
-    case dbo: org.bson.Document => setBox(Full(valueMeta.fromDocument(dbo)))
+    case dbo: Document => setBox(Full(valueMeta.fromDocument(dbo)))
     case _ => genericSetFromAny(in)
   }
 

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonRecordField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonRecordField.scala
@@ -24,9 +24,9 @@ import http.js.JsExp
 import http.js.JE.JsNull
 import json.JsonAST._
 import json.Printer
-
 import net.liftweb.record._
 import com.mongodb._
+import org.bson.Document
 
 import scala.xml._
 
@@ -62,6 +62,7 @@ class BsonRecordField[OwnerType <: BsonRecord[OwnerType], SubRecordType <: BsonR
 
   def setFromAny(in: Any): Box[SubRecordType] = in match {
     case dbo: DBObject => setBox(Full(valueMeta.fromDBObject(dbo)))
+    case dbo: org.bson.Document => setBox(Full(valueMeta.fromDocument(dbo)))
     case _ => genericSetFromAny(in)
   }
 
@@ -103,4 +104,11 @@ class BsonRecordListField[OwnerType <: BsonRecord[OwnerType], SubRecordType <: B
     })))
     case other => setBox(FieldHelpers.expectedA("JArray", other))
   }
+
+  override def setFromDocumentList(list: java.util.List[Document]): Box[List[SubRecordType]] = {
+    setBox(Full(list.map{ doc =>
+      valueMeta.fromDocument(doc)
+    }.toList))
+  }
+
 }

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JObjectField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JObjectField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2012 WorldWide Conferencing, LLC
+ * Copyright 2010-2017 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JObjectField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JObjectField.scala
@@ -28,6 +28,7 @@ import net.liftweb.record.{Field, FieldHelpers, MandatoryTypedField}
 import scala.xml.NodeSeq
 
 import com.mongodb._
+import org.bson.Document
 
 class JObjectField[OwnerType <: BsonRecord[OwnerType]](rec: OwnerType)
 extends Field[JObject, OwnerType]
@@ -48,6 +49,7 @@ with MongoFieldFlavor[JObject] {
 
   def setFromAny(in: Any): Box[JObject] = in match {
     case dbo: DBObject => setBox(setFromDBObject(dbo))
+    case doc: Document => setBox(setFromDocument(doc))
     case jv: JObject => setBox(Full(jv))
     case Some(jv: JObject) => setBox(Full(jv))
     case Full(jv: JObject) => setBox(Full(jv))
@@ -73,4 +75,8 @@ with MongoFieldFlavor[JObject] {
 
   def setFromDBObject(obj: DBObject): Box[JObject] =
     Full(JObjectParser.serialize(obj)(owner.meta.formats).asInstanceOf[JObject])
+
+  def setFromDocument(obj: Document): Box[JObject] =
+    Full(JObjectParser.serialize(obj)(owner.meta.formats).asInstanceOf[JObject])
+
 }

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JsonObjectField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JsonObjectField.scala
@@ -17,16 +17,14 @@ package record
 package field
 
 import scala.xml.{NodeSeq, Text}
-
 import net.liftweb.common.{Box, Empty, Failure, Full}
-
 import net.liftweb.http.js.JE.{JsNull, Str}
 import net.liftweb.json.JsonAST._
 import net.liftweb.json.{JsonParser, Printer}
 import net.liftweb.record.{Field, FieldHelpers, MandatoryTypedField, Record}
 import net.liftweb.util.Helpers.tryo
-
 import com.mongodb.DBObject
+import org.bson.Document
 
 abstract class JsonObjectField[OwnerType <: BsonRecord[OwnerType], JObjectType <: JsonObject[JObjectType]]
   (rec: OwnerType, valueMeta: JsonObjectMeta[JObjectType])
@@ -83,5 +81,6 @@ abstract class JsonObjectField[OwnerType <: BsonRecord[OwnerType], JObjectType <
   // set this field's value using a DBObject returned from Mongo.
   def setFromDBObject(dbo: DBObject): Box[JObjectType] =
     setFromJValue(JObjectParser.serialize(dbo).asInstanceOf[JObject])
+
 }
 

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JsonObjectField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JsonObjectField.scala
@@ -24,7 +24,6 @@ import net.liftweb.json.{JsonParser, Printer}
 import net.liftweb.record.{Field, FieldHelpers, MandatoryTypedField, Record}
 import net.liftweb.util.Helpers.tryo
 import com.mongodb.DBObject
-import org.bson.Document
 
 abstract class JsonObjectField[OwnerType <: BsonRecord[OwnerType], JObjectType <: JsonObject[JObjectType]]
   (rec: OwnerType, valueMeta: JsonObjectMeta[JObjectType])

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoFieldFlavor.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoFieldFlavor.scala
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-package net.liftweb 
-package mongodb 
-package record 
-package field 
+package net.liftweb
+package mongodb
+package record
+package field
 
 import net.liftweb.common.{Box, Empty, Failure, Full}
 import net.liftweb.http.js.JE.{JsNull, JsRaw}
 import net.liftweb.json.Printer
 import net.liftweb.json.JsonAST._
 import com.mongodb.DBObject
-import org.bson.Document
 
 /**
 * Describes common aspects related to Mongo fields

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoFieldFlavor.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoFieldFlavor.scala
@@ -23,8 +23,8 @@ import net.liftweb.common.{Box, Empty, Failure, Full}
 import net.liftweb.http.js.JE.{JsNull, JsRaw}
 import net.liftweb.json.Printer
 import net.liftweb.json.JsonAST._
-
 import com.mongodb.DBObject
+import org.bson.Document
 
 /**
 * Describes common aspects related to Mongo fields

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoListField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoListField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2017 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,7 +162,7 @@ class MongoListField[OwnerType <: BsonRecord[OwnerType], ListType: Manifest](rec
     setBox(Full(dbo.asInstanceOf[BasicDBList].toList.asInstanceOf[MyType]))
 
   def setFromDocumentList(list: java.util.List[Document]): Box[MyType] = {
-    throw new RuntimeException("Warning, , setting Document as field with no conversion, probably not something you want to do")
+    throw new RuntimeException("Warning, setting Document as field with no conversion, probably not something you want to do")
   }
 
 }

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoListField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoListField.scala
@@ -75,8 +75,8 @@ class MongoListField[OwnerType <: BsonRecord[OwnerType], ListType: Manifest](rec
       case jlist: java.util.List[_] => {
         if(!jlist.isEmpty) {
           val elem = jlist.get(0)
-          if(elem.isInstanceOf[org.bson.Document]) {
-            setFromDocumentList(jlist.asInstanceOf[java.util.List[org.bson.Document]])
+          if(elem.isInstanceOf[Document]) {
+            setFromDocumentList(jlist.asInstanceOf[java.util.List[Document]])
           } else {
             setBox(Full(jlist.toList.asInstanceOf[MyType]))
           }

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoListField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoListField.scala
@@ -30,6 +30,7 @@ import net.liftweb.record.{Field, FieldHelpers, MandatoryTypedField, Record}
 import util.Helpers._
 
 import com.mongodb._
+import org.bson.Document
 import org.bson.types.ObjectId
 import org.joda.time.DateTime
 
@@ -71,6 +72,18 @@ class MongoListField[OwnerType <: BsonRecord[OwnerType], ListType: Manifest](rec
       case list@c::xs if mf.runtimeClass.isInstance(c) => setBox(Full(list.asInstanceOf[MyType]))
       case Some(list@c::xs) if mf.runtimeClass.isInstance(c) => setBox(Full(list.asInstanceOf[MyType]))
       case Full(list@c::xs) if mf.runtimeClass.isInstance(c) => setBox(Full(list.asInstanceOf[MyType]))
+      case jlist: java.util.List[_] => {
+        if(!jlist.isEmpty) {
+          val elem = jlist.get(0)
+          if(elem.isInstanceOf[org.bson.Document]) {
+            setFromDocumentList(jlist.asInstanceOf[java.util.List[org.bson.Document]])
+          } else {
+            setBox(Full(jlist.toList.asInstanceOf[MyType]))
+          }
+        } else {
+          setBox(Full(Nil))
+        }
+      }
       case s: String => setFromString(s)
       case Some(s: String) => setFromString(s)
       case Full(s: String) => setFromString(s)
@@ -147,6 +160,11 @@ class MongoListField[OwnerType <: BsonRecord[OwnerType], ListType: Manifest](rec
   // set this field's value using a DBObject returned from Mongo.
   def setFromDBObject(dbo: DBObject): Box[MyType] =
     setBox(Full(dbo.asInstanceOf[BasicDBList].toList.asInstanceOf[MyType]))
+
+  def setFromDocumentList(list: java.util.List[Document]): Box[MyType] = {
+    throw new RuntimeException("Warning, , setting Document as field with no conversion, probably not something you want to do")
+  }
+
 }
 
 /*

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoAsyncTestKit.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoAsyncTestKit.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2010-2017 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+
+import util.{ConnectionIdentifier, DefaultConnectionIdentifier, Props}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{Await, Promise}
+import scala.concurrent.duration._
+import java.util.concurrent.TimeoutException
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.BeforeAfterEach
+
+import org.bson.Document
+
+import com.mongodb.Block
+import com.mongodb.async.SingleResultCallback
+import com.mongodb.async.client.{MongoClients, MongoDatabase}
+
+// The sole mongo object for testing async
+object TestMongoAsync {
+  val mongo = {
+    val uri = Props.get("mongo.test.uri", "127.0.0.1:27017")
+    MongoClients.create(s"mongodb://$uri")
+  }
+
+  class SingleResultCallbackF[A]() extends SingleResultCallback[A] {
+    private[this] val p = Promise[A]()
+
+    override def onResult(result: A, error: Throwable): Unit = {
+      Option(error) match {
+        case None =>
+          p.success(result)
+        case Some(t) =>
+          p.failure(t)
+      }
+    }
+
+    def future = p.future
+  }
+
+  lazy val isMongoRunning: Boolean =
+    try {
+      val res = mongo.listDatabaseNames
+      val cb = new SingleResultCallbackF[Void]()
+
+      res.forEach(
+        new Block[String]() {
+          override def apply(name: String): Unit = { }
+        },
+        cb
+      )
+
+      // this will throw an exception if it can't connect to the db
+      Await.result(cb.future, Duration(2000, MILLISECONDS))
+      true
+    } catch {
+      case _: TimeoutException =>
+        false
+    }
+}
+
+trait MongoAsyncTestKit extends Specification with BeforeAfterEach {
+  sequential
+
+  protected def dbName = "lift_record_"+this.getClass.getName
+    .replace("$", "")
+    .replace("net.liftweb.mongodb.record.", "")
+    .replace(".", "_")
+    .toLowerCase
+
+  // If you need more than one db, override this
+  protected def dbs: List[(ConnectionIdentifier, String)] =
+    (DefaultConnectionIdentifier, dbName) :: Nil
+
+  def debug: Boolean = false
+
+  def before = {
+    // define the dbs
+    dbs.foreach { case (id, db) =>
+      MongoAsync.defineDb(id, TestMongoAsync.mongo.getDatabase(db))
+      MongoDB.defineDb(id, TestMongo.mongo, db)
+    }
+  }
+
+  def checkMongoIsRunning = {
+    TestMongoAsync.isMongoRunning must beEqualTo(true).orSkip
+    TestMongo.isMongoRunning must beEqualTo(true).orSkip
+  }
+
+  def after = {
+    if (!debug && TestMongoAsync.isMongoRunning) {
+      val cb = new SingleResultCallback[Void] {
+        override def onResult(result: Void, t: Throwable) = { }
+      }
+      // drop the databases
+      dbs.foreach { case (id, _) =>
+        MongoAsync.use(id) { _.drop(cb) }
+      }
+    }
+
+    // clear the mongo instances
+    dbs.foreach { case (id, _) =>
+      MongoAsync.remove(id)
+    }
+
+    if (!debug && TestMongo.isMongoRunning) {
+      // drop the databases
+      dbs.foreach { case (id, _) =>
+        MongoDB.use(id) { db => db.dropDatabase }
+      }
+    }
+
+    // clear the mongo instances
+    dbs.foreach { case (id, _) =>
+      MongoDB.remove(id)
+    }
+  }
+}
+

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
@@ -25,9 +25,7 @@ import org.bson.types.ObjectId
 import org.specs2.mutable._
 import org.specs2.specification._
 import org.specs2.execute.AsResult
-
 import org.joda.time.DateTime
-
 import common._
 import json._
 import mongodb.BsonDSL._
@@ -37,10 +35,11 @@ import http.js.JE._
 import http.js.JsExp
 import net.liftweb.record._
 import common.Box._
-import xml.{Elem, NodeSeq, Text}
-import util.{Helpers, FieldError}
-import Helpers._
 
+import xml.{Elem, NodeSeq, Text}
+import util.{FieldError, Helpers}
+import Helpers._
+import org.bson.Document
 import org.bson.types.ObjectId
 
 /**
@@ -550,6 +549,18 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundEach {
         )),
         Empty
       )
+    }
+  }
+
+  "MongoMapField" should {
+    "create itself from bson doc" in {
+      import scala.collection.JavaConversions._
+      val rec = MapTestRecord.createRecord
+      val map = Map("a" -> "4", "b" -> "5", "c" -> "6")
+      val doc = new Document(map)
+      rec.mandatoryStringMapField.setFromDocument(doc)
+      rec.mandatoryStringMapField.value must_== map
+      rec.mandatoryStringMapField.asDocument must_== doc
     }
   }
 

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 WorldWide Conferencing, LLC
+ * Copyright 2006-2017 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
@@ -554,10 +554,10 @@ object MongoFieldSpec extends Specification with MongoTestKit with AroundEach {
 
   "MongoMapField" should {
     "create itself from bson doc" in {
-      import scala.collection.JavaConversions._
+      import scala.collection.JavaConverters._
       val rec = MapTestRecord.createRecord
-      val map = Map("a" -> "4", "b" -> "5", "c" -> "6")
-      val doc = new Document(map)
+      val map = Map[String, AnyRef]("a" -> "4", "b" -> "5", "c" -> "6")
+      val doc = new Document(map.asJava)
       rec.mandatoryStringMapField.setFromDocument(doc)
       rec.mandatoryStringMapField.value must_== map
       rec.mandatoryStringMapField.asDocument must_== doc

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoRecordAsyncSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoRecordAsyncSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+
+import org.specs2.mutable.Specification
+
+import org.specs2.concurrent.ExecutionEnv
+
+class MongoRecordAsyncSpec(implicit ee: ExecutionEnv) extends Specification with MongoAsyncTestKit {
+  "MongoRecord Async Specification".title
+
+  import fixtures.FieldTypeTestRecord
+
+  "MongoRecord Async" should {
+
+    "insert asynchronously" in {
+      checkMongoIsRunning
+
+      val obj = FieldTypeTestRecord.createRecord
+        .mandatoryLongField(42L)
+        .mandatoryIntField(27)
+
+      FieldTypeTestRecord.insertAsync(obj) must beEqualTo[Boolean](true).await
+
+      val fetched = FieldTypeTestRecord.find(obj.id.get)
+
+      fetched.isDefined must_== true
+
+      fetched.foreach { o =>
+        o.id.get must_== obj.id.get
+        o.mandatoryLongField.get must_== 42L
+        o.mandatoryIntField.get must_== 27
+      }
+
+      success
+    }
+
+    "replaceOne asynchronously" in {
+      checkMongoIsRunning
+
+      val obj = FieldTypeTestRecord.createRecord
+        .mandatoryLongField(42L)
+        .mandatoryIntField(27)
+
+      FieldTypeTestRecord.replaceOneAsync(obj) must beEqualTo[FieldTypeTestRecord](obj).await
+
+      val fetched = FieldTypeTestRecord.find(obj.id.get)
+
+      fetched.isDefined must_== true
+
+      fetched.foreach { o =>
+        o.id.get must_== obj.id.get
+        o.mandatoryLongField.get must_== 42L
+        o.mandatoryIntField.get must_== 27
+      }
+
+      obj
+        .mandatoryLongField(44L)
+        .mandatoryIntField(29)
+
+      FieldTypeTestRecord.replaceOneAsync(obj) must beEqualTo[FieldTypeTestRecord](obj).await
+
+      val fetched2 = FieldTypeTestRecord.find(obj.id.get)
+
+      fetched2.isDefined must_== true
+
+      fetched2.foreach { o =>
+        o.id.get must_== obj.id.get
+        o.mandatoryLongField.get must_== 44L
+        o.mandatoryIntField.get must_== 29
+      }
+
+      success
+    }
+
+    "replaceOne without upsert" in {
+      checkMongoIsRunning
+
+      val obj = FieldTypeTestRecord.createRecord
+
+      FieldTypeTestRecord.replaceOneAsync(obj, false) must beEqualTo[FieldTypeTestRecord](obj).await
+      FieldTypeTestRecord.find(obj.id.get).isDefined must_== false
+    }
+  }
+}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoTestKit.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoTestKit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 WorldWide Conferencing, LLC
+ * Copyright 2010-2017 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,32 @@ package net.liftweb
 package mongodb
 package record
 
-import util.{ConnectionIdentifier, DefaultConnectionIdentifier}
+import util.{ConnectionIdentifier, DefaultConnectionIdentifier, Props}
+
 
 import org.specs2.mutable.Specification
 import org.specs2.specification.BeforeAfterEach
 
 import com.mongodb._
+
+// The sole mongo object for testing
+object TestMongo {
+  val mongo = {
+    val uri = Props.get("mongo.test.uri", "127.0.0.1:27017")
+    val opts = MongoClientOptions.builder.serverSelectionTimeout(2000)
+    new MongoClient(new MongoClientURI(s"mongodb://$uri", opts))
+  }
+
+  lazy val isMongoRunning: Boolean =
+    try {
+      // this will throw an exception if it can't connect to the db
+      mongo.getConnectPoint
+      true
+    } catch {
+      case _: MongoTimeoutException =>
+        false
+    }
+}
 
 trait MongoTestKit extends Specification with BeforeAfterEach {
   sequential
@@ -34,47 +54,35 @@ trait MongoTestKit extends Specification with BeforeAfterEach {
     .replace(".", "_")
     .toLowerCase
 
-  def mongo = new MongoClient("127.0.0.1", 27017)
-
   // If you need more than one db, override this
-  def dbs: List[(ConnectionIdentifier, String)] = List((DefaultConnectionIdentifier, dbName))
+  def dbs: List[(ConnectionIdentifier, String)] =
+    (DefaultConnectionIdentifier, dbName) :: Nil
 
   def debug = false
 
   def before = {
     // define the dbs
-    dbs foreach { case (id, db) =>
-      MongoDB.defineDb(id, mongo, db)
+    dbs.foreach { case (id, db) =>
+      MongoDB.defineDb(id, TestMongo.mongo, db)
     }
   }
 
-  def isMongoRunning: Boolean =
-    try {
-      if (dbs.length < 1)
-        false
-      else {
-        dbs foreach { case (id, _) =>
-          MongoDB.use(id) ( db => { db.getName } )
-        }
-        true
-      }
-    } catch {
-      case _: Exception => false
-    }
-
-  def checkMongoIsRunning =
-    isMongoRunning must beEqualTo(true).orSkip
+  def checkMongoIsRunning = {
+    TestMongo.isMongoRunning must beEqualTo(true).orSkip
+  }
 
   def after = {
-    if (!debug && isMongoRunning) {
+    if (!debug && TestMongo.isMongoRunning) {
       // drop the databases
-      dbs foreach { case (id, _) =>
+      dbs.foreach { case (id, _) =>
         MongoDB.use(id) { db => db.dropDatabase }
       }
     }
 
     // clear the mongo instances
-    MongoDB.closeAll()
+    dbs.foreach { case (id, _) =>
+      MongoDB.remove(id)
+    }
   }
 }
 

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JObjectParser.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JObjectParser.scala
@@ -28,6 +28,7 @@ import net.liftweb.util.SimpleInjector
 
 import com.mongodb.{BasicDBObject, BasicDBList, DBObject}
 import org.bson.types.ObjectId
+import org.bson.Document
 
 object JObjectParser extends SimpleInjector {
   /**
@@ -63,6 +64,11 @@ object JObjectParser extends SimpleInjector {
       case x: BasicDBObject => JObject(
         x.keySet.toList.map { f =>
           JField(f.toString, serialize(x.get(f.toString))(formats))
+        }
+      )
+      case x: Document => JObject(
+        x.keySet.toList.map { f =>
+          JField(f.toString, serialize(x.get(f.toString), formats))
         }
       )
       case x => {

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoAsync.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoAsync.scala
@@ -1,0 +1,91 @@
+package net.liftweb.mongodb
+
+import java.util.concurrent.ConcurrentHashMap
+
+import com.mongodb.MongoException
+import com.mongodb.async.client.{MongoClient, MongoCollection, MongoDatabase}
+import com.mongodb.async.SingleResultCallback
+import net.liftweb.util.ConnectionIdentifier
+import org.bson.Document
+import org.bson.codecs.{IntegerCodec, LongCodec, ObjectIdCodec, StringCodec}
+import org.bson.codecs.configuration.CodecRegistries
+
+import scala.concurrent.Promise
+
+private[mongodb] class SingleBooleanVoidCallback(f: () => Unit) extends SingleResultCallback[Void] {
+  private[this] val p = Promise[Boolean]()
+  override def onResult(result: java.lang.Void, t: Throwable): Unit = {
+    if (t == null) {
+      f()
+      p.success(true)
+    }
+    else p.failure(t)
+  }
+  def future = p.future
+}
+/*
+  Async version of MongoClient
+ */
+object MongoAsync {
+
+  /*
+  * HashMap of Mongo instance and db name tuples, keyed by ConnectionIdentifier
+  */
+  private[this] val dbs = new ConcurrentHashMap[ConnectionIdentifier, (MongoClient, String)]
+  val codecRegistry = CodecRegistries.fromRegistries(com.mongodb.MongoClient.getDefaultCodecRegistry(),
+    CodecRegistries.fromCodecs(new LongPrimitiveCodec, new IntegerPrimitiveCodec)
+  )
+
+  /**
+    * Define a Mongo db using a MongoClient instance.
+    */
+  def defineDb(name: ConnectionIdentifier, mngo: MongoClient, dbName: String) {
+    dbs.put(name, (mngo, dbName))
+  }
+
+  /*
+  * Get a DB reference
+  */
+  def getDb(name: ConnectionIdentifier): Option[MongoDatabase] = dbs.get(name) match {
+    case null => None
+    case (mngo, db) => Some(mngo.getDatabase(db).withCodecRegistry(codecRegistry))
+  }
+
+
+  def use[T](ci: ConnectionIdentifier)(f: (MongoDatabase) => T): T = {
+    val db = getDb(ci) match {
+      case Some(mongo) => mongo
+      case _ => throw new MongoException("Mongo not found: "+ci.toString)
+    }
+    f(db)
+  }
+
+  /**
+    * Executes function {@code f} with the mongo named {@code name} and collection names {@code collectionName}.
+    * Gets a collection for you.
+    */
+  def useCollection[T](name: ConnectionIdentifier, collectionName: String)(f: (MongoCollection[Document]) => T): T = {
+    val coll = getCollection(name, collectionName) match {
+      case Some(collection) => collection
+      case _ => throw new MongoException("Mongo not found: "+collectionName+". ConnectionIdentifier: "+name.toString)
+    }
+
+    f(coll)
+  }
+
+  /*
+* Get a Mongo collection. Gets a Mongo db first.
+*/
+  private[this] def getCollection(name: ConnectionIdentifier, collectionName: String): Option[MongoCollection[Document]] = getDb(name) match {
+    case Some(mongo) if mongo != null => Some(mongo.getCollection(collectionName))
+    case _ => None
+  }
+
+  def closeAll(): Unit = {
+    import scala.collection.JavaConverters._
+    dbs.values.asScala.foreach { case (mngo, _) =>
+      mngo.close()
+    }
+    dbs.clear()
+  }
+}

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoAsync.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoAsync.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.liftweb.mongodb
 
 import java.util.concurrent.ConcurrentHashMap
@@ -7,53 +23,80 @@ import com.mongodb.async.client.{MongoClient, MongoCollection, MongoDatabase}
 import com.mongodb.async.SingleResultCallback
 import net.liftweb.util.ConnectionIdentifier
 import org.bson.Document
-import org.bson.codecs.{IntegerCodec, LongCodec, ObjectIdCodec, StringCodec}
-import org.bson.codecs.configuration.CodecRegistries
 
 import scala.concurrent.Promise
 
 private[mongodb] class SingleBooleanVoidCallback(f: () => Unit) extends SingleResultCallback[Void] {
   private[this] val p = Promise[Boolean]()
-  override def onResult(result: java.lang.Void, t: Throwable): Unit = {
-    if (t == null) {
-      f()
-      p.success(true)
+
+  override def onResult(result: java.lang.Void, error: Throwable): Unit = {
+    Option(error) match {
+      case None =>
+        f()
+        p.success(true)
+      case Some(t) =>
+        p.failure(t)
     }
-    else p.failure(t)
   }
+
   def future = p.future
 }
-/*
-  Async version of MongoClient
- */
+
+/**
+  * Async version of MongoDB.
+  *
+  * You should only have one instance of MongoClient in a JVM.
+  *
+  * Example:
+  *
+  * {{{
+  * import com.mongodb.async.client.MongoClients
+  * import net.liftweb.util.{ConnectionIdentifier, DefaultConnectionIdentifier}
+  * import org.bson.codecs.configuration.CodecRegistries
+  *
+  * val client = MongoClients.create("mongodb://127.0.0.1:27017")
+  *
+  * // main database
+  * MongoAsync.defineDb(DefaultConnectionIdentifier, client.getDatabase("mydb"))
+  *
+  * // admin database
+  * case object AdminIdentifier extends ConnectionIdentifier {
+  *   val jndiName = "admin"
+  * }
+  *
+  * val codecRegistry = CodecRegistries.fromRegistries(
+  *   com.mongodb.MongoClient.getDefaultCodecRegistry(),
+  *   CodecRegistries.fromCodecs(new LongPrimitiveCodec, new IntegerPrimitiveCodec)
+  * )
+
+  * val admin = client.getDatabase("admin").withCodecRegistry(codecRegistry)
+  * MongoAsync.defineDb(AdminIdentifier, admin)
+  *
+  * }}}
+  */
 object MongoAsync {
 
-  /*
-  * HashMap of Mongo instance and db name tuples, keyed by ConnectionIdentifier
-  */
-  private[this] val dbs = new ConcurrentHashMap[ConnectionIdentifier, (MongoClient, String)]
-  val codecRegistry = CodecRegistries.fromRegistries(com.mongodb.MongoClient.getDefaultCodecRegistry(),
-    CodecRegistries.fromCodecs(new LongPrimitiveCodec, new IntegerPrimitiveCodec)
-  )
+  /**
+    * HashMap of MongoDatabase instances keyed by ConnectionIdentifier
+    */
+  private[this] val dbs = new ConcurrentHashMap[ConnectionIdentifier, MongoDatabase]
 
   /**
-    * Define a Mongo db using a MongoClient instance.
+    * Define a Mongo db using a MongoDatabase instance.
     */
-  def defineDb(name: ConnectionIdentifier, mngo: MongoClient, dbName: String) {
-    dbs.put(name, (mngo, dbName))
+  def defineDb(id: ConnectionIdentifier, db: MongoDatabase): Unit = {
+    dbs.put(id, db)
   }
 
-  /*
-  * Get a DB reference
-  */
-  def getDb(name: ConnectionIdentifier): Option[MongoDatabase] = dbs.get(name) match {
-    case null => None
-    case (mngo, db) => Some(mngo.getDatabase(db).withCodecRegistry(codecRegistry))
+  /**
+    * Get a MongoDatabase reference
+    */
+  private[this] def getDatabase(name: ConnectionIdentifier): Option[MongoDatabase] = {
+    Option(dbs.get(name))
   }
-
 
   def use[T](ci: ConnectionIdentifier)(f: (MongoDatabase) => T): T = {
-    val db = getDb(ci) match {
+    val db = getDatabase(ci) match {
       case Some(mongo) => mongo
       case _ => throw new MongoException("Mongo not found: "+ci.toString)
     }
@@ -61,7 +104,7 @@ object MongoAsync {
   }
 
   /**
-    * Executes function {@code f} with the mongo named {@code name} and collection names {@code collectionName}.
+    * Executes function {@code f} with the mongo named {@code name} and collection named {@code collectionName}.
     * Gets a collection for you.
     */
   def useCollection[T](name: ConnectionIdentifier, collectionName: String)(f: (MongoCollection[Document]) => T): T = {
@@ -73,19 +116,25 @@ object MongoAsync {
     f(coll)
   }
 
-  /*
-* Get a Mongo collection. Gets a Mongo db first.
-*/
-  private[this] def getCollection(name: ConnectionIdentifier, collectionName: String): Option[MongoCollection[Document]] = getDb(name) match {
+  /**
+    * Get a Mongo collection. Gets a Mongo db first.
+    */
+  private[this] def getCollection(name: ConnectionIdentifier, collectionName: String): Option[MongoCollection[Document]] = getDatabase(name) match {
     case Some(mongo) if mongo != null => Some(mongo.getCollection(collectionName))
     case _ => None
   }
 
-  def closeAll(): Unit = {
-    import scala.collection.JavaConverters._
-    dbs.values.asScala.foreach { case (mngo, _) =>
-      mngo.close()
-    }
+  /**
+    * Clear the HashMap.
+    */
+  def clear(): Unit = {
     dbs.clear()
+  }
+
+  /**
+    * Remove a specific ConnectionIdentifier from the HashMap.
+    */
+  def remove(id: ConnectionIdentifier): Option[MongoDatabase] = {
+    Option(dbs.remove(id))
   }
 }

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoAsync.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoAsync.scala
@@ -95,17 +95,20 @@ object MongoAsync {
     Option(dbs.get(name))
   }
 
-  def use[T](ci: ConnectionIdentifier)(f: (MongoDatabase) => T): T = {
-    val db = getDatabase(ci) match {
+  /**
+    * Executes function {@code f} with the mongo database identified by {@code name}.
+    */
+  def use[T](name: ConnectionIdentifier)(f: (MongoDatabase) => T): T = {
+    val db = getDatabase(name) match {
       case Some(mongo) => mongo
-      case _ => throw new MongoException("Mongo not found: "+ci.toString)
+      case _ => throw new MongoException("Mongo not found: "+name.toString)
     }
     f(db)
   }
 
   /**
-    * Executes function {@code f} with the mongo named {@code name} and collection named {@code collectionName}.
-    * Gets a collection for you.
+    * Executes function {@code f} with the collection named {@code collectionName} from
+    * the mongo database identified by {@code name}.
     */
   def useCollection[T](name: ConnectionIdentifier, collectionName: String)(f: (MongoCollection[Document]) => T): T = {
     val coll = getCollection(name, collectionName) match {
@@ -116,12 +119,8 @@ object MongoAsync {
     f(coll)
   }
 
-  /**
-    * Get a Mongo collection. Gets a Mongo db first.
-    */
-  private[this] def getCollection(name: ConnectionIdentifier, collectionName: String): Option[MongoCollection[Document]] = getDatabase(name) match {
-    case Some(mongo) if mongo != null => Some(mongo.getCollection(collectionName))
-    case _ => None
+  private[this] def getCollection(name: ConnectionIdentifier, collectionName: String): Option[MongoCollection[Document]] = {
+    getDatabase(name).map(_.getCollection(collectionName))
   }
 
   /**

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoCodecs.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoCodecs.scala
@@ -1,0 +1,14 @@
+package net.liftweb.mongodb
+
+import org.bson.codecs._
+
+/**
+  * additional codecs to register for primitive types
+  */
+class LongPrimitiveCodec extends LongCodec {
+  override def getEncoderClass() = java.lang.Long.TYPE
+}
+
+class IntegerPrimitiveCodec extends IntegerCodec {
+  override def getEncoderClass() = java.lang.Integer.TYPE
+}

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoCodecs.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoCodecs.scala
@@ -1,14 +1,33 @@
+/*
+ * Copyright 2017 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.liftweb.mongodb
 
 import org.bson.codecs._
 
 /**
-  * additional codecs to register for primitive types
+  * Codec for java.lang.Long
   */
 class LongPrimitiveCodec extends LongCodec {
   override def getEncoderClass() = java.lang.Long.TYPE
 }
 
+/**
+  * Codec for java.lang.Integer
+  */
 class IntegerPrimitiveCodec extends IntegerCodec {
   override def getEncoderClass() = java.lang.Integer.TYPE
 }

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoRules.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoRules.scala
@@ -1,5 +1,5 @@
 /**
-  * Copyright 2014 WorldWide Conferencing, LLC
+  * Copyright 2014-2017 WorldWide Conferencing, LLC
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package mongodb
 import util.{ConnectionIdentifier, SimpleInjector}
 import util.Helpers._
 
+import com.mongodb.WriteConcern
+
 object MongoRules extends SimpleInjector {
   private def defaultCollectionNameFunc(conn: ConnectionIdentifier, name: String): String = {
     charSplit(name, '.').last.toLowerCase+"s"
@@ -33,4 +35,8 @@ object MongoRules extends SimpleInjector {
     *  RecordRules.collectionName.default.set((_,name) => StringHelpers.snakify(name))
     */
   val collectionName = new Inject[(ConnectionIdentifier, String) => String](defaultCollectionNameFunc _) {}
+
+  /** The default WriteConcern used in some places.
+    */
+  val defaultWriteConcern = new Inject[WriteConcern](WriteConcern.ACKNOWLEDGED) {}
 }

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectMongoClient.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectMongoClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WorldWide Conferencing, LLC
+ * Copyright 2014-2017 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,14 +23,11 @@ import com.mongodb._
 
 import org.specs2.mutable.Specification
 
-
 /**
  * System under specification for MongoDirectMonoClient.
  */
 class MongoDirectMongoClientSpec extends Specification with MongoTestKit {
   "MongoDirectMongoClient Specification".title
-
-  override def mongo = new MongoClient("127.0.0.1", 27017)
 
   "MongoClient example" in {
 

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDocumentMongoClientSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDocumentMongoClientSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2017 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,8 +50,6 @@ class MongoDocumentMongoClientSpec extends Specification with MongoTestKit {
   "MongoDocumentMongoClient Specification".title
 
   import mongoclienttestdocs._
-
-  override def mongo = new MongoClient("127.0.0.1", 27017)
 
   "MongoClient example" in {
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -224,7 +224,7 @@ object BuildDef extends Build {
     persistenceProject("mongodb")
         .dependsOn(json_ext, util)
         .settings(parallelExecution in Test := false,
-                  libraryDependencies += mongo_driver,
+                  libraryDependencies ++= Seq(mongo_java_driver, mongo_java_driver_async),
                   initialize in Test <<= (resourceDirectory in Test) { rd =>
                     System.setProperty("java.util.logging.config.file", (rd / "logging.properties").absolutePath)
                   })

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,8 @@ object Dependencies {
   lazy val joda_time              = "joda-time"                  % "joda-time"          % "2.9.2"
   lazy val joda_convert           = "org.joda"                   % "joda-convert"       % "1.8.1"
   lazy val htmlparser             = "nu.validator.htmlparser"    % "htmlparser"         % "1.4"
-  lazy val mongo_java_driver      = "org.mongodb"                % "mongo-java-driver"  % "3.4.0"
+  lazy val mongo_java_driver      = "org.mongodb"                % "mongodb-driver"     % "3.4.1"
+  lazy val mongo_java_driver_async  = "org.mongodb"              % "mongodb-driver-async" % "3.4.1"
   lazy val paranamer              = "com.thoughtworks.paranamer" % "paranamer"          % "2.8"
   lazy val scalajpa               = "org.scala-libs"             % "scalajpa"           % "1.5"     cross CVMappingAll
   lazy val scalap: ModuleMap      = "org.scala-lang"             % "scalap"             % _


### PR DESCRIPTION
This contains all of Marek's work, plus I added some tests and updated MongoTestKit.

I also redid MongoAsync.defineDb to take a `MongoDatabase` instead of `(MongoClient, String)` . This allows the user to configure the `MongoDatabase` however they like. Because of this, I removed the setting of the CodecRegistry. This will have to be done by the user. An example is provided in the comments.