### PR TITLE
Use a custom implicitNotFound error for CSS transforms

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/CssSel.scala
+++ b/core/util/src/main/scala/net/liftweb/util/CssSel.scala
@@ -4,6 +4,7 @@ package util
 import common._
 import xml._
 import collection.mutable.ListBuffer
+import scala.annotation.implicitNotFound
 
 /**
  * Created with IntelliJ IDEA.
@@ -753,6 +754,7 @@ final class CssJBridge extends CssBindImplicits {
 
 }
 
+@implicitNotFound("The value you're attempting to use on the right hand side of the #> operator can't be automatically converted to a (NodeSeq)=>NodeSeq function. Consider binding the individual members of the class you're trying to use, or define an implicit CanBind[T] that tells Lift how to convert this to a (NodeSeq)=>NodeSeq.")
 trait CanBind[-T] {
   def apply(it: => T)(ns: NodeSeq): Seq[NodeSeq]
 }


### PR DESCRIPTION
**[Mailing List](https://groups.google.com/forum/#!forum/liftweb) thread**:
N/A

This adds a custom error message that provides a bit more direction when we can't find an implicit converter for a CSS transform. Tested it out by creating an error in a spec... it looks like this!

```
[error] /Users/matt/Projects/framework/core/util/src/test/scala/net/liftweb/util/CssSelectorSpec.scala:502: The value you're attempting to use on the right hand side of the #> operator can't be automatically converted to a (NodeSeq)=>NodeSeq function. Consider binding the individual members of the class you're trying to use, or define an implicit CanBind[T] that tells Lift how to convert this to a (NodeSeq)=>NodeSeq.
[error]       ".foo" #> Bacon("boo!")
[error]              ^
[error] one error found
```

Fixes #930 