### PR TITLE
Loggable Boxes: Add BoxLogging helpers.

### DIFF
--- a/core/common/src/main/scala/net/liftweb/common/BoxLogging.scala
+++ b/core/common/src/main/scala/net/liftweb/common/BoxLogging.scala
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2007-2017 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package common
+
+/**
+ * Mix this trait in to get some low-cost implicits for logging boxes
+ * easily. The consumer will need to implement a `[[logBoxError]]`
+ * method to log messages with an optional `Throwable`, as well as its related
+ * friends for trace, debug, info, and warn levels. This allows abstracting out
+ * where and what the actual logger is.
+ *
+ * With this mixed in, boxes will have `[[logFailure]]` and
+ * `[[logFailure]]` methods. The first logs all `[[Failure]]`s as well
+ * as `[[Empty]]`. The second logs only `Failure`s and
+ * `[[ParamFailure]]`s, treating `Empty` as a valid value. These both log their
+ * respective items at ERROR level. You can also use `traceLog*`, `debugLog*`,
+ * `infoLog*`, and `warnLog*` if you want to log at other levels (e.g., you can
+ * use `infoLogFailure` to log an `Empty` or `Failure` at `INFO` level).
+ *
+ * All of these return the box unchanged, so you can continue to use it
+ * in `for` comprehensions, call `openOr` on it, etc.
+ *
+ * There is an implementation for anyone who wants to use Lift's
+ * `[[Loggable]]` trait called `[[LoggableBoxLogging]]`. Another implementaiton
+ * is available for use with a plain SLF4J logger, `SLF4JBoxLogging`. You can
+ * also implement a version for any other logging adapter. Lastly, you can
+ * simply import `BoxLogging._` to get the methods available at a top level;
+ * however, note that using them this way will lose information about where the
+ * log message came from.
+ *
+ * Here is an example of how you might use this in system that executes a third-
+ * party service and notifies another system of failures.
+ *
+ * {{{
+ * val systemResult: Box[ServiceReturn] =
+ *   system
+ *     .executeService(true, requester)
+ *     .map(...)
+ *     .logFailure("Failed to execute service") match {
+ *       case Full(content) =>
+ *         content
+ *       case failure: Failure =>
+ *         otherSystem.notifyFailure(failure)
+ *       case Empty =>
+ *         otherSystem.notifyFailure(Failure("No idea what happened."))
+ *     }
+ * }}}
+ */
+trait BoxLogging {
+  private[this] def logBoxError(message: String): Unit = {
+    logBoxError(message, None)
+  }
+  private[this] def logBoxWarn(message: String): Unit = {
+    logBoxWarn(message, None)
+  }
+  private[this] def logBoxInfo(message: String): Unit = {
+    logBoxInfo(message, None)
+  }
+  private[this] def logBoxDebug(message: String): Unit = {
+    logBoxDebug(message, None)
+  }
+  private[this] def logBoxTrace(message: String): Unit = {
+    logBoxTrace(message, None)
+  }
+
+  /**
+   * Called with an error message and possibly a throwable that caused
+   * the error in question. Should ERROR log the message and the throwable.
+   *
+   * Exists in order to abstract away logger abstractions. Abstractception,
+   * as it were.
+   */
+  protected def logBoxError(message: String, throwable: Option[Throwable]): Unit
+  /**
+   * Called with a warn message and possibly a throwable that caused the issue
+   * in question. Should WARN log the message and the throwable.
+   *
+   * Exists in order to abstract away logger abstractions. Abstractception,
+   * as it were.
+   */
+  protected def logBoxWarn(message: String, throwable: Option[Throwable]): Unit
+  /**
+   * Called with an info message and possibly a throwable that caused the issue
+   * in question. Should INFO log the message and the throwable.
+   *
+   * Exists in order to abstract away logger abstractions. Abstractception,
+   * as it were.
+   */
+  protected def logBoxInfo(message: String, throwable: Option[Throwable]): Unit
+  /**
+   * Called with a debug message and possibly a throwable that caused the issue
+   * in question. Should DEBUG log the message and the throwable.
+   *
+   * Exists in order to abstract away logger abstractions. Abstractception,
+   * as it were.
+   */
+  protected def logBoxDebug(message: String, throwable: Option[Throwable]): Unit
+  /**
+   * Called with a trace message and possibly a throwable that caused the issue
+   * in question. Should TRACE log the message and the throwable.
+   *
+   * Exists in order to abstract away logger abstractions. Abstractception,
+   * as it were.
+   */
+  protected def logBoxTrace(message: String, throwable: Option[Throwable]): Unit
+
+  implicit class LogEmptyOrFailure[T](val box: Box[T]) extends AnyRef {
+    private def doLog(message: String, logFn: (String, Option[Throwable])=>Unit, onEmpty: ()=>Unit) = {
+      box match {
+        case ParamFailure(failureMessage, exception, Full(chain), param) =>
+          logFn(s"$message: $failureMessage with param $param", exception)
+          chain.logFailure(s"$failureMessage with param $param caused by", logFn)
+
+        case ParamFailure(failureMessage, exception, _, param) =>
+          logFn(s"$message: $failureMessage with param $param", exception)
+
+        case Failure(failureMessage, exception, Full(chain)) =>
+          logFn(s"$message: $failureMessage", exception)
+          chain.logFailure(s"$failureMessage caused by", logFn)
+
+        case Failure(failureMessage, exception, _) =>
+          logFn(s"$message: $failureMessage", exception)
+
+        case Empty =>
+          onEmpty()
+
+        case _: Full[_] => // nothing to log
+      }
+    }
+
+    private def logFailure(message: String, logFn: (String, Option[Throwable])=>Unit): Unit = {
+      doLog(message, logFn, ()=>logFn(s"$message: Box was Empty.", None))
+    }
+
+    def logEmptyBox(message: String): Box[T] = {
+      doLog(message, logBoxError, ()=>logBoxError(s"$message: Box was Empty."))
+      box
+    }
+
+    def warnLogEmptyBox(message: String): Box[T] = {
+      doLog(message, logBoxWarn, ()=>logBoxWarn(s"$message: Box was Empty."))
+      box
+    }
+
+    def infoLogEmptyBox(message: String): Box[T] = {
+      doLog(message, logBoxInfo, ()=>logBoxInfo(s"$message: Box was Empty."))
+      box
+    }
+
+    def debugLogEmptyBox(message: String): Box[T] = {
+      doLog(message, logBoxDebug, ()=>logBoxDebug(s"$message: Box was Empty."))
+      box
+    }
+
+    def traceLogEmptyBox(message: String): Box[T] = {
+      doLog(message, logBoxTrace, ()=>logBoxTrace(s"$message: Box was Empty."))
+      box
+    }
+
+    def logFailure(message: String): Box[T] = {
+      doLog(message, logBoxError, ()=>())
+      box
+    }
+
+    def warnLogFailure(message: String): Box[T] = {
+      doLog(message, logBoxWarn, ()=>())
+      box
+    }
+
+    def infoLogFailure(message: String): Box[T] = {
+      doLog(message, logBoxInfo, ()=>())
+      box
+    }
+
+    def debugLogFailure(message: String): Box[T] = {
+      doLog(message, logBoxDebug, ()=>())
+      box
+    }
+
+    def traceLogFailure(message: String): Box[T] = {
+      doLog(message, logBoxTrace, ()=>())
+      box
+    }
+  }
+}
+
+/**
+ * A version of `[[BoxLogging]]` with a default implementation of
+ * `logBoxError` that logs to the logger provided by Lift's
+ * `[[Loggable]]`.
+ */
+trait LoggableBoxLogging extends BoxLogging with Loggable {
+  protected def logBoxError(message: String, throwable: Option[Throwable]) = {
+    throwable match {
+      case Some(throwable) =>
+        logger.error(message, throwable)
+      case _ =>
+        logger.error(message)
+    }
+  }
+  protected def logBoxWarn(message: String, throwable: Option[Throwable]) = {
+    throwable match {
+      case Some(throwable) =>
+        logger.warn(message, throwable)
+      case _ =>
+        logger.warn(message)
+    }
+  }
+  protected def logBoxInfo(message: String, throwable: Option[Throwable]) = {
+    throwable match {
+      case Some(throwable) =>
+        logger.info(message, throwable)
+      case _ =>
+        logger.info(message)
+    }
+  }
+  protected def logBoxDebug(message: String, throwable: Option[Throwable]) = {
+    throwable match {
+      case Some(throwable) =>
+        logger.debug(message, throwable)
+      case _ =>
+        logger.debug(message)
+    }
+  }
+  protected def logBoxTrace(message: String, throwable: Option[Throwable]) = {
+    throwable match {
+      case Some(throwable) =>
+        // Below, disambiguate between the trace helper for tracing a value and
+        // the one that takes a throwable.
+        logger.trace(message: AnyRef, throwable)
+      case _ =>
+        logger.trace(message)
+    }
+  }
+}
+
+trait SLF4JBoxLogging extends BoxLogging {
+  protected val logger: org.slf4j.Logger
+
+  protected def logBoxError(message: String, throwable: Option[Throwable]) = {
+    throwable match {
+      case Some(throwable) =>
+        logger.error(message, throwable)
+      case _ =>
+        logger.error(message)
+    }
+  }
+  protected def logBoxWarn(message: String, throwable: Option[Throwable]) = {
+    throwable match {
+      case Some(throwable) =>
+        logger.warn(message, throwable)
+      case _ =>
+        logger.warn(message)
+    }
+  }
+  protected def logBoxInfo(message: String, throwable: Option[Throwable]) = {
+    throwable match {
+      case Some(throwable) =>
+        logger.info(message, throwable)
+      case _ =>
+        logger.info(message)
+    }
+  }
+  protected def logBoxDebug(message: String, throwable: Option[Throwable]) = {
+    throwable match {
+      case Some(throwable) =>
+        logger.debug(message, throwable)
+      case _ =>
+        logger.debug(message)
+    }
+  }
+  protected def logBoxTrace(message: String, throwable: Option[Throwable]) = {
+    throwable match {
+      case Some(throwable) =>
+        logger.trace(message, throwable)
+      case _ =>
+        logger.trace(message)
+    }
+  }
+}
+
+/**
+ * A convenience singleton for `[[BoxLogging]]` that makes `logFailure`
+ * and `logFailure` available for all code after it's been imported
+ * as `import com.elemica.common.BoxLogging._`. Logging done this way
+ * will come from `BoxLogging`, not from the class where the box was
+ * logged.
+ */
+object BoxLogging extends LoggableBoxLogging

--- a/core/common/src/test/scala/net/liftweb/common/BoxLoggingSpec.scala
+++ b/core/common/src/test/scala/net/liftweb/common/BoxLoggingSpec.scala
@@ -1,0 +1,454 @@
+package net.liftweb
+package common
+
+import org.slf4j.{Logger=>SLF4JLogger}
+
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+object BoxLoggingSpec extends Specification with Mockito {
+  class MockBoxLoggingClass extends BoxLogging {
+    var loggedErrors = List[(String, Option[Throwable])]()
+    var loggedWarns = List[(String, Option[Throwable])]()
+    var loggedInfos = List[(String, Option[Throwable])]()
+    var loggedDebugs = List[(String, Option[Throwable])]()
+    var loggedTraces = List[(String, Option[Throwable])]()
+
+    protected def logBoxError(message: String, throwable: Option[Throwable]): Unit = {
+      loggedErrors ::= (message, throwable)
+    }
+    protected def logBoxWarn(message: String, throwable: Option[Throwable]): Unit = {
+      loggedWarns ::= (message, throwable)
+    }
+    protected def logBoxInfo(message: String, throwable: Option[Throwable]): Unit = {
+      loggedInfos ::= (message, throwable)
+    }
+    protected def logBoxDebug(message: String, throwable: Option[Throwable]): Unit = {
+      loggedDebugs ::= (message, throwable)
+    }
+    protected def logBoxTrace(message: String, throwable: Option[Throwable]): Unit = {
+      loggedTraces ::= (message, throwable)
+    }
+  }
+
+  "BoxLogging" should {
+    "when logging empty boxes" in {
+      def verifyContentList(list: List[(String, Option[Throwable])]) = {
+        list must beLike {
+          case (paramFailure4, None) ::
+               (paramFailure3, None) ::
+               (paramFailure2, None) ::
+               (paramFailure1, Some(paramExp)) ::
+               (chained1, None) ::
+               (chained2, None) ::
+               (level1, None) ::
+               (level2, Some(exp2)) ::
+               (level3, None) ::
+               (level4, Some(exp4)) ::
+               (emptyMessage, None) ::
+               (fullParamMessage, Some(paramException)) ::
+               (paramMessage, None) ::
+               (exceptedMessage, Some(failureException)) ::
+               (failureMessage, None) ::
+               Nil =>
+            (failureMessage must startWith("Second")) and
+              (failureMessage must contain("Failed")) and
+              (exceptedMessage must startWith("Third")) and
+              (exceptedMessage must contain("Excepted")) and
+              (failureException.getMessage must_== "uh-oh") and
+              (paramMessage must startWith("Fourth")) and
+              (paramMessage must contain("ParamFailed")) and
+              (paramMessage must contain("BoxLoggingSpec")) and
+              (fullParamMessage must startWith("Fifth")) and
+              (fullParamMessage must contain("ParamExcepted")) and
+              (fullParamMessage must contain("BoxLoggingSpec")) and
+              (paramException.getMessage must_== "param uh-oh") and
+              (emptyMessage must startWith("Sixth")) and
+              (emptyMessage must contain("Empty")) and
+              (level1 must contain("Failure level 3 caused by: Failure level 4")) and
+              (level2 must contain("Failure level 2 caused by: Failure level 3")) and
+              (exp2 must beAnInstanceOf[IllegalArgumentException]) and
+              (level3 must contain("Failure level 1 caused by: Failure level 2")) and
+              (level4 must contain("Multilevel failure: Failure level 1")) and
+              (exp4 must beAnInstanceOf[NullPointerException]) and
+              (chained1 must contain("Chained failure caused by: Boom")) and
+              (chained2 must contain("Chain all failures: Chained failure")) and
+              (paramFailure4 must contain("Param Failure lvl 3 with param Param 3 caused by: Param Failure lvl 4 with param Param 4")) and
+              (paramFailure3 must contain("Failure lvl 2 caused by: Param Failure lvl 3 with param Param 3")) and
+              (paramFailure2 must contain("Param Failure lvl 1 with param Param 1 caused by: Failure lvl 2")) and
+              (paramFailure1 must contain("Param failure: Param Failure lvl 1 with param Param 1")) and
+              (paramExp must beAnInstanceOf[IllegalArgumentException])
+        }
+      }
+
+      "log correctly on ERROR level" in {
+        val results =
+          new MockBoxLoggingClass {
+            Full("Not empty").logEmptyBox("First")
+            Failure("Failed").logEmptyBox("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).logEmptyBox("Third")
+            ParamFailure("ParamFailed", this).logEmptyBox("Fourth")
+            ParamFailure(
+              "ParamExcepted",
+              Full(new Exception("param uh-oh")),
+              Empty,
+              this
+            ).logEmptyBox("Fifth")
+            (Empty).logEmptyBox("Sixth")
+            Failure(
+              "Failure level 1", Full(new NullPointerException), Full(Failure(
+                "Failure level 2", Empty, Full(Failure(
+                  "Failure level 3", Full(new IllegalArgumentException), Full(Failure(
+                    "Failure level 4"
+                  )))
+                ))
+              )
+            ).logEmptyBox("Multilevel failure")
+            (Failure("Boom") ?~! "Chained failure").logEmptyBox("Chain all failures")
+            ParamFailure(
+              "Param Failure lvl 1", Full(new IllegalArgumentException), Full(Failure(
+                "Failure lvl 2", Empty, Full(ParamFailure(
+                  "Param Failure lvl 3", Empty, Full(ParamFailure(
+                    "Param Failure lvl 4",
+                    "Param 4"
+                  )),
+                  "Param 3"
+                ))
+              )),
+              "Param 1"
+            ).logEmptyBox("Param failure")
+          }
+
+        verifyContentList(results.loggedErrors)
+      }
+
+      "log correctly on WARN level" in {
+        val results =
+          new MockBoxLoggingClass {
+            Full("Not empty").warnLogEmptyBox("First")
+            Failure("Failed").warnLogEmptyBox("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).warnLogEmptyBox("Third")
+            ParamFailure("ParamFailed", this).warnLogEmptyBox("Fourth")
+            ParamFailure(
+              "ParamExcepted",
+              Full(new Exception("param uh-oh")),
+              Empty,
+              this
+            ).warnLogEmptyBox("Fifth")
+            (Empty).warnLogEmptyBox("Sixth")
+            Failure(
+              "Failure level 1", Full(new NullPointerException), Full(Failure(
+                "Failure level 2", Empty, Full(Failure(
+                  "Failure level 3", Full(new IllegalArgumentException), Full(Failure(
+                    "Failure level 4"
+                  )))
+                ))
+              )
+            ).warnLogEmptyBox("Multilevel failure")
+            (Failure("Boom") ?~! "Chained failure").warnLogEmptyBox("Chain all failures")
+            ParamFailure(
+              "Param Failure lvl 1", Full(new IllegalArgumentException), Full(Failure(
+                "Failure lvl 2", Empty, Full(ParamFailure(
+                  "Param Failure lvl 3", Empty, Full(ParamFailure(
+                    "Param Failure lvl 4",
+                    "Param 4"
+                  )),
+                  "Param 3"
+                ))
+              )),
+              "Param 1"
+            ).warnLogEmptyBox("Param failure")
+          }
+
+        verifyContentList(results.loggedWarns)
+      }
+
+      "log correctly on INFO level" in {
+        val results =
+          new MockBoxLoggingClass {
+            Full("Not empty").infoLogEmptyBox("First")
+            Failure("Failed").infoLogEmptyBox("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).infoLogEmptyBox("Third")
+            ParamFailure("ParamFailed", this).infoLogEmptyBox("Fourth")
+            ParamFailure(
+              "ParamExcepted",
+              Full(new Exception("param uh-oh")),
+              Empty,
+              this
+            ).infoLogEmptyBox("Fifth")
+            (Empty).infoLogEmptyBox("Sixth")
+            Failure(
+              "Failure level 1", Full(new NullPointerException), Full(Failure(
+                "Failure level 2", Empty, Full(Failure(
+                  "Failure level 3", Full(new IllegalArgumentException), Full(Failure(
+                    "Failure level 4"
+                  )))
+                ))
+              )
+            ).infoLogEmptyBox("Multilevel failure")
+            (Failure("Boom") ?~! "Chained failure").infoLogEmptyBox("Chain all failures")
+            ParamFailure(
+              "Param Failure lvl 1", Full(new IllegalArgumentException), Full(Failure(
+                "Failure lvl 2", Empty, Full(ParamFailure(
+                  "Param Failure lvl 3", Empty, Full(ParamFailure(
+                    "Param Failure lvl 4",
+                    "Param 4"
+                  )),
+                  "Param 3"
+                ))
+              )),
+              "Param 1"
+            ).infoLogEmptyBox("Param failure")
+          }
+
+        verifyContentList(results.loggedInfos)
+      }
+
+      "log correctly on DEBUG level" in {
+        val results =
+          new MockBoxLoggingClass {
+            Full("Not empty").debugLogEmptyBox("First")
+            Failure("Failed").debugLogEmptyBox("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).debugLogEmptyBox("Third")
+            ParamFailure("ParamFailed", this).debugLogEmptyBox("Fourth")
+            ParamFailure(
+              "ParamExcepted",
+              Full(new Exception("param uh-oh")),
+              Empty,
+              this
+            ).debugLogEmptyBox("Fifth")
+            (Empty).debugLogEmptyBox("Sixth")
+            Failure(
+              "Failure level 1", Full(new NullPointerException), Full(Failure(
+                "Failure level 2", Empty, Full(Failure(
+                  "Failure level 3", Full(new IllegalArgumentException), Full(Failure(
+                    "Failure level 4"
+                  )))
+                ))
+              )
+            ).debugLogFailure("Multilevel failure")
+            (Failure("Boom") ?~! "Chained failure").debugLogFailure("Chain all failures")
+            ParamFailure(
+              "Param Failure lvl 1", Full(new IllegalArgumentException), Full(Failure(
+                "Failure lvl 2", Empty, Full(ParamFailure(
+                  "Param Failure lvl 3", Empty, Full(ParamFailure(
+                    "Param Failure lvl 4",
+                    "Param 4"
+                  )),
+                  "Param 3"
+                ))
+              )),
+              "Param 1"
+            ).debugLogFailure("Param failure")
+          }
+
+        verifyContentList(results.loggedDebugs)
+      }
+
+      "log correctly on TRACE level" in {
+        val results =
+          new MockBoxLoggingClass {
+            Full("Not empty").traceLogEmptyBox("First")
+            Failure("Failed").traceLogEmptyBox("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).traceLogEmptyBox("Third")
+            ParamFailure("ParamFailed", this).traceLogEmptyBox("Fourth")
+            ParamFailure(
+              "ParamExcepted",
+              Full(new Exception("param uh-oh")),
+              Empty,
+              this
+            ).traceLogEmptyBox("Fifth")
+            (Empty).traceLogEmptyBox("Sixth")
+            Failure(
+              "Failure level 1", Full(new NullPointerException), Full(Failure(
+                "Failure level 2", Empty, Full(Failure(
+                  "Failure level 3", Full(new IllegalArgumentException), Full(Failure(
+                    "Failure level 4"
+                  )))
+                ))
+              )
+            ).traceLogEmptyBox("Multilevel failure")
+            (Failure("Boom") ?~! "Chained failure").traceLogEmptyBox("Chain all failures")
+            ParamFailure(
+              "Param Failure lvl 1", Full(new IllegalArgumentException), Full(Failure(
+                "Failure lvl 2", Empty, Full(ParamFailure(
+                  "Param Failure lvl 3", Empty, Full(ParamFailure(
+                    "Param Failure lvl 4",
+                    "Param 4"
+                  )),
+                  "Param 3"
+                ))
+              )),
+              "Param 1"
+            ).traceLogEmptyBox("Param failure")
+          }
+
+        verifyContentList(results.loggedTraces)
+      }
+    }
+
+    "when logging only failures" in {
+      def verifyContentList(list: List[(String, Option[Throwable])]) = {
+        list must beLike {
+          case (fullParamMessage, Some(paramException)) ::
+                  (paramMessage, None) ::
+                  (exceptedMessage, Some(failureException)) ::
+                  (failureMessage, None) ::
+                  Nil =>
+            (failureMessage must startWith("Second")) and
+              (failureMessage must contain("Failed")) and
+              (exceptedMessage must startWith("Third")) and
+              (exceptedMessage must contain("Excepted")) and
+              (failureException.getMessage must_== "uh-oh") and
+              (paramMessage must startWith("Fourth")) and
+              (paramMessage must contain("ParamFailed")) and
+              (paramMessage must contain("BoxLoggingSpec")) and
+              (fullParamMessage must startWith("Fifth")) and
+              (fullParamMessage must contain("ParamExcepted")) and
+              (fullParamMessage must contain("BoxLoggingSpec")) and
+              (paramException.getMessage must_== "param uh-oh")
+        }
+      }
+
+      "log correctly on ERROR level" in {
+        val results =
+          new MockBoxLoggingClass {
+            Full("Not empty").logFailure("First")
+            Failure("Failed").logFailure("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).logFailure("Third")
+            ParamFailure("ParamFailed", this).logFailure("Fourth")
+            ParamFailure(
+              "ParamExcepted",
+              Full(new Exception("param uh-oh")),
+              Empty,
+              this
+            ).logFailure("Fifth")
+            (Empty).logFailure("Sixth")
+          }
+
+        verifyContentList(results.loggedErrors)
+      }
+
+      "log correctly on WARN level" in {
+        val results =
+          new MockBoxLoggingClass {
+            Full("Not empty").warnLogFailure("First")
+            Failure("Failed").warnLogFailure("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).warnLogFailure("Third")
+            ParamFailure("ParamFailed", this).warnLogFailure("Fourth")
+            ParamFailure(
+              "ParamExcepted",
+              Full(new Exception("param uh-oh")),
+              Empty,
+              this
+            ).warnLogFailure("Fifth")
+            (Empty).warnLogFailure("Sixth")
+          }
+
+        verifyContentList(results.loggedWarns)
+      }
+
+      "log correctly on INFO level" in {
+        val results =
+          new MockBoxLoggingClass {
+            Full("Not empty").infoLogFailure("First")
+            Failure("Failed").infoLogFailure("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).infoLogFailure("Third")
+            ParamFailure("ParamFailed", this).infoLogFailure("Fourth")
+            ParamFailure(
+              "ParamExcepted",
+              Full(new Exception("param uh-oh")),
+              Empty,
+              this
+            ).infoLogFailure("Fifth")
+            (Empty).infoLogFailure("Sixth")
+          }
+
+        verifyContentList(results.loggedInfos)
+      }
+
+      "log correctly on DEBUG level" in {
+        val results =
+          new MockBoxLoggingClass {
+            Full("Not empty").debugLogFailure("First")
+            Failure("Failed").debugLogFailure("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).debugLogFailure("Third")
+            ParamFailure("ParamFailed", this).debugLogFailure("Fourth")
+            ParamFailure(
+              "ParamExcepted",
+              Full(new Exception("param uh-oh")),
+              Empty,
+              this
+            ).debugLogFailure("Fifth")
+            (Empty).debugLogFailure("Sixth")
+          }
+
+        verifyContentList(results.loggedDebugs)
+      }
+
+      "log correctly on TRACE level" in {
+        val results =
+          new MockBoxLoggingClass {
+            Full("Not empty").traceLogFailure("First")
+            Failure("Failed").traceLogFailure("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).traceLogFailure("Third")
+            ParamFailure("ParamFailed", this).traceLogFailure("Fourth")
+            ParamFailure(
+              "ParamExcepted",
+              Full(new Exception("param uh-oh")),
+              Empty,
+              this
+            ).traceLogFailure("Fifth")
+            (Empty).traceLogFailure("Sixth")
+          }
+
+        verifyContentList(results.loggedTraces)
+      }
+    }
+
+    "when logging in a Loggable" in {
+      import net.liftweb.common.Logger
+      import org.slf4j.{Logger => SLF4JLogger}
+
+      val mockLogger = mock[SLF4JLogger]
+      mockLogger.isErrorEnabled() returns true
+
+      class MyLoggable extends LoggableBoxLogging {
+        override val logger = new Logger {
+          override protected def _logger = mockLogger
+        }
+      }
+
+      "log to the Lift logger" in {
+        val result =
+          new MyLoggable {
+            Failure("Failed").logFailure("Second")
+            Failure("Excepted", Full(new Exception("uh-oh")), Empty).logFailure("Third")
+          }
+
+        (there was one(mockLogger).error(any[String])) and
+        (there was one(mockLogger).error(any[String], any[Exception]))
+      }
+    }
+
+    "when logging with in SLF4J context" in {
+      import org.slf4j.{Logger => SLF4JLogger}
+
+      val mockLogger = mock[SLF4JLogger]
+
+      class TestClass extends SLF4JBoxLogging {
+        val logger = mockLogger
+      }
+
+      "log to the SLF4J logger" in {
+        new TestClass {
+          Failure("Failed").logFailure("Second")
+          Failure("Excepted", Full(new Exception("uh-oh")), Empty).logFailure("Third")
+        }
+
+        there was one(mockLogger).error(any[String])
+        there was one(mockLogger).error(any[String], any[Exception])
+      }
+    }
+  }
+}

--- a/core/common/src/test/scala/net/liftweb/common/HListSpec.scala
+++ b/core/common/src/test/scala/net/liftweb/common/HListSpec.scala
@@ -81,6 +81,8 @@ object HListSpec extends Specification {
 
           success
         }
+
+        case Right(_) => failure
         case Left(_) => failure
       }
     }
@@ -90,7 +92,7 @@ object HListSpec extends Specification {
       import HLists._
 
       val res = for {
-        a :+: one :+: lst :+: _ <- 
+        a :+: one :+: lst :+: _ <-
         (Full("a") ?~ "Yak" :&: Full(1) :&: Full(List(1,2,3))) ?~! "Dude"
       } yield a.length * one * lst.foldLeft(1)(_ * _)
 

--- a/core/common/src/test/scala/net/liftweb/common/LoggingSpec.scala
+++ b/core/common/src/test/scala/net/liftweb/common/LoggingSpec.scala
@@ -37,27 +37,27 @@ object LoggingSpec extends Specification {
       (new MyTopClass).x must_== 1
       MyTopObj.x must_==1
     }
-    
+
     "be nested in object" in {
       object MyObj extends Loggable {
         logger.info("nested Hello")
         val x = 2
       }
-      
+
       MyObj.x must_== 2
-      
+
     }
-    
+
     "create named loggers" in {
       val logger = Logger("MyLogger")
-      
+
       logger.info("Logged with my named logger")
       success
     }
-    
+
     "log static MDC values" in {
       val logger = Logger("StaticMDC")
-      
+
       logger.info("Logged with no MDC")
       MDC.put("mdc1" -> (1,2))
       logger.info("Logged with mdc1=(1,2)")
@@ -71,17 +71,17 @@ object LoggingSpec extends Specification {
       logger.info("Logged with no MDC")
       success
     }
-    
+
     "save MDC context with logWith" in {
       val logger = Logger("logWith")
-      
+
       logger.info("Logged with no MDC")
       MDC.put("mdc1" -> (1,2), "mdc2" -> "yy")
       logger.info("Logged with mdc1=(1,2), mdc2=yy")
       Logger.logWith("mdc2" -> "xx") {
         logger.info("Logged with mdc1=(1,2), mdc2=xx")
         Logger.logWith("mdc1" -> 99) {
-           logger.info("Logged with mdc1=99, mdc2=xx") 
+           logger.info("Logged with mdc1=99, mdc2=xx")
         }
         logger.info("Logged with mdc1=(1,2), mdc2=xx")
       }
@@ -97,7 +97,7 @@ object LoggingSpec extends Specification {
           trace("result",l.foldLeft(0)(trace("lhs",_) + trace("rhs",_))) must_== l.foldLeft(0)(_+_)
           val x = 1
       }
-      MyObj.x
+      MyObj
       success
     }
 
@@ -106,12 +106,12 @@ object LoggingSpec extends Specification {
         First.info("In first")
       }
       object First extends Logger
-      
+
       trait Second {
         private val logger = Logger(classOf[Second])
         logger.info("In second")
       }
-      
+
       class C extends First with Second with Logger {
         info("In C")
         val x = 2


### PR DESCRIPTION
Direct lift from the commit message:

`BoxLogging` provides helpers for logging boxes and then continuing to operate on
the box, alloing logging to become a fluent part of the box interaction. It
provides methods that can allow for logging empties and failures, or just
failures. It also allows logging these to different log levels, and allows for
different adapters to be applied.

For example, one could write a snippet:

```scala
  class MySnippet(id: String) extends LoggableBoxLogging {
    def render = {
      "#content" #> {
        Content.getById(id).flatMap { content =>
          content.text.asHtml // assume this returns Box[NodeSeq]
        }.infoLogEmptyBox(s"Failed to retrieve content HTML for $id")
    }
  }
```

When this snippet gets rendered, if the provided content lookup fails, or if
the conversion to `NodeSeq` fails, there will be an INFO level log that will
capture this failure with the provided message prefix.

`BoxLogging` provides handling for arbitrary-depth failure chains, as well as
providing logging for failure params, thus ensuring all of the information in a
failure will be logged. It also correctly passes any captured Throwable to the
logger methods, provided that the adapter handles them correctly.

Two adapters are provided out of the box: `LoggableBoxLogging`, which can be
mixed in as above and is based on Lift's `Loggable`, and `SLF4JBoxLogging`,
which is based on the raw SLF4J interface, and requires a protected `logger`
`var` with an SLF4J logger to be available.

Lastly, for simplicity, you can `import net.liftweb.common.BoxLogging._` to have
the logging helpers available without mixing anything else into your classes.

We've been using this at @elemica with great success for a while now, so it's time
to contribute it on back to Lift. This version even grew some extra capabilities, with
the possibility of doing this logging at various log levels.

See #1856 .