### PR TITLE
Upgrade nu.validator html parser

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
   lazy val jbcrypt                = "org.mindrot"                % "jbcrypt"            % "0.4"
   lazy val joda_time              = "joda-time"                  % "joda-time"          % "2.10"
   lazy val joda_convert           = "org.joda"                   % "joda-convert"       % "2.1"
-  lazy val htmlparser             = "nu.validator.htmlparser"    % "htmlparser"         % "1.4"
+  lazy val htmlparser             = "nu.validator"               % "htmlparser"         % "1.4.12"
   lazy val mongo_java_driver      = "org.mongodb"                % "mongodb-driver"     % "3.7.1"
   lazy val mongo_java_driver_async  = "org.mongodb"              % "mongodb-driver-async" % "3.7.1"
   lazy val paranamer              = "com.thoughtworks.paranamer" % "paranamer"          % "2.8"


### PR DESCRIPTION
Liftweb has a slightly ancient nu.validator version.

Specifically it breaks vuetify data-table since it removes <td> tags
inside <template>.

I know I haven't discussed this on the mailing list but since the change is small and passes all lift tests I'm hoping I don't get shot for it =)
