### PR TITLE
Fix example in lift-json's Xml helper.

### DIFF
--- a/core/actor/src/test/scala/net/liftweb/actor/LAFutureSpec.scala
+++ b/core/actor/src/test/scala/net/liftweb/actor/LAFutureSpec.scala
@@ -108,7 +108,10 @@ class LAFutureSpec extends Specification {
         val three: LAFuture[Box[Int]] = LAFuture(() => Full(3): Box[Int])
 
         val collectResult = LAFuture.collectAll(one, two, three)
-        collectResult.get(timeout) shouldEqual Full(List(1, 2, 3))
+        collectResult.get(timeout) should beLike {
+          case Full(Full(results)) =>
+            results should contain(allOf(1, 2, 3))
+        }
       }
 
       "collectAll reports a failed LAFuture as a failure for the overall future" in {


### PR DESCRIPTION
We had some outdated example code that used `map` instead of `mapField`.

Spotted [on Stack Overflow](https://stackoverflow.com/questions/43100997/compilation-error-in-code-snippet-by-lift-json-3-0-1-to-convert-json-arrays-into).