### PR TITLE
Consider LiftRules.cometCreation while building comets

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2576,7 +2576,7 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
   // Runs some base setup tasks before returning the comet.
   private def buildCometByCreationInfo(creationInfo: CometCreationInfo): Box[LiftCometActor] = {
     LiftRules.cometCreationFactory.vend.apply(creationInfo) or
-    LiftRules.cometCreation.toList.find(_.isDefinedAt(creationInfo)).map(_.apply(creationInfo)) or {
+    NamedPF.applyBox(creationInfo, LiftRules.cometCreation.toList) or {
       val cometType =
         findType[LiftCometActor](
           creationInfo.cometType,


### PR DESCRIPTION
This fixes a bug that appeared in Lift 3 where we stopped considering cometCreation while creating
comets from creation info.

Decided to take my own stab at this one @Shadowfiend - let me know how I did!

Do still need to test it throughly though.

Closes #1902.
