### PR TITLE
Add workaround for travis issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_script:
   - "cd web/webkit"
   - "npm install"
   - "cd -"
+  - sudo chmod +x /usr/local/bin/sbt
 
 notifications:
   webhooks:


### PR DESCRIPTION
As of the 2017-05-04 update to travis Precise images, /usr/local/bin/sbt is not
actually executable out of the box. We add a before_script hook per the
recommendation issued by the travis folks at travis-ci/travis-ci#7703 in order
to make sbt executable again, allowing the rest of the build to continue
normally.