### PR TITLE
Adding a ContainerSerializer that works for anything extending Serializable

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/Vars.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Vars.scala
@@ -319,6 +319,7 @@ object ContainerSerializer {
 
   implicit def listSerializer[T](implicit tc: ContainerSerializer[T]): ContainerSerializer[List[T]] = buildSerializer
 
+  implicit def anyRefSerializer[T <: Serializable]: ContainerSerializer[T] = buildSerializer
 }
 
 /**


### PR DESCRIPTION
[ML Topic](https://groups.google.com/forum/?pli=1#!topic/liftweb/IU9PcqGthbE)

If you using a `ContainerVar[T]`, you are required to provide an implicit `ContainerSerializer[T]`. Lift provides about a dozen implementations, but there is not a generic one. So for instance, if you were to create a `Container[Box[String]]`, you will get a compiler failure: 

```
[error] /Users/joescii/Documents/code/oss/squeryl-auth-module/src/main/scala/net/liftmodules/squerylauth/AuthUser.scala:58: could not find implicit value for parameter containerSerializer: net.liftweb.http.ContainerSerializer[net.liftweb.common.Box[String]]
[error]   private object curUserId extends ContainerVar[Box[String]](Empty)
[error]                                    
```

The addition of this implicit serializer takes care of this case. 