### PR TITLE
The Avengers: Infinity NaNny: JSON-serialize +/- infinity and NaN as null.

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -946,6 +946,9 @@ object JsonAST {
     case null          => buf.append("null")
     case JBool(true)   => buf.append("true")
     case JBool(false)  => buf.append("false")
+    // These special double values serialize to null; otherwise, we would
+    // generate invalid JSON.
+    case JDouble(nully) if nully.isNaN || nully.isInfinity => buf.append("null")
     case JDouble(n)    => buf.append(n.toString)
     case JInt(n)       => buf.append(n.toString)
     case JNull         => buf.append("null")

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -924,7 +924,7 @@ object JsonAST {
   case object FailToRenderSpecialDoubleValues extends DoubleRenderer {
     def apply(double: Double): String = {
       if (double.isNaN || double.isInfinity) {
-        throw new IllegalArgumentException(s"Double value $double is not renderable to JSON.")
+        throw new IllegalArgumentException(s"Double value $double cannot be rendered to JSON with the current DoubleRenderer.")
       } else {
         double.toString
       }

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -886,8 +886,8 @@ object JsonAST {
    * Parent trait for double renderers, which decide how doubles contained in
    * a JDouble are rendered to JSON string.
    */
-  sealed trait DoubleRenderer {
-    def renderDouble(double: Double): String
+  sealed trait DoubleRenderer extends Function1[Double,String] {
+    def apply(double: Double): String
   }
   /**
    * A `DoubleRenderer` that renders special values `NaN`, `-Infinity`, and
@@ -898,7 +898,7 @@ object JsonAST {
    * Usage is not recommended.
    */
   case object RenderSpecialValuesAsIs extends DoubleRenderer {
-    def renderDouble(double: Double): String = {
+    def apply(double: Double): String = {
       double.toString
     }
   }
@@ -908,7 +908,7 @@ object JsonAST {
    * `toString`.
    */
   case object RenderSpecialValuesAsNull extends DoubleRenderer {
-    def renderDouble(double: Double): String = {
+    def apply(double: Double): String = {
       if (double.isNaN || double.isInfinity) {
         "null"
       } else {
@@ -922,7 +922,7 @@ object JsonAST {
    * doubles are rendered normally using `toString`.
    */
   case object FailToRenderSpecialValues extends DoubleRenderer {
-    def renderDouble(double: Double): String = {
+    def apply(double: Double): String = {
       if (double.isNaN || double.isInfinity) {
         throw new IllegalArgumentException(s"Double value $double is not renderable to JSON.")
       } else {
@@ -1003,7 +1003,7 @@ object JsonAST {
     case null          => buf.append("null")
     case JBool(true)   => buf.append("true")
     case JBool(false)  => buf.append("false")
-    case JDouble(n)    => buf.append(settings.doubleRenderer.renderDouble(n))
+    case JDouble(n)    => buf.append(settings.doubleRenderer(n))
     case JInt(n)       => buf.append(n.toString)
     case JNull         => buf.append("null")
     case JString(null) => buf.append("null")

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -897,7 +897,7 @@ object JsonAST {
    *
    * Usage is not recommended.
    */
-  case object RenderSpecialValuesAsIs extends DoubleRenderer {
+  case object RenderSpecialDoubleValuesAsIs extends DoubleRenderer {
     def apply(double: Double): String = {
       double.toString
     }
@@ -907,7 +907,7 @@ object JsonAST {
    * `Infinity` as `null`. Other doubles are rendered normally using
    * `toString`.
    */
-  case object RenderSpecialValuesAsNull extends DoubleRenderer {
+  case object RenderSpecialDoubleValuesAsNull extends DoubleRenderer {
     def apply(double: Double): String = {
       if (double.isNaN || double.isInfinity) {
         "null"
@@ -921,7 +921,7 @@ object JsonAST {
    * special values `NaN`, `-Infinity`, and `Infinity` are encountered. Other
    * doubles are rendered normally using `toString`.
    */
-  case object FailToRenderSpecialValues extends DoubleRenderer {
+  case object FailToRenderSpecialDoubleValues extends DoubleRenderer {
     def apply(double: Double): String = {
       if (double.isNaN || double.isInfinity) {
         throw new IllegalArgumentException(s"Double value $double is not renderable to JSON.")
@@ -948,7 +948,7 @@ object JsonAST {
     indent: Int,
     escapeChars: Set[Char] = Set(),
     spaceAfterFieldName: Boolean = false,
-    doubleRenderer: DoubleRenderer = RenderSpecialValuesAsNull
+    doubleRenderer: DoubleRenderer = RenderSpecialDoubleValuesAsNull
   ) {
     val lineBreaks_? = indent > 0
   }

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -891,7 +891,8 @@ object JsonAST {
   }
   /**
    * A `DoubleRenderer` that renders special values `NaN`, `-Infinity`, and
-   * `Infinity` as-is using `toString`. This is not strictly valid JSON, but
+   * `Infinity` as-is using `toString`. This is not valid JSON, meaning JSON
+   * libraries generally won't be able to parse it (including lift-json!), but
    * JavaScript can eval it. Other double values are also rendered the same
    * way.
    *

--- a/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
@@ -94,15 +94,15 @@ object JsonPrintingSpec extends Specification  with JValueGen with ScalaCheck {
       render(JDouble(double)) must_== double.toString
     }
 
-    "render positive infinity as null" in {
+    "throw an exception when attempting to render positive infinity" in {
       render(JDouble(Double.PositiveInfinity)) must throwAn[IllegalArgumentException]
     }
 
-    "render negative infinity as null" in {
+    "throw an exception when attempting to render negative infinity" in {
       render(JDouble(Double.NegativeInfinity)) must throwAn[IllegalArgumentException]
     }
 
-    "render NaN as null" in {
+    "throw an exception when attempting to render NaN" in {
       render(JDouble(Double.NaN)) must throwAn[IllegalArgumentException]
     }
   }

--- a/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
@@ -34,6 +34,20 @@ object JsonPrintingSpec extends Specification  with JValueGen with ScalaCheck {
     forAll(rendering)
   }
 
+  "rendering special double values" should {
+    "render positive infinity as null" in {
+      JsonAST.compactRender(JDouble(Double.PositiveInfinity)) must_== "null"
+    }
+
+    "render negative infinity as null" in {
+      JsonAST.compactRender(JDouble(Double.NegativeInfinity)) must_== "null"
+    }
+
+    "render NaN as null" in {
+      JsonAST.compactRender(JDouble(Double.NaN)) must_== "null"
+    }
+  }
+
   private def parse(json: String) = scala.util.parsing.json.JSON.parseRaw(json)
 
   implicit def arbDoc: Arbitrary[JValue] = Arbitrary(genJValue)

--- a/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
@@ -17,6 +17,8 @@
 package net.liftweb
 package json
 
+import scala.util.Random
+
 import org.specs2.mutable.Specification
 import org.specs2.ScalaCheck
 import org.scalacheck.Arbitrary
@@ -34,7 +36,12 @@ object JsonPrintingSpec extends Specification  with JValueGen with ScalaCheck {
     forAll(rendering)
   }
 
-  "rendering special double values" should {
+  "rendering special double values by default" should {
+    "render a standard double as is" in {
+      val double = Random.nextDouble
+      JsonAST.compactRender(JDouble(double)) must_== double.toString
+    }
+
     "render positive infinity as null" in {
       JsonAST.compactRender(JDouble(Double.PositiveInfinity)) must_== "null"
     }
@@ -45,6 +52,58 @@ object JsonPrintingSpec extends Specification  with JValueGen with ScalaCheck {
 
     "render NaN as null" in {
       JsonAST.compactRender(JDouble(Double.NaN)) must_== "null"
+    }
+  }
+
+  "rendering special double values with as-is handling" should {
+    def render(json: JValue) = {
+      JsonAST.render(
+        json,
+        JsonAST.RenderSettings(0, doubleRenderer = JsonAST.RenderSpecialValuesAsIs)
+      )
+    }
+
+    "render a standard double as is" in {
+      val double = Random.nextDouble
+      render(JDouble(double)) must_== double.toString
+    }
+
+    "render positive infinity as null" in {
+      render(JDouble(Double.PositiveInfinity)) must_== "Infinity"
+    }
+
+    "render negative infinity as null" in {
+      render(JDouble(Double.NegativeInfinity)) must_== "-Infinity"
+    }
+
+    "render NaN as null" in {
+      render(JDouble(Double.NaN)) must_== "NaN"
+    }
+  }
+
+  "rendering special double values with special value exceptions enabled" should {
+    def render(json: JValue) = {
+      JsonAST.render(
+        json,
+        JsonAST.RenderSettings(0, doubleRenderer = JsonAST.FailToRenderSpecialValues)
+      )
+    }
+
+    "render a standard double as is" in {
+      val double = Random.nextDouble
+      render(JDouble(double)) must_== double.toString
+    }
+
+    "render positive infinity as null" in {
+      render(JDouble(Double.PositiveInfinity)) must throwAn[IllegalArgumentException]
+    }
+
+    "render negative infinity as null" in {
+      render(JDouble(Double.NegativeInfinity)) must throwAn[IllegalArgumentException]
+    }
+
+    "render NaN as null" in {
+      render(JDouble(Double.NaN)) must throwAn[IllegalArgumentException]
     }
   }
 

--- a/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
@@ -59,7 +59,7 @@ object JsonPrintingSpec extends Specification  with JValueGen with ScalaCheck {
     def render(json: JValue) = {
       JsonAST.render(
         json,
-        JsonAST.RenderSettings(0, doubleRenderer = JsonAST.RenderSpecialValuesAsIs)
+        JsonAST.RenderSettings(0, doubleRenderer = JsonAST.RenderSpecialDoubleValuesAsIs)
       )
     }
 
@@ -85,7 +85,7 @@ object JsonPrintingSpec extends Specification  with JValueGen with ScalaCheck {
     def render(json: JValue) = {
       JsonAST.render(
         json,
-        JsonAST.RenderSettings(0, doubleRenderer = JsonAST.FailToRenderSpecialValues)
+        JsonAST.RenderSettings(0, doubleRenderer = JsonAST.FailToRenderSpecialDoubleValues)
       )
     }
 


### PR DESCRIPTION
Before now, we were serializing these as their Scala string equivalents. This
meant only JavaScript when evaling JSON as actual JavaScript could deserialize 
it. lift-json itself couldn't deserialize the serialized special values, in fact.

We also make this behavior customizable by providing a `RenderSettings`
parameter, `DoubleRenderer`, which is charged with taking a `Double` and
rendering it to `String`. Three variants are provided: an as-is renderer that is
identical to pre-3.1 handling of special `Double` values like `NaN`, the new
null-special-values renderer that has the behavior described above, and a
new behavior, `FailToRenderSpecialValues`, which throws an exception when
a special `Double` value is encountered rather than serializing it in any way.

Still an open question on the list:
 - [x] [Should we provide a Formats toggle for this behavior?](https://groups.google.com/d/msg/liftweb/7p9CNfClhhM/GaQy3HqDAwAJ)

This is a fix for #1780.