### PR TITLE
ajk-service-request-timer

### DIFF
--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
@@ -27,7 +27,6 @@ import org.specs2.specification._
 import org.specs2.execute.AsResult
 import org.joda.time.DateTime
 import common._
-import json._
 import mongodb.BsonDSL._
 import util.Helpers.randomString
 import http.{LiftSession, S}
@@ -39,6 +38,7 @@ import common.Box._
 import xml.{Elem, NodeSeq, Text}
 import util.{FieldError, Helpers}
 import Helpers._
+import net.liftweb.json.JsonAST._
 import org.bson.Document
 import org.bson.types.ObjectId
 

--- a/persistence/record/src/test/scala/net/liftweb/record/RecordSpec.scala
+++ b/persistence/record/src/test/scala/net/liftweb/record/RecordSpec.scala
@@ -20,19 +20,16 @@ package record
 import java.util.Calendar
 
 import org.specs2.mutable.Specification
-import org.joda.time._
-
-import http.js.JE._
+import org.joda.time.DateTime
 import common._
-import http.{S, LiftSession}
-import json._
+import http.{LiftSession, S}
 import util._
 import util.Helpers._
-
 import field.Countries
 import fixtures._
-
-import JsonDSL._
+import net.liftweb.http.js.JE._
+import net.liftweb.json.JsonAST._
+import net.liftweb.json.JsonDSL._
 
 
 /**

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1978,8 +1978,22 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    */
   @volatile var logUnreadRequestVars = true
 
-  /** Controls whether or not the service handling timing messages (Service request (GET) ... took ... Milliseconds) are logged. Defaults to true. */
-  @volatile var logServiceRequestTiming = true
+/**
+  * Handles logging of servicing a request
+  * two default implementations:
+  *   - NoOpServiceTimer that does nothing
+  *   - StandardServiceTimer that logs time it takes to serve the request (Service request (GET) ... took ... Milliseconds).
+  *     This is the default used.
+  *
+  *     Set custom in Boot:
+  *     LiftRules.installServiceRequestTimer(MyCustomServiceTimer)
+  */
+  val serviceRequestTimer = new LiftRulesGuardedSetting[FactoryMaker[ServiceRequestTimer]]("serviceRequestTimer", new FactoryMaker[ServiceRequestTimer](StandardServiceTimer){})
+
+  def installServiceRequestTimer(default: ServiceRequestTimer): Unit = {
+    val factoryMaker = new FactoryMaker[ServiceRequestTimer](default) {}
+    serviceRequestTimer.set(factoryMaker)
+  }
 
   /** Provides a function that returns random names for form variables, page ids, callbacks, etc. */
   @volatile var funcNameGenerator: () => String = defaultFuncNameGenerator(Props.mode)

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1978,7 +1978,14 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
    */
   @volatile var logUnreadRequestVars = true
 
-/**
+  /** Controls whether or not the service handling timing messages (Service request (GET) ... took ... Milliseconds) are logged.
+    * If set to false NoOpServiceTimer is used.
+    * We should remove this setting in Lift-4 and only depend on serviceRequestTimer
+    * Defaults to true.
+    * */
+  @volatile var logServiceRequestTiming = true
+
+  /**
   * Handles logging of servicing a request
   * two default implementations:
   *   - NoOpServiceTimer that does nothing

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftServlet.scala
@@ -159,15 +159,7 @@ class LiftServlet extends Loggable {
           )
         }
 
-        if (LiftRules.logServiceRequestTiming) {
-          logTime {
-            val ret = doService(req, resp)
-            val msg = "Service request (" + req.request.method + ") " + req.request.uri + " returned " + resp.getStatus + ","
-            (msg, ret)
-          }
-        } else {
-          doService(req, resp)
-        }
+        LiftRules.serviceRequestTimer.get.vend.logTime(req, resp)(doService)
       }
 
       req.request.resumeInfo match {

--- a/web/webkit/src/main/scala/net/liftweb/http/ServiceRequestTimer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/ServiceRequestTimer.scala
@@ -1,0 +1,24 @@
+package net.liftweb.http
+
+import net.liftweb.http.provider.HTTPResponse
+import net.liftweb.util.Helpers
+
+trait ServiceRequestTimer {
+  def logTime(req: Req, resp: HTTPResponse)(doService: (Req, HTTPResponse) => Boolean): Boolean
+}
+
+object NoOpServiceTimer extends ServiceRequestTimer {
+  override def logTime(req: Req, resp: HTTPResponse)(doService: (Req, HTTPResponse) => Boolean): Boolean = {
+    doService(req, resp)
+  }
+}
+
+object StandardServiceTimer extends ServiceRequestTimer {
+  override def logTime(req: Req, resp: HTTPResponse)(doService: (Req, HTTPResponse) => Boolean): Boolean = {
+    Helpers.logTime {
+      val ret = doService(req, resp)
+      val msg = "Service request (" + req.request.method + ") " + req.request.uri + " returned " + resp.getStatus + ","
+      (msg, ret)
+    }
+  }
+}

--- a/web/webkit/src/main/scala/net/liftweb/http/provider/HTTPProvider.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/provider/HTTPProvider.scala
@@ -132,6 +132,9 @@ trait HTTPProvider {
   }
 
   private def postBoot {
+    if (!LiftRules.logServiceRequestTiming) {
+      LiftRules.installServiceRequestTimer(NoOpServiceTimer)
+    }
     try {
       ResourceBundle getBundle (LiftRules.liftCoreResourceName)
     } catch {


### PR DESCRIPTION
Refactor timing of servicing a request out to ServiceRequestTimer.
The default-implementation, StandardServiceTimer, gives the same
logging as the old parameter logServiceRequestTiming=true