### PR TITLE
Adding a null guard

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/SessionMaster.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SessionMaster.scala
@@ -199,7 +199,7 @@ object SessionMaster extends LiftActor with Loggable {
   def isDead(sessionId: String): Boolean = killedSessions.containsKey(sessionId)
 
   private val reaction: PartialFunction[Any, Unit] = {
-    case RemoveSession(sessionId) =>
+    case RemoveSession(sessionId) if sessionId != null =>
 
       val ses = lockRead(nsessions)
       (Box !! ses.get(sessionId)).foreach {


### PR DESCRIPTION
Adding a null guard to prevent alarming yet harmless NullPointerException messages in the appserver log. Resolves #1929 

**[Mailing List](https://groups.google.com/forum/#!forum/liftweb) thread**:
https://groups.google.com/forum/#!topic/liftweb/lHHJZJfiWcs
