### PR TITLE
Fix of a tryo function

### DIFF
--- a/core/common/src/main/scala/net/liftweb/common/Tryo.scala
+++ b/core/common/src/main/scala/net/liftweb/common/Tryo.scala
@@ -21,8 +21,12 @@ trait Tryo {
     try {
       Full(f)
     } catch {
-      case c if ignore.exists(_.isAssignableFrom(c.getClass)) => onError.foreach(_(c)); Empty
-      case c if (ignore == null || ignore.isEmpty) => onError.foreach(_(c)); Failure(c.getMessage, Full(c), Empty)
+      case c: Throwable =>
+        onError.foreach(_(c))
+        if (ignore == null || !ignore.exists(_.isAssignableFrom(c.getClass)))
+          Failure(c.getMessage, Full(c), Empty)
+        else
+          Empty
     }
   }
 

--- a/core/common/src/test/scala/net/liftweb/common/BoxSpec.scala
+++ b/core/common/src/test/scala/net/liftweb/common/BoxSpec.scala
@@ -515,6 +515,41 @@ class BoxSpec extends Specification with ScalaCheck with BoxGenerator {
     }
   }
 
+  "A Box tryo method" should {
+    "return Full" in {
+      Box.tryo(1) must_== Full(1)
+    }
+
+    "return Failure(_, Full(NPE), _) in case of NPE" in {
+      val obj: Object = null
+
+      Box.tryo(obj.toString) must beLike {
+        case Failure(_, Full(ex), _) => ex.getClass must_== classOf[NullPointerException]
+      }
+    }
+
+    "return Empty in case of NPE and ignore list with NPE" in {
+      val ignore: List[Class[_]] = List(classOf[NullPointerException])
+
+      Box.tryo(ignore)(throw new NullPointerException) must_== Empty
+    }
+
+    "return Failure(_, Full(NPE), _) in case of non empty ignore list without NPE" in {
+      val ignore: List[Class[_]] = List(classOf[IllegalArgumentException])
+
+      Box.tryo(ignore)(throw new NullPointerException) must beLike {
+        case Failure(_, Full(ex), _) => ex.getClass must_== classOf[NullPointerException]
+      }
+    }
+
+    "not throw NPE in case of nullable ignore list" in {
+      val ignore: List[Class[_]] = null
+
+      Box.tryo(ignore)(throw new IllegalArgumentException) must beLike {
+        case Failure(_, Full(ex), _) => ex.getClass must_== classOf[IllegalArgumentException]
+      }
+    }
+  }
 }
 
 


### PR DESCRIPTION
A current implementation of a **tryo** function has a few bugs. Basically, there are two cases when the function throws an exception instead of returning **Failure**. Here are these cases as a part of tests.
```
    "return Failure(_, Full(NPE), _) in case of non empty ignore list without NPE" in {
      val ignore: List[Class[_]] = List(classOf[IllegalArgumentException])

      Box.tryo(ignore)(throw new NullPointerException) must beLike {
        case Failure(_, Full(ex), _) => ex.getClass must_== classOf[NullPointerException]
      }
    }

    "not throw NPE in case of nullable ignore list" in {
      val ignore: List[Class[_]] = null

      Box.tryo(ignore)(throw new IllegalArgumentException) must beLike {
        case Failure(_, Full(ex), _) => ex.getClass must_== classOf[IllegalArgumentException]
      }
    }
```
The first one is about returning Failure with exception instead of throwing exception in case of exception is not in nonempty ignore list.
The second one is about throwing NPE in case of nullable ignore list. Basically, it is true for other parameters as well. For example for onError param. But I left existing condition for checking ignore list for null. Maybe is better to remove this condition at all or add the same checking to **onError** parameter.