### PR TITLE
Formalize support policy, start README reorg.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@ Ticket and Pull Request Guidelines
 ==================================
 
 The policy on issues is:
+* Issues should be actionable items of work for the Committers or an outside contributor to
+  execute on, and should describe an issue in a supported version of Lift.
 * Non-committers should discuss issues on the Lift mailing list before opening
   a issue.
 * All non-committer issues should have a link back to the mailing list
@@ -18,6 +20,7 @@ The policy on issues is:
 
 We will accept pull requests into the Lift codebase if the pull requests meet
 all of the following criteria:
+* The request is for a currently supported version of Lift. (See [SUPPORT.md][supfile].)
 * The request handles an issue that has been discussed on the Lift mailing list
   and whose solution has been requested by the committers (and in general adheres
   to the spirit of the issue guidelines above).
@@ -29,3 +32,5 @@ pull request, the Lift committers are taking responsibility for maintaining that
 and there are many reasons why this might not be desirable for certain features. We
 will strive to communicate clearly why pull requests are not accepted if we decide
 not to accept them.
+
+[supfile]: https://github.com/lift/framework/blob/master/SUPPORT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ all of the following criteria:
 * The request handles an issue that has been discussed on the Lift mailing list
   and whose solution has been requested by the committers (and in general adheres
   to the spirit of the issue guidelines above).
-* The request includes a signature at the bottom of the /contributors.md file.
+* The contributor's signature is already in or added to /contributors.md file.
 
 Note that only Lift committers can merge a pull request, and accepting or rejecting
 a pull request is entirely at the discretion of the Lift committers. By merging a

--- a/README.md
+++ b/README.md
@@ -13,26 +13,6 @@ Lift applications are:
 
 Because Lift applications are written in [Scala](http://www.scala-lang.org), an elegant JVM language, you can still use your favorite Java libraries and deploy to your favorite Servlet Container and app server. Use the code you've already written and deploy to the container you've already configured!
 
-## Issues
-
-Issues on the Lift GitHub project are intended to describe actionable,
-already-discussed items. Committers on the project may open issues for
-themselves at any time, but non-committers should visit the [Lift mailing
-list](https://groups.google.com/forum/#!forum/liftweb) and start a discussion
-for any issue that they wish to open.
-
-## Pull Requests
-
-We will accept pull requests into the [Lift codebase](https://github.com/lift)
-if the pull requests meet the following criteria:
-
-* The request handles an issue that has been discussed on the [Lift mailing list](http://groups.google.com/forum/#!forum/liftweb)
-  and whose solution has been requested (and in general adheres to the spirit of
-  the issue guidelines outlined in [CONTRIBUTING.md](https://github.com/lift/framework/blob/master/CONTRIBUTING.md)).
-* The request includes a signature at the bottom of the `/contributors.md` file.
-
-For more details, see [CONTRIBUTING.md](https://github.com/lift/framework/blob/master/CONTRIBUTING.md).
-
 ## Getting Started
 
 **Compatibility note:**
@@ -41,30 +21,32 @@ you'll need to use Lift 2.6 until you can upgrade your Java installation.
 
 You can create a new Lift project using your favorite build system by adding Lift as a dependency:
 
-#### sbt
+### With sbt
 
 We recommend using the latest sbt version, which is currently 0.13.15, but anything 0.13.6+ will work
 with the instructions below.
 
 Create or update your `project/plugins.sbt` file with the `xsbt-web-plugin`:
 
-	addSbtPlugin("com.github.siasia" %% "xsbt-web-plugin" % "3.0.2")
+```scala
+addSbtPlugin("com.github.siasia" %% "xsbt-web-plugin" % "3.0.2")
+```
 
 Then, add the plugin and Lift to your `build.sbt` file:
 
-	enablePlugins(JettyPlugin)
+```scala
+enablePlugins(JettyPlugin)
 
-	libraryDependencies ++= {
-		val liftVersion = "3.1.0"
-		Seq(
-                  "net.liftweb"       %% "lift-webkit" % liftVersion % "compile",
-                  "ch.qos.logback" % "logback-classic" % "1.1.3"
-		)
-	}
+libraryDependencies ++= {
+  val liftVersion = "3.1.0"
+  Seq(
+    "net.liftweb"       %% "lift-webkit" % liftVersion % "compile",
+    "ch.qos.logback" % "logback-classic" % "1.2.5"
+  )
+}
+```
 
-You can [learn more on the cookbook](http://cookbook.liftweb.net/#LiftFromScratch).
-
-#### Maven:
+### With Maven
 
 You can use one of the several archetypes -- `lift-archetype-blank`, `lift-archetype-basic`, `lift-archetype-jpa-basic` -- to generate a new Lift project. You must set `archetypeRepository` and `remoteRepositories` to `http://scala-tools.org/repo-releases` or `http://scala-tools.org/repo-snapshots`, depending on whether you are using a release or the latest SNAPSHOT.
 
@@ -79,7 +61,33 @@ Or, you can add Lift to your `pom.xml` like so:
 Where `${scala.version}` is `2.11` or `2.12`. Individual patch releases of the Scala compiler (e.g. 2.12.2)
 are binary compatible with everything in their release series, so you only need the first two version parts.
 
-You can [learn more on the wiki](http://www.assembla.com/wiki/show/liftweb/Using_Maven).
+You can learn more about Maven integration [on the wiki](http://www.assembla.com/wiki/show/liftweb/Using_Maven).
+
+### Learning Lift
+
+There are lots of resources out there for learning Lift. Some of our favorites include:
+
+* [The Lift Cookbook](http://cookbook.liftweb.net/)
+* [Simply Lift](http://simply.liftweb.net)
+
+If you've found one that you particularly enjoy, please open a PR to update this README!
+
+## Issues & Pull Requests
+
+Per our [contributing guidelines][contribfile], Issues on the Lift GitHub project are intended to
+describe actionable, already-discussed items. Committers on the project may open issues for
+themselves at any time, but non-committers should visit the [Lift mailing
+list](https://groups.google.com/forum/#!forum/liftweb) and start a discussion
+for any issue that they wish to open.
+
+We will accept issues and pull requests into the Lift codebase if the pull requests meet the following criteria:
+
+* The request is for a [supported version of Lift][supfile]
+* The request adheres to our [contributing guidelines][contribfile], including having been discussed
+  on the Mailing List if its from a non-committer.
+
+[contribfile]: https://github.com/lift/framework/blob/master/CONTRIBUTING.md
+[sigfile]: https://github.com/lift/framework/blob/master/contributors.md
 
 ## Project Organization
 
@@ -89,17 +97,16 @@ The Lift Framework is divided into several components that are published indepen
 
 This repository, `framework`, contains the following components:
 
-#### core
-
-Core elements used by Lift projects. If you wish to reuse some of Lift's helpers and constructs, such as `Box`, this component may be all you need. However, a web application will most likely require one or more of Lift's components.
-
-#### web
-
-This component includes all of Lift's core HTTP and web handling. Including `lift-webkit` in your build process should be sufficient for basic applications and will include `lift-core` as a transitive dependency.
-
-#### persistence
-
-This component includes Mapper and Record, Lift's two ORMs. While you needn't use either and can use the ORM of your choice, Mapper and Record integrate nicely with Lift's idioms. Mapper is an ORM for relational databases, while Record is a broader ORM with support for both SQL databases and NoSQL datastores.
+* **core:** Core elements used by Lift projects. If you wish to reuse some of Lift's helpers and
+constructs, such as `Box`, this component may be all you need. However, a web application will most
+likely require one or more of Lift's components.
+* **web:** This component includes all of Lift's core HTTP and web handling. Including `lift-webkit`
+in your build process should be sufficient for basic applications and will include `lift-core` as a
+transitive dependency.
+* **persistence:** This component includes Mapper and Record, Lift's two ORMs. While you needn't use
+either and can use the ORM of your choice, Mapper and Record integrate nicely with Lift's idioms.
+Mapper is an ORM for relational databases, while Record is a broader ORM with support for both SQL
+databases and NoSQL datastores.
 
 ### Other Repostories
 
@@ -107,9 +114,10 @@ There are a variety of other repositories available on the Lift GitHub page. Whi
 
 #### modules
 
-The [modules](https://github.com/liftmodules) repository contains the many add-on modules that are part of the Lift project. If you don't find a module you need here, consider [creating a module](http://www.assembla.com/spaces/liftweb/wiki/Modules) and sharing it with the community.
-
-Please note that the modules project does accept pull requests.
+The [modules](https://github.com/liftmodules) organization contains the many add-on modules that are
+part of the Lift project. If you don't find a module you need here, consider
+[creating a module](http://www.assembla.com/spaces/liftweb/wiki/Modules) and sharing it with the
+community.
 
 #### examples
 
@@ -144,10 +152,6 @@ The Lift wiki is hosted on Assembla and can be found at [http://www.assembla.com
 ### ScalaDocs
 
 The ScalaDocs for each release of Lift, in additional to the actual JARs, are available on the Liftweb.net site. You can access the source code–based documentation for releases via the site's homepage or by navigating directly to the URL for the specific release. For instance, the Lift 3.0 release can be accessed at [http://liftweb.net/api/31/api/](http://liftweb.net/api/31/api/).
-
-### Cookbook
-
-You can find up-to-date information on the [Lift Cookbook](http://cookbook.liftweb.net/)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This repository, `framework`, contains the following components:
 
 * **core:** Core elements used by Lift projects. If you wish to reuse some of Lift's helpers and
 constructs, such as `Box`, this component may be all you need. However, a web application will most
-likely require one or more of Lift's components.
+likely require one or more of Lift's other components.
 * **web:** This component includes all of Lift's core HTTP and web handling. Including `lift-webkit`
 in your build process should be sufficient for basic applications and will include `lift-core` as a
 transitive dependency.
@@ -114,8 +114,9 @@ There are a variety of other repositories available on the Lift GitHub page. Whi
 
 #### modules
 
-The [modules](https://github.com/liftmodules) organization contains the many add-on modules that are
-part of the Lift project. If you don't find a module you need here, consider
+The [modules](https://github.com/liftmodules) organization contains some of the many add-on modules
+that are part of the Lift project. If you don't find a module you need here, consider
+looking for it on the [Lift modules directory](https://liftweb.net/lift_modules) or
 [creating a module](http://www.assembla.com/spaces/liftweb/wiki/Modules) and sharing it with the
 community.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,7 +1,7 @@
 # The Lift Framework Support Policy
 
 Ongoing maintenance and development of the Lift Framework is a volunteer effort executed by a
-passionate group of Lift supporters known a the Lift Committers. With the assistance of
+passionate group of Lift supporters known as the Lift Committers. With the assistance of
 outside contributors, the Lift Committers work to ensure that with each release of Lift we provide
 a selection of new features and bug fixes. The Lift Committers stand behind and provide ongoing
 support for the contributions they make to Lift, and a condition of accepting changes from outside

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,67 @@
+# The Lift Framework Support Policy
+
+Ongoing maintenance and development of the Lift Framework is a volunteer effort executed by a
+passionate group of Lift supporters known a the Lift Committers. With the assistance of
+outside contributors, the Lift Committers work to ensure that with each release of Lift we provide
+a selection of new features and bug fixes. The Lift Committers stand behind and provide ongoing
+support for the contributions they make to Lift, and a condition of accepting changes from outside
+contributors is that the Committers feel comfortable supporting those changes long term.
+
+Because maintenance of the Framework is a  volunteer effort and all of the Committers have busy
+lives with precious free time, they must be intentional with the community support they provide for
+Lift. To that end, the Committers have decided to embrace the following support policy for releases
+of Lift:
+
+* Lift ships a new release every six months, with three milestones and at least one Release
+Candidate building up to each release. Each normal release results in a bump of the middle number
+of the version (e.g. 3.1.0 to 3.2.0).
+* Brand new features are always a part of new releases. Breaking changes will only ship as a part
+of a major release, which results in a bump of the first number of the version (e.g. 2.6.0 to 3.0.0).
+* Bug fixes and minor performance improvements will be shipped for releases for 18 months after
+their release date.
+* Security fixes will be shipped for the current and previous two major releases.
+  * Due to a change in our release scheme, Lift 2.5 will receive security fixes until the release
+  of Lift 4.0 and Lift 2.6 will receive security fixes until the release of Lift 5.0.
+  * Any application using Lift 2.4 or earlier should be upgraded as soon as possible.
+  * Major releases aren't on a regular schedule, but we will announce and update this policy with
+  actual dates when major releases become planned.
+
+As of July 23rd, 2017 the current support status looks like this:
+
+|Version  |Initial Release  | Last Release     | Current Support Status          |
+|---------|-----------------|------------------|---------------------------------|
+|< 2.5    |                 |                  | Not supported                   |
+|2.5      |June 2013        | 2.5.4 (Jan 2016) | Security fixes (until Lift 4.0) |
+|2.6      |January 2015     | 2.6.3 (Jan 2016) | Security fixes (until Lift 5.0) |
+|3.0      |November 2016    | 3.0.1 (Dec 2016) | Minor fixes (until May 2018)    |
+|3.1      |July 2017        | 3.1.0 (Jul 2017) | Minor fixes (until Jan 2019)    |
+
+Per this support policy please ensure you're using a currently supported version of Lift before:
+
+* Opening a [Mailing List][ml] thread asking for help from the committers.
+* Filing an issue in GitHub.
+* Opening a Pull Request intended to patch an older version of Lift.
+
+## Common issues
+
+We're sure that this support policy won't meet every organization's needs. To that end, the
+committers wanted to address a few specific problems that may come up as a result of this support
+strategy.
+
+### I need help upgrading Lift
+
+If you're using an ancient version of Lift, you may find that a lot has changed and upgrading has
+become quite challenging. If you're in this position, please reach out to the community on the
+[Lift Mailing List][ml]. We're happy to answer quick questions about changes we've made.
+
+If your needs are more involved, you may want to consider hiring a member of the Lift community
+or a Lift Committer to help you upgrade your application. A number of members in the community do
+part-time consulting off and on and several more consult full time as their day job.
+
+### I need to plan for longer-term support of a Lift application
+
+For some organizations 18 months just isn't a sufficient support window. If your organization is in
+this situation, please consider reaching out on the [Mailing List][ml]. You may be able to hire a
+Lift community member to help you provide longer-term support for your application.
+
+[ml]: https://groups.google.com/forum/#!forum/liftweb

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,13 +12,14 @@ lives with precious free time, they must be intentional with the community suppo
 Lift. To that end, the Committers have decided to embrace the following support policy for releases
 of Lift:
 
-* Lift ships a new release every six months, with three milestones and at least one Release
-Candidate building up to each release. Each normal release results in a bump of the middle number
-of the version (e.g. 3.1.0 to 3.2.0).
-* Brand new features are always a part of new releases. Breaking changes will only ship as a part
-of a major release, which results in a bump of the first number of the version (e.g. 2.6.0 to 3.0.0).
-* Bug fixes and minor performance improvements will be shipped for releases for 18 months after
-their release date.
+* Lift ships a new release every six months, with three milestones and at least one release
+  candidate building up to each release. Each normal release results in a bump of the middle number
+  of the version (e.g. 3.1.0 to 3.2.0).
+* Brand new features are always a part of new releases. API-incompatible changes will only ship as a
+  part of a major release, which results in a bump of the first number of the version (e.g. 2.6.0 to
+  3.0.0).
+* Bug fixes and minor performance improvements can, by consensus of the Committers, be shipped for
+  releases for 18 months after their release date.
 * Security fixes will be shipped for the current and previous two major releases.
   * Due to a change in our release scheme, Lift 2.5 will receive security fixes until the release
   of Lift 4.0 and Lift 2.6 will receive security fixes until the release of Lift 5.0.
@@ -46,7 +47,7 @@ Per this support policy please ensure you're using a currently supported version
 
 We're sure that this support policy won't meet every organization's needs. To that end, the
 committers wanted to address a few specific problems that may come up as a result of this support
-strategy.
+strategy:
 
 ### I need help upgrading Lift
 


### PR DESCRIPTION
This PR closes #1879.

This bled into #1875 a bit, but I wouldn't say this totally finishes that ticket.

Per the [ML discussion](https://groups.google.com/d/msg/liftweb/POl2WS64-SU/mQPFUs4yAwAJ) this formalizes and publishes our support policy in the GitHub repository. I also took the liberty of making some improvements to the flow of the README, but it's still very much a work in progress. Wanted to go ahead and open this up and have it considered for merge in its current state, however.