### PR TITLE
Use single value append to avoid the overhead of variable arguments

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonParser.scala
@@ -214,8 +214,8 @@ object JsonParser {
           case JField(name, value) =>
             vals.pop(classOf[JField])
             val obj = vals.peek(classOf[IntermediateJObject])
-            obj.fields.append(JField(name,v))
-          case a: IntermediateJArray => a.bits.append(v)
+            obj.fields += (JField(name,v))
+          case a: IntermediateJArray => a.bits += v
           case other => p.fail("expected field or array but got " + other)
       } else {
         vals.push(v)


### PR DESCRIPTION

**[Mailing List](https://groups.google.com/forum/#!forum/liftweb) thread**:
https://groups.google.com/forum/#!topic/liftweb/jD3OG9jD_hs

The newValue method in JsonParser was using a variable argument method when adding a single item to a ListBuffer which triggered extra array allocations. This change uses a single item method bypassing the extra array allocation and optimizing performance.

before change
3.2.0-RC1
[info] LiftJsonBenchmark.readCaseClass thrpt 10 443843.164 ± 5996.863 ops/s

After patch
[info] LiftJsonBenchmark.readCaseClass  thrpt   10  551319.586 ± 6361.040  ops/s
