### PR TITLE
Disable the js auto-rewrite

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/http/ResourceServer.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/ResourceServer.scala
@@ -47,9 +47,12 @@ object ResourceServer {
   }
 
   @volatile var pathRewriter: PartialFunction[List[String], List[String]] = rewriter orElse {
-    case "lift.js" :: Nil => List("lift-min.js")
-    case "json.js" :: Nil => List("json2-min.js")
-    case "json2.js" :: Nil => List("json2-min.js")
+    // These automatic rewrites have been disabled since we're not currently
+    // minifying our internal js files on build. There's an open question in
+    // my mind as to whether or not we _should_ continue doin that.
+    // case "lift.js" :: Nil => List("lift-min.js")
+    // case "json.js" :: Nil => List("json2-min.js")
+    // case "json2.js" :: Nil => List("json2-min.js")
     case xs => xs
   }
 
@@ -136,4 +139,3 @@ object ResourceServer {
     pathRewriter = rw orElse pathRewriter
   }
 }
-

--- a/web/webkit/src/test/scala/net/liftweb/http/ResourceServerSpec.scala
+++ b/web/webkit/src/test/scala/net/liftweb/http/ResourceServerSpec.scala
@@ -33,7 +33,6 @@ class ResourceServerSpec extends Specification  {
     "default json to json2 minified version" in {
       (ResourceServer.pathRewriter("json.js"::Nil) must_== List("json2-min.js")) and
       (ResourceServer.pathRewriter("json2.js"::Nil) must_== List("json2-min.js"))
-    }
+    }.pendingUntilFixed
   }
 }
-


### PR DESCRIPTION
**Mailing List thread**:
https://groups.google.com/d/msg/liftweb/urqpaxe-0U8/204X5JzqDQAJ

This PR removes the auto-rewriting we do for minified JS files.

In previous versions of Lift we would minify the JS files in advance using YUI compressor. This fell by the wayside with the recent sbt upgrades due to compatibility issues. Newer solutions, e.g. sbt-web, seem to favor doing the minification on the build of the final web artifact and combining everything into a single file so I've had some difficulty getting it to play nice with our existing JS files.

In an effort to get a working Lift build again, I've favored disabling the automatic rewrite until we can revisit the issue in more depth.
