### PR TITLE
Session serialization support

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -215,8 +215,14 @@ object S extends S {
    * We create one of these dudes and put it
    */
   private[http] final case class PageStateHolder(owner: Box[String], session: LiftSession) extends AFuncHolder {
+
+    /**
+      * Private no-arg constructor needed for deserialization.
+      */
+    private[this] def this() = this(Empty, null)
+    
     private val loc = S.location
-    private val snapshot:  Function1[Function0[Any], Any] = RequestVarHandler.generateSnapshotRestorer()
+    @transient private val snapshot:  Function1[Function0[Any], Any] = RequestVarHandler.generateSnapshotRestorer()
     override def sessionLife: Boolean = false
 
     def apply(in: List[String]): Any = {

--- a/web/webkit/src/main/scala/net/liftweb/http/S.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/S.scala
@@ -222,7 +222,7 @@ object S extends S {
     private[this] def this() = this(Empty, null)
     
     private val loc = S.location
-    @transient private val snapshot:  Function1[Function0[Any], Any] = RequestVarHandler.generateSnapshotRestorer()
+    private val snapshot:  Function1[Function0[Any], Any] = RequestVarHandler.generateSnapshotRestorer()
     override def sessionLife: Boolean = false
 
     def apply(in: List[String]): Any = {

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/servlet/HTTPRequestServlet.scala
@@ -28,7 +28,7 @@ import net.liftweb.common._
 import net.liftweb.util._
 import Helpers._
 
-class HTTPRequestServlet(val req: HttpServletRequest, val provider: HTTPProvider) extends HTTPRequest {
+class HTTPRequestServlet(@transient val req: HttpServletRequest, @transient val provider: HTTPProvider) extends HTTPRequest {
   private lazy val ctx = {
     new HTTPServletContext(req.getSession.getServletContext)
   }


### PR DESCRIPTION
This PR shuffles a few things around, adds some `@transient` annotations, and adds some default constructors to aid in the success of [lift-cluster](https://github.com/joescii/lift-cluster). Unless I screwed up something, this PR is essentially a refactor to anyone NOT using lift-cluster. 

Relevant (but really long and old) ML thread: https://groups.google.com/forum/#!topic/liftweb/KHjbjev8A0E 