### PR TITLE
Resolve some issues with swallowing exceptions in lift-json

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -272,6 +272,9 @@ object Extraction {
                      args.mkString(",") + "\narg types=" + args.map(a => if (a != null)
                        a.asInstanceOf[AnyRef].getClass.getName else "null").mkString(",") +
                      "\nconstructor=" + jconstructor, matchedException)
+
+              case unmatchedException =>
+                throw unmatchedException
             }
         }
       }

--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -265,11 +265,14 @@ object Extraction {
           val instance = jconstructor.newInstance(args.map(_.asInstanceOf[AnyRef]).toArray: _*)
           setFields(instance.asInstanceOf[AnyRef], json, jconstructor)
         } catch {
-          case e @ (_:IllegalArgumentException | _:InstantiationException) =>
-            fail("Parsed JSON values do not match with class constructor\nargs=" +
-                 args.mkString(",") + "\narg types=" + args.map(a => if (a != null)
-                   a.asInstanceOf[AnyRef].getClass.getName else "null").mkString(",") +
-                 "\nconstructor=" + jconstructor)
+          case exception: Exception =>
+            exception match {
+              case matchedException @ (_:IllegalArgumentException | _:InstantiationException) =>
+                fail("Parsed JSON values do not match with class constructor\nargs=" +
+                     args.mkString(",") + "\narg types=" + args.map(a => if (a != null)
+                       a.asInstanceOf[AnyRef].getClass.getName else "null").mkString(",") +
+                     "\nconstructor=" + jconstructor, matchedException)
+            }
         }
       }
 

--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -17,7 +17,7 @@
 package net.liftweb
 package json
 
-import java.lang.reflect.{Constructor => JConstructor, Type}
+import java.lang.reflect.{Constructor => JConstructor, Type, InvocationTargetException}
 import java.lang.{Integer => JavaInteger, Long => JavaLong, Short => JavaShort, Byte => JavaByte, Boolean => JavaBoolean, Double => JavaDouble, Float => JavaFloat}
 import java.util.Date
 import java.sql.Timestamp
@@ -272,6 +272,9 @@ object Extraction {
                      args.mkString(",") + "\narg types=" + args.map(a => if (a != null)
                        a.asInstanceOf[AnyRef].getClass.getName else "null").mkString(",") +
                      "\nconstructor=" + jconstructor, matchedException)
+
+              case exceptionThrownInConstructor: InvocationTargetException =>
+                fail("An exception was thrown in the class constructor during extraction", exceptionThrownInConstructor)
 
               case unmatchedException =>
                 throw unmatchedException

--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -261,7 +261,13 @@ object JsonParser {
 
     private def convert[A](x: Any, expectedType: Class[A]): A = {
       if (x == null) parser.fail("expected object or array")
-      try { x.asInstanceOf[A] } catch { case _: ClassCastException => parser.fail("unexpected " + x) }
+
+      try {
+        x.asInstanceOf[A]
+      } catch {
+        case cce: ClassCastException =>
+          parser.fail(s"failure during class conversion. I got $x but needed a type of $expectedType", cce)
+      }
     }
 
     def peekOption = if (stack.isEmpty) None else Some(stack.peek)

--- a/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
+++ b/core/json/src/test/scala/net/liftweb/json/ExtractionBugs.scala
@@ -168,4 +168,22 @@ object ExtractionBugs extends Specification {
 
     extracted must_== ("apple", "sammich", "bacon")
   }
+
+  "throw the correct exceptions when things go wrong during extraction" in {
+    implicit val formats = DefaultFormats
+
+    class Holder(bacon: String) {
+      throw new Exception("I'm an exception!")
+    }
+
+    val correctArgsAstRepresentation: JObject = JObject(List(
+      JField("bacon", JString("apple"))
+    ))
+
+    correctArgsAstRepresentation.extract[Holder] must throwA[MappingException].like {
+      case e =>
+        e.getMessage mustEqual "An exception was thrown in the class constructor during extraction"
+        e.getCause.getCause.getMessage mustEqual "I'm an exception!"
+    }
+  }
 }


### PR DESCRIPTION
This should resolve some issues with swallowing exceptions in lift-json extraction/parsing. I did an audit of everywhere `fail` is used and everywhere exceptions are caught in general and I think I got them all.

Closes #1774 