### PR TITLE
Issue#1919: Asset root path should be configurable

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -276,3 +276,8 @@ Noel Kennedy
 ### Email: ###
 nkennedy at rvc dot ac dot uk
 
+### Name: ###
+Henrik Härkönen
+
+### Email: ###
+heharkon@iki.fi

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/LazyLoad.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/LazyLoad.scala
@@ -72,7 +72,7 @@ object LazyLoad extends DispatchSnippet {
               renderedTemplate
             }
           } openOr {
-            <div><img src={s"${LiftRules.assetPath}images/ajax-loader.gif"} alt="Loading"/></div>
+            <div><img src={s"${LiftRules.assetRootPath}images/ajax-loader.gif"} alt="Loading"/></div>
           }
         )
       }

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/LazyLoad.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/LazyLoad.scala
@@ -72,7 +72,7 @@ object LazyLoad extends DispatchSnippet {
               renderedTemplate
             }
           } openOr {
-            <div><img src="/images/ajax-loader.gif" alt="Loading"/></div>
+            <div><img src={s"${LiftRules.assetPath}/images/ajax-loader.gif"} alt="Loading"/></div>
           }
         )
       }

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/LazyLoad.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/LazyLoad.scala
@@ -72,7 +72,7 @@ object LazyLoad extends DispatchSnippet {
               renderedTemplate
             }
           } openOr {
-            <div><img src={s"${LiftRules.assetPath}/images/ajax-loader.gif"} alt="Loading"/></div>
+            <div><img src={s"${LiftRules.assetPath}images/ajax-loader.gif"} alt="Loading"/></div>
           }
         )
       }

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1335,13 +1335,20 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   }
 
   /**
-    * The root path for assets folder. For example to store
-    * asset files under 'myassets' folder, use value '/myassets/'. Assets
-    * under this configurable path follow conventions, for example
-    * the default lazy loading spinner ('ajax-loader.gif') is under
-    * 'images' folder.
+    * The root path for the assets folder.
+    *
+    * This applies also to the URL domain, appended after the deployed context path.
+    * In app developer's work area this folder resides under the 'webapp' folder.
+    *
+    * For example to store asset files under 'myassets' folder,
+    * use value '/myassets/'. Assets under this configurable path follow
+    * conventions, for example the default lazy loading spinner ('ajax-loader.gif')
+    * is under 'images' folder.
+    *
+    * Thus the URL to the assets folder would be:
+    * 'http://<domain name>/<context path>/myassets/'
     */
-  @volatile var assetPath: String = "/"
+  @volatile var assetRootPath: String = "/"
 
   /**
    * Contains the URI path under which all built-in Lift-handled requests are

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1335,6 +1335,13 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   }
 
   /**
+    * The root path for assets folder. Assets under this configurable path
+    * follow conventions, for example the default lazy loading spinner
+    * ('ajax-loader.gif') is under 'images' folder.
+    */
+  @volatile var assetPath: String = "/assets"
+
+  /**
    * Contains the URI path under which all built-in Lift-handled requests are
    * scoped. It does not include the context path and should not begin with a
    * /.

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1335,11 +1335,13 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
   }
 
   /**
-    * The root path for assets folder. Assets under this configurable path
-    * follow conventions, for example the default lazy loading spinner
-    * ('ajax-loader.gif') is under 'images' folder.
+    * The root path for assets folder. For example to store
+    * asset files under 'myassets' folder, use value '/myassets/'. Assets
+    * under this configurable path follow conventions, for example
+    * the default lazy loading spinner ('ajax-loader.gif') is under
+    * 'images' folder.
     */
-  @volatile var assetPath: String = "/assets"
+  @volatile var assetPath: String = "/"
 
   /**
    * Contains the URI path under which all built-in Lift-handled requests are

--- a/web/webkit/src/main/scala/net/liftweb/http/package.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/package.scala
@@ -55,7 +55,7 @@ package object http {
           // Actually complete the render once the future is fulfilled.
           asyncResolveProvider.resolveAsync(concreteResolvable, resolvedResult => deferredRender(resolvedResult))
 
-          <div id={placeholderId}><img src={s"${LiftRules.assetPath}images/ajax-loader.gif"} alt="Loading" /></div>
+          <div id={placeholderId}><img src={s"${LiftRules.assetRootPath}images/ajax-loader.gif"} alt="Loading" /></div>
         } openOr {
           Comment("FIX"+"ME: Asynchronous rendering failed for unknown reason.")
         }

--- a/web/webkit/src/main/scala/net/liftweb/http/package.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/package.scala
@@ -55,7 +55,7 @@ package object http {
           // Actually complete the render once the future is fulfilled.
           asyncResolveProvider.resolveAsync(concreteResolvable, resolvedResult => deferredRender(resolvedResult))
 
-          <div id={placeholderId}><img src="/images/ajax-loader.gif" alt="Loading..." /></div>
+          <div id={placeholderId}><img src={s"${LiftRules.assetPath}/images/ajax-loader.gif"} alt="Loading" /></div>
         } openOr {
           Comment("FIX"+"ME: Asynchronous rendering failed for unknown reason.")
         }

--- a/web/webkit/src/main/scala/net/liftweb/http/package.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/package.scala
@@ -55,7 +55,7 @@ package object http {
           // Actually complete the render once the future is fulfilled.
           asyncResolveProvider.resolveAsync(concreteResolvable, resolvedResult => deferredRender(resolvedResult))
 
-          <div id={placeholderId}><img src={s"${LiftRules.assetPath}/images/ajax-loader.gif"} alt="Loading" /></div>
+          <div id={placeholderId}><img src={s"${LiftRules.assetPath}images/ajax-loader.gif"} alt="Loading" /></div>
         } openOr {
           Comment("FIX"+"ME: Asynchronous rendering failed for unknown reason.")
         }


### PR DESCRIPTION
Added 'assetPath' variable to LiftRules, with default value '/assets'. Rest of the path structure is still convention based, not configurable.

This will address the issue where the Lift template projects are storing the lazy loading gif under assets folder and the framework library expects it to reside at the root level.

On the other hand, also if the default place for the assets is in the way of the application for a reason or another, it is now easier to move somewhere else.

Added also my name to the contributors.md file, as instructed in the documentation.

**[Mailing List](https://groups.google.com/forum/#!topic/liftweb/-2Mh4D2L-cM) thread**:
