### PR TITLE
Bumping logback version to 1.2.3 for a security vulnerability fix

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
 
   // Provided scope:
   // Scope provided by container, available only in compile and test classpath, non-transitive by default.
-  lazy val logback         = "ch.qos.logback"    % "logback-classic"       % "1.1.5"      % "provided"
+  lazy val logback         = "ch.qos.logback"    % "logback-classic"       % "1.2.3"      % "provided"
   lazy val log4j           = "log4j"             % "log4j"                 % "1.2.17"     % "provided"
   lazy val slf4j_log4j12   = "org.slf4j"         % "slf4j-log4j12"         % slf4jVersion % "provided"
   lazy val persistence_api = "javax.persistence" % "persistence-api"       % "1.0.2"      % "provided"


### PR DESCRIPTION
Just to be super conservative, bumping the dependency on logback to version `1.2.3`. Since this dependency is marked as `"provided"`, downstream consumers are not affected and hence this PR isn't strictly necessary. 

Vulnerability details: https://nvd.nist.gov/vuln/detail/CVE-2017-5929
Related play framework security advisory: https://www.playframework.com/security/vulnerability/20170407-LogbackDeser