### PR TITLE
Lift json performance optimizations

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -827,7 +827,8 @@ object JsonAST {
         case '\n' => "\\n"
         case '\r' => "\\r"
         case '\t' => "\\t"
-        case c if ((c >= '\u0000' && c < '\u0020')) || settings.escapeChars.contains(c) =>
+        // Set.contains will cause boxing of c to Character, try and avoid this
+        case c if ((c >= '\u0000' && c < '\u0020')) || (settings.escapeChars.nonEmpty && settings.escapeChars.contains(c)) =>
           "\\u%04x".format(c: Int)
 
         case _ => ""
@@ -947,7 +948,7 @@ object JsonAST {
    */
   case class RenderSettings(
     indent: Int,
-    escapeChars: Set[Char] = Set(),
+    escapeChars: Set[Char] = Set.empty,
     spaceAfterFieldName: Boolean = false,
     doubleRenderer: DoubleRenderer = RenderSpecialDoubleValuesAsNull
   ) {

--- a/core/json/src/main/scala/net/liftweb/json/Meta.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Meta.scala
@@ -231,11 +231,12 @@ private[json] object Meta {
 
     def memoize(x: A, f: A => R): R = {
       val c = cache.get
-      if (c contains x) c(x) else {
+      def addToCache() = {
         val ret = f(x)
         cache.set(c + (x -> ret))
         ret
       }
+      c.getOrElse(x, addToCache)
     }
   }
 


### PR DESCRIPTION
**[Mailing List](https://groups.google.com/forum/#!forum/liftweb) thread**:
https://groups.google.com/forum/#!topic/liftweb/uBzyiDEQsyI

This motivation for this PR is to improve performance of json case class serialization. This change contains two optimizations:

* In appendEscapedString requires a boxing operation to transform Char into Character for the Set.contains(java.lang.Object) operation, even is the escapedChars isEmpty (the default)

- The patch eliminates this check when the settings.escapeChars isEmpty using && to short circuit the Set.contains method 

* In  Meta memoize there is an extra lookup and Option creation as both Map.contains and Map.apply are implemented using Map.get for the case where the key has already been cached (one for contains and another for get, which is creating additional Option instances). 

- The patch uses getOrElse to avoid the second lookup (the or else populates the cache as a side effect).