### PR TITLE
Validate that closing a session from a comet doesn't NPE

### DIFF
--- a/web/webkit/src/test/scala/net/liftweb/http/CometActorSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/CometActorSpec.scala
@@ -94,15 +94,27 @@ object CometActorSpec extends Specification {
     }
 
     "be able to invoke destroySession without causing an NPE" in {
+      var didRun = false
+      var didThrow = false
+
       case object BoomSession
       val comet = new SpecCometActor {
         override def lowPriority = {
           case BoomSession =>
-            S.session.foreach(_.destroySession)
+            try {
+              didRun = true
+              S.session.foreach(_.destroySession)
+            } catch {
+              case e: Exception =>
+                didThrow = true
+            }
         }
       }
 
-      (comet ! BoomSession) must not(throwAn[Exception])
+      comet ! BoomSession
+
+      didRun must beTrue
+      didThrow must beFalse
     }
   }
 }

--- a/web/webkit/src/test/scala/net/liftweb/http/CometActorSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/CometActorSpec.scala
@@ -92,5 +92,17 @@ object CometActorSpec extends Specification {
           redirectUri must beMatching("^[^?]+\\?F[^=]+=_$".r)
       }
     }
+
+    "be able to invoke destroySession without causing an NPE" in {
+      case object BoomSession
+      val comet = new SpecCometActor {
+        override def lowPriority = {
+          case BoomSession =>
+            S.session.foreach(_.destroySession)
+        }
+      }
+
+      (comet ! BoomSession) must not(throwAn[Exception])
+    }
   }
 }


### PR DESCRIPTION
Closes #1145.

In the days of ye old Lift comet actors were using mock request instances. This meant that it was possible to get yourself into the somewhat surprising situation of triggering an NPE from a comet if you attempted to delete a session even though comets are associated with valid sessions.

We've since stopped that practice and now seem to plug in an `Empty` for the request when we're inside a `Comet` as of #1613. As such I was unable to reproduce this issue from a unit test. Decided to open up a PR with a unit test to ensure we don't accidentally regress in the future.