### PR TITLE
This change eliminates the use of Range in the appendEscapeString met…

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -817,8 +817,7 @@ object JsonAST {
   }
 
   private def appendEscapedString(buf: Appendable, s: String, settings: RenderSettings) {
-    for (i <- 0 until s.length) {
-      val c = s.charAt(i)
+    s.foreach { c =>
       val strReplacement = c match {
         case '"'  => "\\\""
         case '\\' => "\\\\"


### PR DESCRIPTION
…hod as this imposes somewhere between a 12-18% performance penalty. There are several causes for this, but the main factor is the additional object creation caused by initializing a range object. This penalty can be avoided by using forEach directly on the input string.

**[Mailing List](https://groups.google.com/forum/#!forum/liftweb) thread**:
https://groups.google.com/forum/#!topic/liftweb/80Ewp4FPpqg
