### PR TITLE
The Extraction mkMapping and decompose methods have code to determine…

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -83,7 +83,7 @@ object Extraction {
         case x: Iterable[_] => JArray(x.toList map decompose)
         case x if (x.getClass.isArray) => JArray(x.asInstanceOf[Array[_]].toList map decompose)
         case x: Option[_] => x.flatMap[JValue] { y => Some(decompose(y)) }.getOrElse(JNothing)
-        case x: Product if tuple_?(x.getClass) && formats.tuplesAsArrays =>
+        case x: Product if formats.tuplesAsArrays && tuple_?(x.getClass) =>
           JArray(x.productIterator.toList.map(decompose))
         case x =>
           val fields = getDeclaredFields(x.getClass)
@@ -192,7 +192,7 @@ object Extraction {
       Col(TypeInfo(clazz, None), mkMapping(typeArgs.head, typeArgs.tail))
     } else if (clazz == classOf[Map[_, _]]) {
       Dict(mkMapping(typeArgs.tail.head, typeArgs.tail.tail))
-    } else if (tuple_?(clazz) && formats.tuplesAsArrays) {
+    } else if (formats.tuplesAsArrays && tuple_?(clazz)) {
       val childMappings = typeArgs.map(c => mkMapping(c, Nil)).toList
       HCol(TypeInfo(clazz, None), childMappings)
     } else {


### PR DESCRIPTION
… if a tuple is being used and whether this should be considered as formatted as array. The tuple_? method is a Seq that contains the classes for the 22 varieties of tuples and the tuple_? method does a O(n) scan on this frequently during the case class serialization / deserialization process. Currently, the code is performing contains first and then checking whether Tuples are formatted as arrays (where the default is false). This change reverses the order to short circuit this check.

**[Mailing List](https://groups.google.com/forum/#!forum/liftweb) thread**:
https://groups.google.com/forum/#!topic/liftweb/E8tHa_5MWt8
