### PR TITLE
Add server instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sbt new lift/blank-app.g8
 
 Follow the prompts to create your Lift application.
 
-### Running the Server
+#### Running the Server
 
 In order to run the server, navigate to the application folder and run the `sbt` command. In the SBT prompt, run:
 
@@ -83,7 +83,7 @@ libraryDependencies ++= {
 [wpsbt]: https://github.com/lift/basic-app.g8/blob/master/src/main/g8/project/web-plugin.sbt
 [wpproj]: https://github.com/earldouglas/xsbt-web-plugin/
 
-### Running the Server
+#### Running the Server
 
 In order to run the server, navigate to the application folder and run the `sbt` command. In the SBT prompt, run:
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ sbt new lift/blank-app.g8
 
 Follow the prompts to create your Lift application.
 
+### Running the Server
+
+In order to run the server, navigate to the application folder and run the `sbt` command. In the SBT prompt, run:
+
+    ~jetty:start
+
+By default, the server should run on http://localhost:8080.
+
 ### With sbt (Existing project)
 
 If you're using Lift in an existing sbt project you'll need to:
@@ -74,6 +82,14 @@ libraryDependencies ++= {
 
 [wpsbt]: https://github.com/lift/basic-app.g8/blob/master/src/main/g8/project/web-plugin.sbt
 [wpproj]: https://github.com/earldouglas/xsbt-web-plugin/
+
+### Running the Server
+
+In order to run the server, navigate to the application folder and run the `sbt` command. In the SBT prompt, run:
+
+    ~jetty:start
+
+By default, the server should run on http://localhost:8080.
 
 ### With Maven
 


### PR DESCRIPTION
**[Mailing List](https://groups.google.com/forum/#!searchin/liftweb/jetty$3Astart%7Csort:date/liftweb/f5ctz6NSIV8/S0fFYQo-AQAJ) thread**:

I thought it would be worth adding information on how to run the server to the README because the instructions I found in many of the tutorials and on the official website are out-of-date. I stumbled upon the above post in the mailing list by chance which contains the correct command for Lift v.3.