### PR TITLE
adding csv suffix to known suffixes

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -276,3 +276,8 @@ Noel Kennedy
 ### Email: ###
 nkennedy at rvc dot ac dot uk
 
+### Name: ###
+Jeff Zhao
+
+### Email: ###
+jeffzhao at gmail dot com

--- a/contributors.md
+++ b/contributors.md
@@ -280,4 +280,4 @@ nkennedy at rvc dot ac dot uk
 Jeff Zhao
 
 ### Email: ###
-jeffzhao at gmail dot com
+jeffzhao415 at gmail dot com

--- a/core/util/src/main/scala/net/liftweb/util/HttpHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/HttpHelpers.scala
@@ -42,7 +42,7 @@ trait HttpHelpers {
                                          "aim","aip","ani","aos","aps","arc","arj","art","asf","asm","asp","asx","au","avi","avs",
                                          "bcpio","bin","bm","bmp","boo","book","boz","bsh","bz","bz2","c","c++","cat","cc","ccad",
                                          "cco","cdf","cer","cha","chat","class","com","conf","cpio","cpp","cpt","crl","crt","csh",
-                                         "css","cxx","dcr","deepv","def","der","dif","dir","dl","doc","dot","dp","drw","dump","dv",
+                                         "css","csv","cxx","dcr","deepv","def","der","dif","dir","dl","doc","dot","dp","drw","dump","dv",
                                          "dvi","dwf","dwg","dxf","dxr","el","elc","env","eps","es","etx","evy","exe","f","f77",
                                          "f90","fdf","fif","fli","flo","flx","fmf","for","fpx","frl","funk","g","g3","gif","gl","gsd",
                                          "gsm","gsp","gss","gtar","gz","gzip","h","hdf","help","hgl","hh","hlb","hlp","hpg","hpgl",


### PR DESCRIPTION
Change: Add csv to the list of known suffixes. 
Motive: @joescii @Bhashit and I was look into a bug that prevent us accessing a local csv resource from webapp. The request got 200 response, but the content is not csv content but base html page, so the request got redirected. Add csv to known suffix list fixed this issue.