### PR TITLE
Bump scala-xml to 1.3.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,7 @@ object Dependencies {
   lazy val scalaz7_core           = "org.scalaz"                %% "scalaz-core"        % "7.2.28"
   lazy val squeryl                = "org.squeryl"               %% "squeryl"            % "0.9.5-7"
   lazy val slf4j_api              = "org.slf4j"                  % "slf4j-api"          % slf4jVersion
-  lazy val scala_xml              = "org.scala-lang.modules"     %% "scala-xml"         % "1.2.0"
+  lazy val scala_xml              = "org.scala-lang.modules"     %% "scala-xml"         % "1.3.0"
   lazy val scala_parallel_collections =  "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0"
   lazy val rhino                  = "org.mozilla"                % "rhino"              % "1.7.10"
   lazy val scala_parser           = "org.scala-lang.modules"     %% "scala-parser-combinators" % "1.1.2"


### PR DESCRIPTION
1.2.0 alongside Scala 2.13 caused some changes in CssSel behavior that
led to List returns in cases where NodeSeq returns were expected instead.
1.3.0 *should* fix this, though that has not yet been proven.

-------

See [mailing list thread](https://groups.google.com/forum/#!msg/liftweb/TxM7GAASb2k/wILgmZCGCgAJ).