### PR TITLE
Validate that no-arg comet constructor doesn't exist before attempting backup constructor

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2615,7 +2615,17 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
       constructor.newInstance(this, name, defaultXml, attributes).asInstanceOf[T]
     }
 
-    val attemptedComet = tryo(buildWithNoArgConstructor) or tryo(buildWithCreateInfoConstructor)
+    // We first attempt to use the no argument constructor. If we get a NoSuchMethodException,
+    // we _then_ try to use the create info constructor. If anything else happens, including
+    // others kinds of exceptions, we abort construction attempts intentionally so we surface
+    // the correct error.
+    val attemptedComet = tryo(buildWithNoArgConstructor) match {
+      case fail @ Failure(_, Full(e: java.lang.NoSuchMethodException), _) =>
+        fail or tryo(buildWithCreateInfoConstructor)
+
+      case other =>
+        other
+    }
 
     attemptedComet match {
       case fail @ Failure(_, Full(e: java.lang.NoSuchMethodException), _) =>

--- a/web/webkit/src/test/scala/net/liftweb/http/LiftSessionSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/LiftSessionSpec.scala
@@ -32,7 +32,7 @@ object LiftSessionSpec extends Specification with BeforeEach {
 
   override def before = receivedMessages = Vector[Int]()
 
-  private class TestCometActor extends CometActor {
+  private[this] class TestCometActor extends CometActor {
     def render = NodeSeq.Empty
 
     override def lowPriority = {
@@ -44,7 +44,7 @@ object LiftSessionSpec extends Specification with BeforeEach {
     }
   }
 
-  private class ExplodesInConstructorCometActor extends CometActor {
+  private[this] class ExplodesInConstructorCometActor extends CometActor {
     def render = NodeSeq.Empty
 
     throw new RuntimeException("boom, this explodes in the constructor!")


### PR DESCRIPTION
Closes #1642.

This checks to make sure that the no-arg constructor is failing because it doesn't exist before attempting the backup constructor. The old behavior was essentially swallowing exceptions from no-arg comet constructors.