### PR TITLE
Move cache defaulting to LiftRules

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1917,7 +1917,13 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
 
   private[http] def withMimeHeaders[T](map: Map[String, List[String]])(f: => T): T = _mimeHeaders.doWith(Full(map))(f)
 
-  @volatile var templateCache: Box[TemplateCache[(Locale, List[String]), NodeSeq]] = Empty
+  @volatile var templateCache: Box[TemplateCache[(Locale, List[String]), NodeSeq]] = {
+    if (Props.productionMode) {
+      Full(InMemoryCache(500))
+    } else {
+      Empty
+    }
+  }
 
   val dateTimeConverter: FactoryMaker[DateTimeConverter] = new FactoryMaker[DateTimeConverter]( () => DefaultDateTimeConverter ) {}
 

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/HTTPProvider.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/HTTPProvider.scala
@@ -134,11 +134,6 @@ trait HTTPProvider {
   private def postBoot {
     try {
       ResourceBundle getBundle (LiftRules.liftCoreResourceName)
-
-      if (Props.productionMode && LiftRules.templateCache.isEmpty) {
-        // Since we're in productin mode and user did not explicitely set any template caching, we're setting it
-        LiftRules.templateCache = Full(InMemoryCache(500))
-      }
     } catch {
       case _: Exception => logger.error("LiftWeb core resource bundle for locale " + Locale.getDefault() + ", was not found ! ")
     } finally {


### PR DESCRIPTION
This change permits changing the template caching in production by simply setting the `templateCache` var in Lift as discussed in the referenced issue. This is a _bit_ of a change in contract, as today if you set the `LiftRule` to `Empty` in the boot class, it'll become an `InMemoryCache`. In practice, I don't think folks are doing this intentionally and it's _more_ confusing that you can't turn off caching.

Closes #1315.