### PR TITLE
Removed requirement of jQuery in liftJQuery definition

### DIFF
--- a/web/webkit/src/main/resources/toserve/lift.js
+++ b/web/webkit/src/main/resources/toserve/lift.js
@@ -507,7 +507,7 @@
 
         return self;
       };
-	  
+
       self['catch'] = self.fail;
 
       self.done = function(f) {
@@ -655,7 +655,9 @@
 
       jQuery(elementOrId).on(eventName, fn);
     },
-    onDocumentReady: jQuery(document).ready,
+    onDocumentReady: function(fn) {
+      jQuery(document).ready(fn);
+    },
     ajaxPost: function(url, data, dataType, onSuccess, onFailure) {
       var processData = true,
           contentType = 'application/x-www-form-urlencoded; charset=UTF-8';


### PR DESCRIPTION
This wasn't discussed on the ML, but OP was right. jQuery was required just to define liftJQuery, making it a requirement to have jQuery loaded, even if you want to use liftVanilla.

The simple solution is to wrap the ```onDocumentReady``` in a function. I tested this with [lift-vanilla-demo](https://github.com/eltimn/lift-vanilla-demo).

Fixes #1797
