### PR TITLE
Handle missing HTTPRequests in S.request

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -1547,7 +1547,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * had been executed on the thread that created the function.
    */
   def buildDeferredFunction[T](deferredFunction: () => T): () => T = {
-    val currentReq = S.request.map(_.snapshot)
+    val currentReq = S.request.filter(_.request != null).map(_.snapshot)
     val renderVersion = RenderVersion.get
     val requestVarFunc = RequestVarHandler.generateSnapshotRestorer[T]()
 
@@ -1565,7 +1565,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
    * request and session context.
    */
   def buildDeferredFunction[A,T](deferredFunction: (A)=>T): (A)=>T = {
-    val currentReq = S.request.map(_.snapshot)
+    val currentReq = S.request.filter(_.request != null).map(_.snapshot)
     val renderVersion = RenderVersion.get
     val requestVarFunc = RequestVarHandler.generateSnapshotRestorer[T]()
 

--- a/web/webkit/src/test/scala/net/liftweb/http/LiftSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LiftSessionSpec.scala
@@ -17,8 +17,10 @@
 package net.liftweb
 package http
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.xml.NodeSeq
-import net.liftweb.common.{Full, Empty}
+import net.liftweb.common.{Full, Empty, Failure}
+import net.liftweb.util.Helpers.tryo
 import org.specs2.specification.BeforeEach
 import org.specs2.mutable.Specification
 
@@ -87,6 +89,22 @@ object LiftSessionSpec extends Specification with BeforeEach {
 
         // Assert that the message was seen twice
         receivedMessages mustEqual Vector(1, 1)
+      }
+    }
+  }
+
+  "LiftSession when building deferred functions" should {
+
+    "not fail when the underlying container request is null" in {
+      val session = new LiftSession("Test Session", "", Empty)
+
+      def stubFunction: () => Int = () => 3
+
+      S.init(Full(Req.nil), session) {
+
+        val attempt = tryo(session.buildDeferredFunction(stubFunction))
+
+        attempt.toOption must beSome
       }
     }
   }


### PR DESCRIPTION
This fixes https://github.com/lift/framework/issues/1831

**[Mailing List](https://groups.google.com/forum/#!msg/liftweb/foD9cXlMxSQ/Cw9zU1c6AwAJ) thread**:

# Description

# Discussion

Sometimes `S.req` returns a `Req` without a `HTTPRequest` inside. Ergo, when we call `HttpRequest.snapshot` in `Req.snapshot`, we get a NPE.

To fix this, we modify currentReq in both definitions of `buildDeferredFunction` so that they filter out null requests.
