### PR TITLE
Support limiting MetaProtoExtendedSession cookies to context path

### DIFF
--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
@@ -143,6 +143,14 @@ KeyedMetaMapper[Long, T] with ProtoSessionCookiePath {
  * to the context path for your application. This is useful if you have
  * multiple applications on a single application server and want to ensure
  * their cookies don't cross-pollinate.
+ *
+ * Example usage:
+ *
+ * {{{
+ * case class AppExtendedSession extends ProtoExtendedSession[AppExtendedSession]
+ * object MetaAppExtendedSession extends MetaProtoExtendedSession[AppExtendedSession]
+ *   with ContextPathExtendedCookie
+ * }}}
  */
 trait ContextPathExtendedCookie extends ProtoSessionCookiePath {
   override def sessionCookiePath = S.contextPath

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
@@ -62,9 +62,6 @@ trait UserIdAsString {
 /**
  * The root trait for defining the session cookie path for extended sessions
  * that defines the default session cookie path: "/".
- *
- * Extend this trait then mix it into an extended session singleton to change
- * the cookie path. See also: [[ContextPathExtendedCookie]]
  */
 trait ProtoSessionCookiePath {
   def sessionCookiePath: String = "/"

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
@@ -59,8 +59,12 @@ trait UserIdAsString {
   def userIdAsString: String
 }
 
+trait ProtoSessionCookiePath {
+  def sessionCookiePath: String = "/"
+}
+
 trait MetaProtoExtendedSession[T <: ProtoExtendedSession[T]] extends
-KeyedMetaMapper[Long, T] {
+KeyedMetaMapper[Long, T] with ProtoSessionCookiePath {
   self: T =>
 
   def CookieName = "ext_id"
@@ -92,7 +96,7 @@ KeyedMetaMapper[Long, T] {
     val inst = create.userId(uid.userIdAsString).saveMe
     val cookie = HTTPCookie(CookieName, inst.cookieId.get).
     setMaxAge(((inst.expiration.get - millis) / 1000L).toInt).
-    setPath("/")
+    setPath(sessionCookiePath)
     S.addCookie(cookie)
   }
 
@@ -120,10 +124,13 @@ KeyedMetaMapper[Long, T] {
             case Full(es) => logUserIdIn(es.userId.get)
             case _ =>
           }
-        
+
         case _ =>
       }
     }
   }
 }
 
+trait ContextPathExtendedCookie extends ProtoSessionCookiePath {
+  override def sessionCookiePath = S.contextPath
+}

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
@@ -59,6 +59,13 @@ trait UserIdAsString {
   def userIdAsString: String
 }
 
+/**
+ * The root trait for defining the session cookie path for extended sessions
+ * that defines the default session cookie path: "/".
+ *
+ * Extend this trait then mix it into an extended session singleton to change
+ * the cookie path. See also: [[ContextPathExtendedCookie]]
+ */
 trait ProtoSessionCookiePath {
   def sessionCookiePath: String = "/"
 }
@@ -131,6 +138,12 @@ KeyedMetaMapper[Long, T] with ProtoSessionCookiePath {
   }
 }
 
+/**
+ * Mix this in to your extended session singleton to set the cookie path
+ * to the context path for your application. This is useful if you have
+ * multiple applications on a single application server and want to ensure
+ * their cookies don't cross-pollinate.
+ */
 trait ContextPathExtendedCookie extends ProtoSessionCookiePath {
   override def sessionCookiePath = S.contextPath
 }


### PR DESCRIPTION
This PR add support for limiting the extended sessions provided by `MetaProtoExtendedSession` to the current context path instead of `/`.  To use this, add `with ContextPathExtendedCookie` to your `MetaProtoExtendedSession`.

Closes #1758.