### PR TITLE
Revolting Expressions: Disable event extraction for `fixHtmlFunc` (and `JsExp` by association)

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -1869,13 +1869,20 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * Note that most of the time you can just call
    * `[[normalizeHtmlAndAppendEventHandlers]]` and not worry about the extra
    * `JsCmd`, as Lift will automatically append it to the response.
+   *
+   * @param forceExtractInlineJavaScript If `None`, uses `LiftRules.extractInlineJavaScript`
+   *        to decide whether or not to extract inline JS from the passed nodes. If `Some`,
+   *        extracts (`Some(true)`) or doesn't (`Some(false)`).
    */
-  def normalizeHtmlAndEventHandlers(nodes: NodeSeq): NodesAndEventJs = {
+  def normalizeHtmlAndEventHandlers(
+    nodes: NodeSeq,
+    forceExtractInlineJavaScript: Option[Boolean] = None
+  ): NodesAndEventJs = {
     HtmlNormalizer.normalizeHtmlAndEventHandlers(
       nodes,
       S.contextPath,
       LiftRules.stripComments.vend,
-      LiftRules.extractInlineJavaScript
+      forceExtractInlineJavaScript getOrElse LiftRules.extractInlineJavaScript
     )
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/js/JsCommands.scala
@@ -38,7 +38,7 @@ object JsCommands {
  * also read and included in the response. Also in this process, all of the
  * `JsCmd` instances have their `toJsCmd` methods called to convert them to a
  * string.
- * 
+ *
  * @note The contents of `jsToAppend` are cleared in this process!
  */
 class JsCommands(val reverseList: List[JsCmd]) {
@@ -571,9 +571,15 @@ trait HtmlFixer {
    * construct a function that executes the contents of the scripts
    * then evaluations to Expression.  For use when converting
    * a JsExp that contains HTML.
+   *
+   *
+   * @note Currently, `fixHtmlFunc` does '''not''' do event extraction, even when
+   *       `LiftRules.extractInlineJavaScript` is `true`, due to poor interactions
+   *       with `JsExp` usage. This will be fixed in a future Lift release; see
+   *       https://github.com/lift/framework/issues/1801 .
    */
   def fixHtmlFunc(uid: String, content: NodeSeq)(f: String => String) =
-    fixHtmlAndJs(uid, content) match {
+    fixHtmlAndJs(uid, content, forceExtractInlineJavaScript = Some(false)) match {
       case (str, Nil) => f(str)
       case (str, cmds) => "((function() {"+cmds.reduceLeft{_ & _}.toJsCmd+" return "+f(str)+";})())"
     }
@@ -596,7 +602,11 @@ trait HtmlFixer {
    * This method must be run in the context of the thing creating the XHTML
    * to capture the bound functions
    */
-  protected def fixHtmlAndJs(uid: String, content: NodeSeq): (String, List[JsCmd]) = {
+  protected def fixHtmlAndJs(
+    uid: String,
+    content: NodeSeq,
+    forceExtractInlineJavaScript: Option[Boolean] = None
+  ): (String, List[JsCmd]) = {
     import Helpers._
 
     val w = new java.io.StringWriter
@@ -607,7 +617,8 @@ trait HtmlFixer {
           session.processSurroundAndInclude(
             s"JS SetHTML id: $uid",
             content
-          )
+          ),
+          forceExtractInlineJavaScript
         )
       } openOr {
         NodesAndEventJs(content, JsCmds.Noop)
@@ -726,7 +737,7 @@ object JsCmds {
       elem ++ Script(LiftRules.jsArtifacts.onLoad(Run("if (document.getElementById(" + id.encJs + ")) {document.getElementById(" + id.encJs + ").focus();};")))
     }
   }
-  
+
   /**
    * Sets the value of an element and sets the focus
    */

--- a/web/webkit/src/test/scala/net/liftweb/http/LiftMergeSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LiftMergeSpec.scala
@@ -4,8 +4,7 @@ package http
 import scala.xml._
 
 import org.specs2._
-  import execute.{Result, AsResult}
-  import mutable.{Around, Specification}
+  import mutable.Specification
   import matcher.XmlMatchers
   import mock.Mockito
 
@@ -14,41 +13,6 @@ import org.mockito.Mockito._
 import common._
 
 import js.JE.JsObj
-
-trait BaseAround extends Around {
-  override def around[T: AsResult](test: =>T): Result = {
-    AsResult(test)
-  }
-}
-
-trait LiftRulesSetup extends Around {
-  def rules: LiftRules
-
-  abstract override def around[T: AsResult](test: => T): Result = {
-    super.around {
-      LiftRulesMocker.devTestLiftRulesInstance.doWith(rules) {
-        AsResult(test)
-      }
-    }
-  }
-}
-
-trait SSetup extends Around {
-  def session: LiftSession
-  def req: Box[Req]
-
-  abstract override def around[T: AsResult](test: => T): Result = {
-    super.around {
-      S.init(req, session) {
-        AsResult(test)
-      }
-    }
-  }
-}
-
-class WithRules(val rules: LiftRules) extends BaseAround with LiftRulesSetup
-
-class WithLiftContext(val rules: LiftRules, val session: LiftSession, val req: Box[Req] = Empty) extends BaseAround with LiftRulesSetup with SSetup
 
 class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
   val mockReq = mock[Req]
@@ -62,7 +26,7 @@ class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
   testRules.autoIncludeAjaxCalc.default.set(() => () => (_: LiftSession) => false)
   testRules.excludePathFromContextPathRewriting.default
     .set(
-      () => { in: String => 
+      () => { in: String =>
         in.startsWith("exclude-me")
       }
     )
@@ -198,7 +162,7 @@ class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
           mockReq
         )
 
-      (result \\ "link").map(_ \@ "href") must_== 
+      (result \\ "link").map(_ \@ "href") must_==
         "/context-path/testlink" ::
         "/context-path/testlink2" ::
         "/context-path/testlink3" :: Nil
@@ -232,7 +196,7 @@ class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
           mockReq
         )
 
-      (result \\ "script").map(_ \@ "src") must_== 
+      (result \\ "script").map(_ \@ "src") must_==
         "/context-path/testscript" ::
         "/context-path/testscript2" :: Nil
     }
@@ -265,7 +229,7 @@ class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
           mockReq
         )
 
-      (result \\ "a").map(_ \@ "href") must_== 
+      (result \\ "a").map(_ \@ "href") must_==
         "/context-path/testa1" ::
         "testa3" ::
         "/context-path/testa2" ::
@@ -302,7 +266,7 @@ class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
           mockReq
         )
 
-      (result \\ "form").map(_ \@ "action") must_== 
+      (result \\ "form").map(_ \@ "action") must_==
         "/context-path/testform1" ::
         "testform3" ::
         "/context-path/testform2" ::
@@ -339,7 +303,7 @@ class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
           )
         }
 
-      (result \\ "script").map(_ \@ "src") must_== 
+      (result \\ "script").map(_ \@ "src") must_==
         "testscript" ::
         "testscript2" ::
         "testscript3" :: Nil
@@ -373,7 +337,7 @@ class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
           )
         }
 
-      (result \\ "link").map(_ \@ "href") must_== 
+      (result \\ "link").map(_ \@ "href") must_==
         "testlink" ::
         "testlink2" ::
         "testlink3" :: Nil
@@ -407,7 +371,7 @@ class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
           )
         }
 
-      (result \\ "a").map(_ \@ "href") must_== 
+      (result \\ "a").map(_ \@ "href") must_==
         "rewritten" ::
         "rewritten" ::
         "rewritten" :: Nil
@@ -441,7 +405,7 @@ class LiftMergeSpec extends Specification with XmlMatchers with Mockito {
           )
         }
 
-      (result \\ "form").map(_ \@ "action") must_== 
+      (result \\ "form").map(_ \@ "action") must_==
         "rewritten" ::
         "rewritten" ::
         "rewritten" :: Nil

--- a/web/webkit/src/test/scala/net/liftweb/http/SpecContextHelpers.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/SpecContextHelpers.scala
@@ -1,0 +1,61 @@
+package net.liftweb
+package http
+
+import org.specs2._
+  import execute.{Result, AsResult}
+  import mutable.{Around, Specification}
+
+import common.{Box, Empty}
+
+/**
+ * Used for stacking other `around` providers like `[[LiftRulesSetup]]`.
+ */
+trait BaseAround extends Around {
+  override def around[T: AsResult](test: =>T): Result = {
+    AsResult(test)
+  }
+}
+
+/**
+ * Given an instance method or variable `rules`, wraps the spec in a setup of
+ * that rules instance as the one used by Lift for the duration of the spec.
+ */
+trait LiftRulesSetup extends Around {
+  def rules: LiftRules
+
+  abstract override def around[T: AsResult](test: => T): Result = {
+    super.around {
+      LiftRulesMocker.devTestLiftRulesInstance.doWith(rules) {
+        AsResult(test)
+      }
+    }
+  }
+}
+
+/**
+ * Given an instance method or variable `rules`, wraps the spec in a setup of
+ * that rules instance as the one used by Lift for the duration of the spec.
+ */
+trait SSetup extends Around {
+  def session: LiftSession
+  def req: Box[Req]
+
+  abstract override def around[T: AsResult](test: => T): Result = {
+    super.around {
+      S.init(req, session) {
+        AsResult(test)
+      }
+    }
+  }
+}
+
+/**
+ * Wraps a spec in a context where `rules` are the Lift rules in effect.
+ */
+class WithRules(val rules: LiftRules) extends BaseAround with LiftRulesSetup
+
+/**
+ * Wraps a spec in a context where `rules` are the Lift rules in effect, `session`
+ * is the current Lift session, and `req`, if specified, is the current request.
+ */
+class WithLiftContext(val rules: LiftRules, val session: LiftSession, val req: Box[Req] = Empty) extends BaseAround with LiftRulesSetup with SSetup

--- a/web/webkit/src/test/scala/net/liftweb/http/js/HtmlFixerSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/js/HtmlFixerSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2017 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package http
+package js
+
+import org.specs2.mutable.Specification
+
+import common._
+import json._
+import JsonDSL._
+import util.Helpers._
+
+object HtmlFixerSpec extends Specification  {
+  "HtmlFixer" should {
+    val testFixer = new HtmlFixer {}
+    val testSession = new LiftSession("/context-path", "underlying id", Empty)
+    val testRules = new LiftRules()
+    testRules.extractInlineJavaScript = true
+
+    "never extract inline JS in fixHtmlFunc" in new WithLiftContext(testRules, testSession) {
+      testFixer.fixHtmlFunc("test", <div onclick="clickMe();"></div>)(identity) must_==
+        """"<div onclick=\"clickMe();\"></div>""""
+    }
+  }
+}


### PR DESCRIPTION
This allows enabling `extractInlineJavaScript` without being worried about
`JsExp` not behaving correctly.

It is a first pass semi-fix for #1801, but a better, more complete fix should
be done that allows inline JS extraction to operate even in these cases. That's
for later, though.