### PR TITLE
Save the server-port of the original request

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
@@ -19,9 +19,9 @@ package http
 package provider 
 package servlet 
 
-import java.io.{InputStream}
-import java.util.{Locale}
-import javax.servlet.http.{HttpServletRequest}
+import java.io.InputStream
+import java.util.Locale
+import javax.servlet.http.HttpServletRequest
 import org.apache.commons.fileupload.servlet._
 import org.apache.commons.fileupload.ProgressListener
 import net.liftweb.common._
@@ -127,7 +127,7 @@ class HTTPRequestServlet(val req: HttpServletRequest, val provider: HTTPProvider
     } yield id
 
   def extractFiles: List[ParamHolder] = (new Iterator[ParamHolder] {
-    val mimeUpload = (new ServletFileUpload)
+    val mimeUpload = new ServletFileUpload
     mimeUpload.setProgressListener(new ProgressListener {
       lazy val progList: (Long, Long, Int) => Unit = S.session.flatMap(_.progressListener) openOr LiftRules.progressListener
 
@@ -178,113 +178,4 @@ class HTTPRequestServlet(val req: HttpServletRequest, val provider: HTTPProvider
   }
 }
 
-private [servlet] class OfflineRequestSnapshot(req: HTTPRequest, val provider: HTTPProvider) extends HTTPRequest {
 
-  private val _cookies = List(req.cookies :_*)
-
-  private val _headers = List(req.headers :_*)
-
-  private val _params = List(req.params :_*)
-
-  private [this] val _serverPort = req.serverPort
-
-
-  def cookies: List[HTTPCookie] = _cookies
-
-  val authType: Box[String] = req.authType
-
-  def headers(name: String): List[String] = _headers.filter(_.name == name).map(_.name)
-
-  // Just as a sample, to be replaced later
-  def _newheaders(name: String): List[String] = {
-    _headers
-      .find(_.name.equalsIgnoreCase(name))
-      .map(_.values)
-      .getOrElse(Nil)
-  }
-
-  def headers: List[HTTPParam] = _headers
-
-  val contextPath: String = req.contextPath
-
-  val context: HTTPContext = req.context
-
-  val contentType: Box[String] = req.contentType
-
-  val uri: String = req.uri
-
-  val url: String = req.url
-
-  val queryString: Box[String] = req.queryString
-
-  def param(name: String): List[String] = _params.filter(_.name == name).map(_.name)
-
-  def params: List[HTTPParam] = _params
-
-  def paramNames: List[String] = _params.map(_.name)
-
-  /**
-   * Destroy the underlying servlet session... null for offline requests
-   */
-  def destroyServletSession() {
-    // do nothing here
-  }
-
-  val session: HTTPSession = req.session
-
-  val sessionId: Box[String] = req.sessionId
-
-  val remoteAddress: String = req.remoteAddress
-
-  val remotePort: Int = req.remotePort
-
-  val remoteHost: String = req.remoteHost
-
-  val serverName: String = req.serverName
-
-  val scheme: String = req.scheme
-
-  lazy val serverPort: Int = _serverPort match {
-    case 80 =>
-      headers("X-SSL")
-        .flatMap(Helpers.asBoolean)
-        .filter(identity)
-        .map(_ => 443)
-        .headOption
-        .getOrElse(80)
-    case x => x
-  }
-
-  val method: String = req.method
-
-  val resumeInfo : Option[(Req, LiftResponse)] = req.resumeInfo
-
-  def suspend(timeout: Long): RetryState.Value =
-    throw new UnsupportedOperationException("Cannot suspend a snapshot")
-
-  def resume(what: (Req, LiftResponse)): Boolean =
-    throw new UnsupportedOperationException("Cannot resume a snapshot")
-
-  def suspendResumeSupport_? = false
-
-  def inputStream: InputStream =
-    throw new UnsupportedOperationException("InputStream is not available")
-
-  val multipartContent_? : Boolean = req.multipartContent_?
-
-  def extractFiles: List[ParamHolder] =
-    throw new UnsupportedOperationException("It is unsafe to extract files")
-
-  val locale: Box[Locale] = req.locale
-
-  def setCharacterEncoding(encoding: String) =
-    throw new UnsupportedOperationException("It is unsafe to set the character encoding ")
-
-  def snapshot = this
-
-  /**
-   * The User-Agent of the request
-   */
-  lazy val userAgent: Box[String] =  headers find (_.name equalsIgnoreCase "user-agent") flatMap (_.values.headOption)
-
-}

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
@@ -186,6 +186,8 @@ private class OfflineRequestSnapshot(req: HTTPRequest, val provider: HTTPProvide
 
   private val _params = List(req.params :_*)
 
+  private val _serverPort = req.serverPort
+
 
   def cookies: List[HTTPCookie] = _cookies
 
@@ -234,8 +236,8 @@ private class OfflineRequestSnapshot(req: HTTPRequest, val provider: HTTPProvide
 
   val scheme: String = req.scheme
 
-  lazy val serverPort: Int = req.serverPort match {
-    case 80 => headers("X-SSL").flatMap(Helpers.asBoolean _).filter(a => a).map(a => 443).headOption getOrElse 80
+  lazy val serverPort: Int = _serverPort match {
+    case 80 => headers("X-SSL").flatMap(Helpers.asBoolean).filter(identity).map(a => 443).headOption getOrElse 80
     case x => x
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
@@ -186,7 +186,7 @@ private class OfflineRequestSnapshot(req: HTTPRequest, val provider: HTTPProvide
 
   private val _params = List(req.params :_*)
 
-  private val _serverPort = req.serverPort
+  private [this] val _serverPort = req.serverPort
 
 
   def cookies: List[HTTPCookie] = _cookies

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
@@ -237,7 +237,13 @@ private class OfflineRequestSnapshot(req: HTTPRequest, val provider: HTTPProvide
   val scheme: String = req.scheme
 
   lazy val serverPort: Int = _serverPort match {
-    case 80 => headers("X-SSL").flatMap(Helpers.asBoolean).filter(identity).map(a => 443).headOption getOrElse 80
+    case 80 =>
+      headers("X-SSL")
+        .flatMap(Helpers.asBoolean)
+        .filter(identity)
+        .map(_ => 443)
+        .headOption
+        .getOrElse(80)
     case x => x
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
@@ -178,7 +178,7 @@ class HTTPRequestServlet(val req: HttpServletRequest, val provider: HTTPProvider
   }
 }
 
-private class OfflineRequestSnapshot(req: HTTPRequest, val provider: HTTPProvider) extends HTTPRequest {
+private [servlet] class OfflineRequestSnapshot(req: HTTPRequest, val provider: HTTPProvider) extends HTTPRequest {
 
   private val _cookies = List(req.cookies :_*)
 
@@ -194,6 +194,14 @@ private class OfflineRequestSnapshot(req: HTTPRequest, val provider: HTTPProvide
   val authType: Box[String] = req.authType
 
   def headers(name: String): List[String] = _headers.filter(_.name == name).map(_.name)
+
+  // Just as a sample, to be replaced later
+  def _newheaders(name: String): List[String] = {
+    _headers
+      .find(_.name.equalsIgnoreCase(name))
+      .map(_.values)
+      .getOrElse(Nil)
+  }
 
   def headers: List[HTTPParam] = _headers
 

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshot.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshot.scala
@@ -1,0 +1,118 @@
+package net.liftweb.http.provider.servlet
+
+import java.io.InputStream
+import java.util.Locale
+
+import net.liftweb.common.Box
+import net.liftweb.http.provider._
+import net.liftweb.http.{LiftResponse, ParamHolder, Req}
+import net.liftweb.util.Helpers
+
+private [servlet] class OfflineRequestSnapshot(req: HTTPRequest, val provider: HTTPProvider) extends HTTPRequest {
+
+  private val _cookies = List(req.cookies :_*)
+
+  private val _headers = List(req.headers :_*)
+
+  private val _params = List(req.params :_*)
+
+  private [this] val _serverPort = req.serverPort
+
+
+  def cookies: List[HTTPCookie] = _cookies
+
+  val authType: Box[String] = req.authType
+
+  // Just as a sample, to be replaced later
+  def headers(name: String): List[String] = {
+    _headers
+      .find(_.name.equalsIgnoreCase(name))
+      .map(_.values)
+      .getOrElse(Nil)
+  }
+
+  def headers: List[HTTPParam] = _headers
+
+  val contextPath: String = req.contextPath
+
+  val context: HTTPContext = req.context
+
+  val contentType: Box[String] = req.contentType
+
+  val uri: String = req.uri
+
+  val url: String = req.url
+
+  val queryString: Box[String] = req.queryString
+
+  def param(name: String): List[String] = _params.filter(_.name == name).map(_.name)
+
+  def params: List[HTTPParam] = _params
+
+  def paramNames: List[String] = _params.map(_.name)
+
+  /**
+   * Destroy the underlying servlet session... null for offline requests
+   */
+  def destroyServletSession() {
+    // do nothing here
+  }
+
+  val session: HTTPSession = req.session
+
+  val sessionId: Box[String] = req.sessionId
+
+  val remoteAddress: String = req.remoteAddress
+
+  val remotePort: Int = req.remotePort
+
+  val remoteHost: String = req.remoteHost
+
+  val serverName: String = req.serverName
+
+  val scheme: String = req.scheme
+
+  lazy val serverPort: Int = _serverPort match {
+    case 80 =>
+      headers("X-SSL")
+        .flatMap(Helpers.asBoolean)
+        .filter(identity)
+        .map(_ => 443)
+        .headOption
+        .getOrElse(80)
+    case x => x
+  }
+
+  val method: String = req.method
+
+  val resumeInfo : Option[(Req, LiftResponse)] = req.resumeInfo
+
+  def suspend(timeout: Long): RetryState.Value =
+    throw new UnsupportedOperationException("Cannot suspend a snapshot")
+
+  def resume(what: (Req, LiftResponse)): Boolean =
+    throw new UnsupportedOperationException("Cannot resume a snapshot")
+
+  def suspendResumeSupport_? = false
+
+  def inputStream: InputStream =
+    throw new UnsupportedOperationException("InputStream is not available")
+
+  val multipartContent_? : Boolean = req.multipartContent_?
+
+  def extractFiles: List[ParamHolder] =
+    throw new UnsupportedOperationException("It is unsafe to extract files")
+
+  val locale: Box[Locale] = req.locale
+
+  def setCharacterEncoding(encoding: String) =
+    throw new UnsupportedOperationException("It is unsafe to set the character encoding ")
+
+  def snapshot = this
+
+  /**
+   * The User-Agent of the request
+   */
+  lazy val userAgent: Box[String] =  headers find (_.name equalsIgnoreCase "user-agent") flatMap (_.values.headOption)
+
+}

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshot.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshot.scala
@@ -10,13 +10,13 @@ import net.liftweb.util.Helpers
 
 private [servlet] class OfflineRequestSnapshot(req: HTTPRequest, val provider: HTTPProvider) extends HTTPRequest {
 
-  private val _cookies = List(req.cookies :_*)
+  private[this] val _cookies = List(req.cookies :_*)
 
-  private val _headers = List(req.headers :_*)
+  private[this] val _headers = List(req.headers :_*)
 
-  private val _params = List(req.params :_*)
+  private[this] val _params = List(req.params :_*)
 
-  private [this] val _serverPort = req.serverPort
+  private[this] val _serverPort = req.serverPort
 
 
   def cookies: List[HTTPCookie] = _cookies

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshot.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshot.scala
@@ -23,7 +23,6 @@ private [servlet] class OfflineRequestSnapshot(req: HTTPRequest, val provider: H
 
   val authType: Box[String] = req.authType
 
-  // Just as a sample, to be replaced later
   def headers(name: String): List[String] = {
     _headers
       .find(_.name.equalsIgnoreCase(name))
@@ -45,7 +44,12 @@ private [servlet] class OfflineRequestSnapshot(req: HTTPRequest, val provider: H
 
   val queryString: Box[String] = req.queryString
 
-  def param(name: String): List[String] = _params.filter(_.name == name).map(_.name)
+  def param(name: String): List[String] = {
+    _params
+      .find(_.name == name)
+      .map(_.values)
+      .getOrElse(Nil)
+  }
 
   def params: List[HTTPParam] = _params
 

--- a/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
@@ -47,11 +47,22 @@ object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
         falseSSLHeaderReq.serverPort shouldEqual 90
       }
     }
+
+    "have a 'param' method that returns the list of parameters with a given name (case-sensitive)" in {
+      val tennisParams = List("Roger Federer", "Raphael Nadal")
+      val swimmingParams = List("Michael Phelps", "Ian Thorpe")
+      val params = HTTPParam("tennis", tennisParams) :: HTTPParam("swimming", swimmingParams) :: Nil
+      val snapshot = getRequestSnapshot(80, params = params)
+
+      snapshot.param("tennis") shouldEqual tennisParams
+      snapshot.param("Tennis") should beEmpty
+      snapshot.param("swimming") shouldEqual swimmingParams
+    }
   }
 
   private[this] val xSSLHeader = HTTPParam(X_SSL, List("true")) :: Nil
 
-  private def getRequestSnapshot(originalPort: Int, headers: List[HTTPParam] = xSSLHeader) = {
+  private[this] def getRequestSnapshot(originalPort: Int, headers: List[HTTPParam] = xSSLHeader, params: List[HTTPParam] = Nil) = {
     val mockHttpRequest = mock[HTTPRequest]
     val httpProvider = new HTTPProvider {
       override protected def context: HTTPContext = null
@@ -59,7 +70,7 @@ object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
 
     when(mockHttpRequest.headers).thenReturn(headers)
     when(mockHttpRequest.cookies).thenReturn(Nil)
-    when(mockHttpRequest.params).thenReturn(Nil)
+    when(mockHttpRequest.params).thenReturn(params)
     when(mockHttpRequest.serverPort).thenReturn(originalPort)
     new OfflineRequestSnapshot(mockHttpRequest, httpProvider)
   }

--- a/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
@@ -26,6 +26,8 @@ object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
 
   private val X_SSL = "X-SSL"
 
+  var xx: Int = _
+
   "OfflineRequestSnapshot" should {
     "have a 'headers' method that returns the list of headers with a given name" in {
       val req = getRequestSnapshot(originalPort = 80)

--- a/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
@@ -24,7 +24,7 @@ import org.specs2.mock.Mockito
 
 object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
 
-  private val X_SSL = "X-SSL"
+  private[this] val X_SSL = "X-SSL"
 
   "OfflineRequestSnapshot" should {
     "have a 'headers' method that returns the list of headers with a given name" in {
@@ -49,7 +49,7 @@ object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
     }
   }
 
-  private val xSSLHeader = HTTPParam(X_SSL, List("true")) :: Nil
+  private[this] val xSSLHeader = HTTPParam(X_SSL, List("true")) :: Nil
 
   private def getRequestSnapshot(originalPort: Int, headers: List[HTTPParam] = xSSLHeader) = {
     val mockHttpRequest = mock[HTTPRequest]

--- a/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2010-2011 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb.http.provider.servlet
+
+import net.liftweb.http.provider._
+import net.liftweb.mockweb.WebSpec
+import org.mockito.Mockito._
+import org.specs2.mock.Mockito
+
+
+/**
+ * System under specification for Req.
+ */
+object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
+
+  "A snapshot request should" in {
+    val mockHttpRequest = mock[HTTPRequest]
+    val mockProvider = mock[HTTPProvider]
+    val headers = HTTPParam("X-SSL", List("true")) :: Nil
+    when(mockHttpRequest.headers).thenReturn(headers)
+    when(mockHttpRequest.cookies).thenReturn(Nil)
+    when(mockHttpRequest.params).thenReturn(Nil)
+    when(mockHttpRequest.serverPort).thenReturn(80)
+    val snapshotReq = new OfflineRequestSnapshot(mockHttpRequest, mockProvider)
+
+    "have a headers method that returns the list of headers with a given name" in {
+      snapshotReq.headers("X-SSL") shouldEqual List("true")
+
+      // this test shouldn't be successful
+      snapshotReq.headers("X-SSL") shouldEqual List("X-SSL")
+    }
+
+    "the new headers implementation should work correctly" in {
+      snapshotReq._newheaders("X-SSL") shouldEqual List("true")
+    }
+
+    "return server-port 443 when the X-SSL header is present" in {
+      snapshotReq.serverPort shouldEqual 443
+    }
+  }
+
+}
+

--- a/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
@@ -26,8 +26,6 @@ object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
 
   private val X_SSL = "X-SSL"
 
-  var xx: Int = _
-
   "OfflineRequestSnapshot" should {
     "have a 'headers' method that returns the list of headers with a given name" in {
       val req = getRequestSnapshot(originalPort = 80)

--- a/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
@@ -55,7 +55,9 @@ object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
 
   private def getRequestSnapshot(originalPort: Int, headers: List[HTTPParam] = xSSLHeader) = {
     val mockHttpRequest = mock[HTTPRequest]
-    val httpProvider = mock[HTTPProvider]
+    val httpProvider = new HTTPProvider {
+      override protected def context: HTTPContext = null
+    }
 
     when(mockHttpRequest.headers).thenReturn(headers)
     when(mockHttpRequest.cookies).thenReturn(Nil)

--- a/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
@@ -25,26 +25,36 @@ import org.specs2.mock.Mockito
 object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
 
   private[this] val X_SSL = "X-SSL"
+  private[this] val xSSLHeader = HTTPParam(X_SSL, List("true")) :: Nil
 
   "OfflineRequestSnapshot" should {
     "have a 'headers' method that returns the list of headers with a given name" in {
-      val req = getRequestSnapshot(originalPort = 80)
+      val req = getRequestSnapshot(originalPort = 80, headers = xSSLHeader)
       req.headers("X-SSL") shouldEqual List("true")
       req.headers("Unknown") must beEmpty
     }
 
     "have the serverPort value" in {
       "443 when the 'X-SSL' header is set to the string 'true' (case-insensitive) and original port is 80" in {
-        val port80Req = getRequestSnapshot(originalPort = 80)
+        val port80Req = getRequestSnapshot(originalPort = 80, headers = xSSLHeader)
         port80Req.serverPort shouldEqual 443
       }
-      s"equal to the original request-port when the '$X_SSL' header is absent or not set to the string 'true' (case-insensitive), or if the original port is not 80" in {
-        val req = getRequestSnapshot(originalPort = 90)
-        val nonSSLReq = getRequestSnapshot(originalPort = 80, headers =  Nil)
-        val falseSSLHeaderReq = getRequestSnapshot(originalPort = 90, headers =  HTTPParam(X_SSL, List("anything")) :: Nil)
-        req.serverPort shouldEqual 90
-        nonSSLReq.serverPort shouldEqual 80
-        falseSSLHeaderReq.serverPort shouldEqual 90
+
+      s"equal to the original request-port when" in {
+        s"the '$X_SSL' header is absent" in {
+          val nonSSLReq = getRequestSnapshot(originalPort = 80)
+          nonSSLReq.serverPort shouldEqual 80
+        }
+
+        s"the '$X_SSL' header is not set to the string 'true' (case-insensitive)" in {
+          val falseSSLHeaderReq = getRequestSnapshot(originalPort = 90, headers =  HTTPParam(X_SSL, List("anything")) :: Nil)
+          falseSSLHeaderReq.serverPort shouldEqual 90
+        }
+
+        "the original request-port is not 80" in {
+          val req = getRequestSnapshot(originalPort = 90, headers = xSSLHeader)
+          req.serverPort shouldEqual 90
+        }
       }
     }
 
@@ -60,9 +70,8 @@ object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
     }
   }
 
-  private[this] val xSSLHeader = HTTPParam(X_SSL, List("true")) :: Nil
 
-  private[this] def getRequestSnapshot(originalPort: Int, headers: List[HTTPParam] = xSSLHeader, params: List[HTTPParam] = Nil) = {
+  private[this] def getRequestSnapshot(originalPort: Int, headers: List[HTTPParam] = Nil, params: List[HTTPParam] = Nil) = {
     val mockHttpRequest = mock[HTTPRequest]
     val httpProvider = new HTTPProvider {
       override protected def context: HTTPContext = null
@@ -76,4 +85,3 @@ object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
   }
 
 }
-

--- a/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/provider/servlet/OfflineRequestSnapshotSpec.scala
@@ -22,9 +22,6 @@ import org.mockito.Mockito._
 import org.specs2.mock.Mockito
 
 
-/**
- * System under specification for Req.
- */
 object OfflineRequestSnapshotSpec extends WebSpec with Mockito {
 
   "A snapshot request should" in {


### PR DESCRIPTION
Issue #1794 

store the server-port of the original request since it's used in a lazy val, and Jetty will recycle the request instance if the lazy val is realized too late