### PR TITLE
Fix confusing DontMergeAttributes modification

### DIFF
--- a/core/util/src/main/scala/net/liftweb/util/CssSel.scala
+++ b/core/util/src/main/scala/net/liftweb/util/CssSel.scala
@@ -393,8 +393,11 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
           }
         }
 
-        case x if x.isInstanceOf[EmptyBox] || x == Full(DontMergeAttributes) => {
+        case x if x.isInstanceOf[EmptyBox] ||
+          x == Full(DontMergeClass) ||
+          x == Full(DontMergeAttributes) => {
           val calced = bind.calculate(realE).map(findElemIfThereIsOne _)
+          val skipClassMerge = x == Full(DontMergeClass) || x == Full(DontMergeAttributes)
 
           calced.length match {
             case 0 => NodeSeq.Empty
@@ -402,7 +405,7 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
               calced.head match {
                 case Group(g) => g
                 case e: Elem => new Elem(e.prefix,
-                  e.label, mergeAll(e.attributes, false, x == Full(DontMergeAttributes)),
+                  e.label, mergeAll(e.attributes, false, skipClassMerge),
                   e.scope, e.minimizeEmpty, e.child: _*)
                 case x => x
               }
@@ -425,7 +428,7 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
                         id => ids.contains(id)
                       } getOrElse (false)
                       val newIds = targetId filter (_ => keepId) map (i => ids - i) getOrElse (ids)
-                      val newElem = new Elem(e.prefix, e.label, mergeAll(e.attributes, !keepId, x == Full(DontMergeAttributes)), e.scope, e.minimizeEmpty, e.child: _*)
+                      val newElem = new Elem(e.prefix, e.label, mergeAll(e.attributes, !keepId, skipClassMerge), e.scope, e.minimizeEmpty, e.child: _*)
                       (newIds, newElem :: result)
                     }
                     case x => (ids, x :: result)

--- a/core/util/src/main/scala/net/liftweb/util/CssSelector.scala
+++ b/core/util/src/main/scala/net/liftweb/util/CssSelector.scala
@@ -80,8 +80,10 @@ final case class PrependKidsSubNode() extends SubNode with WithKids {
   def transform(original: NodeSeq, newNs: NodeSeq): NodeSeq = newNs ++ original
 }
 
-final case object DontMergeAttributes extends SubNode {
-  }
+@deprecated("Please use DontMergeClassValue instead.", "3.3.0")
+final case object DontMergeAttributes extends SubNode
+
+final case object DontMergeClass extends SubNode
 
 final case class SurroundKids() extends SubNode with WithKids {
   def transform(original: NodeSeq, newNs: NodeSeq): NodeSeq = {
@@ -253,7 +255,7 @@ object CssSelectorParser extends PackratParsers with ImplicitConversions {
      name => AttrSubNode(name)
    }) |
 
-   ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
+   ('!' ~ '!' ^^ (a => DontMergeClass)) |
    ('<' ~ '*' ~ '>') ^^ (a => SurroundKids()) |
    ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
    ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |

--- a/core/util/src/test/scala/net/liftweb/util/CssSelectorSpec.scala
+++ b/core/util/src/test/scala/net/liftweb/util/CssSelectorSpec.scala
@@ -503,7 +503,26 @@ object CssBindHelpersSpec extends Specification with XmlMatchers {
       (res \ "@class").length must_== 0
     }
 
+    "don't merge class attribute" in {
+      val func = "p !!" #> <span class="replacement">10</span>
+      val res = func.apply(<p class="first second">Test</p>)
+      (res \ "@class").text must_== "replacement"
+    }
 
+    "merge other attributes when using don't merge class modification" in {
+      val func = "p !!" #> <span data-two="2" class="replacement">10</span>
+      val res = func.apply(<p data-one="1" class="first second">Test</p>)
+      (res \ "@data-one").text must_== "1"
+      (res \ "@data-two").text must_== "2"
+      (res \ "@class").text must_== "replacement"
+    }
+
+    "leave node class attribute for replacement without class" in {
+      // TODO: Since was agreed not to change current behaviour, create test for it (https://groups.google.com/forum/#!topic/liftweb/Nswcxoykspc)
+      val func = "p !!" #> <span>10</span>
+      val res = func.apply(<p class="first second">Test</p>)
+      (res \ "@class").text must_== "first second"
+    }
 
     "Remove a subnode's class attribute" in {
 

--- a/docs/css-selectors.adoc
+++ b/docs/css-selectors.adoc
@@ -266,14 +266,15 @@ Remove from attribute rule: `[attribute-name!]`::
   its own separated by a space. For example, `^ [class!]` will remove the
   class named by the transformation result from all root elements.
 
-Don't merge attributes rule: `!!`::
+Don't merge class attribute rule: `!!`::
   By default, if the transformation yields a single element and the element
   matched by the selector is being replaced by that result, the attributes from
   the matched element are merged into the attributes of the transformation's
-  element. This modifier prevents that from happening. For example, by default
-  doing `"input" #> <div />` and applying it to `<input type="text">` would
-  yield `<div type="text" />`. Doing `"input !!" #> <div />` would instead yield
-  `<div />`.
+  element. This modifier prevents *ONLY* class attribute merging from happening.
+  For example, by default doing `"input" #> <div class="c1"/>` and applying it to
+  `<input class="c2" type="text"/>` would yield `<div type="text" class="c1 c2"/>`.
+  Doing `"input !!" #> <div class="c1" />` would instead yield
+  `<div type="text" class="c1"/>`.
 
 Lift node rule: `^^`::
   This rule will lift the first selected element all the way to the root of the


### PR DESCRIPTION
**[Mailing List](https://groups.google.com/forum/#!topic/liftweb/Nswcxoykspc) thread**:

Use DontMergeClass instead of  confusing DontMergeAttributes modification.
Mark DontMergeAttributes  as deprecated.
Added test for DontMergeClass and fixing docs for it [css-selectors.adoc](docs/css-selectors.adoc) file.