### PR TITLE
Eventful Merger: Fix event extraction for pages without head/body elements

### DIFF
--- a/web/webkit/src/test/scala/net/liftweb/webapptest/ToHeadUsages.scala
+++ b/web/webkit/src/test/scala/net/liftweb/webapptest/ToHeadUsages.scala
@@ -167,7 +167,7 @@ object ToHeadUsages extends Specification  {
     }
 
     "Exclude from context rewriting" in {
-      val first = http.Req.fixHtml("/wombat",
+      val first = http.Req.normalizeHtml("/wombat",
         <span>
           <a href="/foo" id="foo">foo</a>
           <a href="/bar" id="bar">bar</a>
@@ -177,7 +177,7 @@ object ToHeadUsages extends Specification  {
       def excludeBar(in: String): Boolean = in.startsWith("/bar")
 
       val second = LiftRules.excludePathFromContextPathRewriting.doWith(excludeBar _) {
-        Req.fixHtml("/wombat",
+        Req.normalizeHtml("/wombat",
           <span>
             <a href="/foo" id="foo">foo</a>
             <a href="/bar" id="bar">bar</a>


### PR DESCRIPTION
Fixes #1807.

Short story here was that in cases where a template had a `head` and `body` element, `LiftMerge` would correctly extract events (when `LiftRules.extractInlineJavaScript` was enabled) and append a page script to the outputted HTML that referenced the extracted event handler attachment code. However, if either of those elements was missing, we went through a path that *still extracted the events*, but never attached the page JS reference. As a result, the events in question were lost.

We now correctly generate the page JS and attach a script reference to the end of the element that is returned from `LiftMerge`.