### PR TITLE
Rushed Responder: Always suspend comet requests before resuming them.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
@@ -117,6 +117,10 @@ class LiftServlet extends Loggable {
       try {
         reqOrg.request.suspend(cometTimeout)
       } finally {
+        // FIXME This should be removed from the finally block in the next major
+        // FIXME Lift version; it is currently here to ensure any code that
+        // FIXME depends on a response handler running even if requests suspension
+        // FIXME fails continues to work as-is during the 3.x series.
         runFunction(liftResponse => {
           // do the actual write on a separate thread
           Schedule.schedule(() => {

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
@@ -118,9 +118,9 @@ class LiftServlet extends Loggable {
         reqOrg.request.suspend(cometTimeout)
       } finally {
         // FIXME This should be removed from the finally block in the next major
-        // FIXME Lift version; it is currently here to ensure any code that
-        // FIXME depends on a response handler running even if requests suspension
-        // FIXME fails continues to work as-is during the 3.x series.
+        // FIXME Lift version; it is currently here to ensure code continues to
+        // FIXME work as-is during the 3.x series even if it depends on response
+        // FIXME handlers running when request suspension fails.
         runFunction(liftResponse => {
           // do the actual write on a separate thread
           Schedule.schedule(() => {


### PR DESCRIPTION
When a container supports request suspension, we were first scheduling a
function to resume the request on a different thread and then suspending the
request. While the function was scheduled in the future, the fact that it was
scheduled before the suspend had definitively occurred meant there were thread
schedulings where the resume could occur before the suspend had executed,
leading to exceptions.

We now suspend the request *before* scheduling the resume. We schedule the
resume in a finally block to most closely track current behaviors when the
thread scheduling was correct, in which a resume would occur whether or not the
suspend threw an exception. I'm not certain about the full shape of that edge
case, so for now we take the least-changed path to dealing with it while still
addressing the core reported problem.

Should fix #1848.

@waern any chance you could give this a test drive?