### PR TITLE
optimization of StringHelpers.randomString

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala
@@ -175,6 +175,7 @@ trait StringHelpers {
     * @return the generated string
     */
   def randomString(size: Int): String = {
+    if (size < 1) return ""
     val charArray = new Array[Char](size)
     val numRandomBits = 6
     val bytesNeeded = math.ceil((numRandomBits * size) / 8.0).toInt


### PR DESCRIPTION
- Optimize randomString by calling _random.nextBytes for only the bytes we need.
  We use 6 bits per byte and store the 2 leftover bits in a byte (Int actually).
  After 3 iterations we have (3*2) enough bits for a new random char so we use
  these instead of consuming a new random-byte. So for every 4-th iteration we
  use these accumulated random-bits.

Some non-scientific testing shows 30-35% improvement in running-time.