### PR TITLE
Failure Collection: Fix LAFuture.collect/collectAll when sub-futures fail.

### DIFF
--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -176,7 +176,7 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler, context: Box[LAFutur
   /**
    * Java-friendly alias for completed_?.
    */
-  def isCompleted: Boolean = complete_?
+  def isCompleted: Boolean = completed_?
   /**
    * Has the future completed?
    */
@@ -389,10 +389,10 @@ object LAFuture {
               gotCnt += 1
               onFutureSucceeded(value, result, accumulator, index)
 
-              if (gotCnt >= len && ! result.complete_?) {
+              if (gotCnt >= len && ! result.completed_?) {
                 onAllFuturesCompleted(result, accumulator)
 
-                if (! result.complete_?) {
+                if (! result.completed_?) {
                   result.fail(Failure("collect invoker did not complete result"))
                 }
               }
@@ -403,10 +403,10 @@ object LAFuture {
               gotCnt += 1
               onFutureFailed(failureBox, result, accumulator, index)
 
-              if (gotCnt >= len && ! result.complete_?) {
+              if (gotCnt >= len && ! result.completed_?) {
                 onAllFuturesCompleted(result, accumulator)
 
-                if (! result.complete_?) {
+                if (! result.completed_?) {
                   result.fail(Failure("collect invoker did not complete result"))
                 }
               }

--- a/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
+++ b/core/actor/src/main/scala/net/liftweb/actor/LAFuture.scala
@@ -155,19 +155,35 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler, context: Box[LAFutur
   }
 
   /**
+   * Java-friendly alias for satisfied_?.
+   */
+  def isSatisfied: Boolean = satisfied_?
+
+  /**
    * Has the future been satisfied
    */
-  def isSatisfied: Boolean = synchronized {satisfied}
+  def satisfied_? = synchronized {satisfied}
+  /**
+   * Java-friendly alias for aborted_?.
+   */
+  def isAborted: Boolean = aborted_?
 
   /**
    * Has the future been aborted
    */
-  def isAborted: Boolean = synchronized {aborted}
+  def aborted_? = synchronized {satisfied}
 
   /**
-   * Has the future been satisfied or
+   * Java-friendly alias for completed_?.
    */
-  def isCompleted: Boolean = synchronized { ! (isSatisfied || isAborted) }
+  def isCompleted: Boolean = complete_?
+  /**
+   * Has the future completed?
+   */
+  def completed_? : Boolean = synchronized(satisfied || aborted)
+
+  @deprecated("Please use completed_? instead.", "3.1.0")
+  def complete_? : Boolean = completed_?
 
   /**
    * Abort the future.  It can never be satified
@@ -247,11 +263,6 @@ class LAFuture[T](val scheduler: LAScheduler = LAScheduler, context: Box[LAFutur
       }
     }
   }
-
-  /**
-   * Has the future completed?
-   */
-  def complete_? : Boolean = synchronized(satisfied || aborted)
 }
 
 /**

--- a/core/actor/src/test/scala/net/liftweb/actor/LAFutureSpec.scala
+++ b/core/actor/src/test/scala/net/liftweb/actor/LAFutureSpec.scala
@@ -1,6 +1,6 @@
 package net.liftweb.actor
 
-import net.liftweb.common.{Failure, Box}
+import net.liftweb.common.{Box, Failure, Full}
 import org.specs2.mutable.Specification
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -61,30 +61,81 @@ class LAFutureSpec extends Specification {
       result shouldEqual givenFailure
     }
 
-    "collect one future result" in {
-      val givenOneResult = 123
-      val one = LAFuture(() => givenOneResult)
-      LAFuture.collect(one).get(timeout) shouldEqual List(givenOneResult)
+    "when collecting results with LAFuture.collect" in {
+      "collect one future result" in {
+        val givenOneResult = 123
+        val one = LAFuture(() => givenOneResult)
+        LAFuture.collect(one).get(timeout) shouldEqual List(givenOneResult)
+      }
+
+      "collect more future results in correct order" in {
+        val givenOneResult = 123
+        val givenTwoResult = 234
+        val one = LAFuture(() => givenOneResult)
+        val two = LAFuture(() => givenTwoResult)
+        LAFuture.collect(one, two).get(timeout) shouldEqual List(givenOneResult, givenTwoResult)
+      }
+
+      "collect empty list immediately" in {
+        val collectResult = LAFuture.collect(Nil: _*)
+        collectResult.isSatisfied shouldEqual true
+        collectResult.get(timeout) shouldEqual Nil
+      }
+
+      "report a failed LAFuture as a failure for the overall future" in {
+        val one: LAFuture[Int] = new LAFuture
+        val two: LAFuture[Int] = LAFuture(() => 5)
+
+        one.fail(Failure("boom boom boom!"))
+
+        val collectResult = LAFuture.collect(one, two)
+        collectResult.get(timeout) shouldEqual Failure("boom boom boom!")
+      }
     }
 
-    "collect more future results in correct order" in {
-      val givenOneResult = 123
-      val givenTwoResult = 234
-      val one = LAFuture(() => givenOneResult)
-      val two = LAFuture(() => givenTwoResult)
-      LAFuture.collect(one, two).get(timeout) shouldEqual List(givenOneResult, givenTwoResult)
-    }
+    "when collecting Boxed results with collectAll" in {
+      "collectAll collects an EmptyBox immediately" in {
+        val one: LAFuture[Box[Int]] = LAFuture(() => { Failure("whoops"): Box[Int] })
+        val two: LAFuture[Box[Int]] = LAFuture(() => { Thread.sleep(10000); Full(1) })
 
-    "collect empty list immediately" in {
-      val collectResult = LAFuture.collect(Nil: _*)
-      collectResult.isSatisfied shouldEqual true
-      collectResult.get(timeout) shouldEqual Nil
-    }
+        val collectResult = LAFuture.collectAll(one, two)
+        collectResult.get(5000) shouldEqual Failure("whoops")
+      }
 
-    "collectAll empty list immediately" in {
-      val collectResult = LAFuture.collectAll(Nil : _*)
-      collectResult.isSatisfied shouldEqual true
-      collectResult.get(timeout) shouldEqual Nil
+      "collectAll collects a set of Fulls" in {
+        val one: LAFuture[Box[Int]] = LAFuture(() => Full(1): Box[Int])
+        val two: LAFuture[Box[Int]] = LAFuture(() => Full(2): Box[Int])
+        val three: LAFuture[Box[Int]] = LAFuture(() => Full(3): Box[Int])
+
+        val collectResult = LAFuture.collectAll(one, two, three)
+        collectResult.get(timeout) shouldEqual Full(List(1, 2, 3))
+      }
+
+      "collectAll reports a failed LAFuture as a failure for the overall future" in {
+        val one: LAFuture[Box[Int]] = new LAFuture
+        val two: LAFuture[Box[Int]] = LAFuture(() => Full(5): Box[Int])
+
+        one.fail(Failure("boom boom boom!"))
+
+        val collectResult = LAFuture.collectAll(one, two)
+        collectResult.get(timeout) shouldEqual Failure("boom boom boom!")
+      }
+
+      "collectAll empty list immediately" in {
+        val collectResult = LAFuture.collectAll(Nil : _*)
+        collectResult.isSatisfied shouldEqual true
+        collectResult.get(timeout) shouldEqual Nil
+      }
+
+      "report a failed LAFuture as a failure for the overall future" in {
+        val one: LAFuture[Box[Int]] = new LAFuture
+        val two: LAFuture[Box[Int]] = LAFuture(() => Full(5): Box[Int])
+
+        one.fail(Failure("boom boom boom!"))
+
+        val collectResult = LAFuture.collectAll(one, two)
+        collectResult.get(timeout) shouldEqual Failure("boom boom boom!")
+      }
     }
   }
 


### PR DESCRIPTION
Before, this would cause the overall future to hang forever. We now fail the
overall future if any contained future fails.

We also refactor the way that collect and collectAll are written to go through
a common path, which is also available for third-party use, and we add some
extra specs around collect and collectAll behavior.

Fixes #1850 .