### PR TITLE
Lift-mapper with Scala 2.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 sudo: false
 scala:
   - 2.11.12
-  - 2.12.10
-  - 2.13.1
+  - 2.12.11
+  - 2.13.2
 cache:
   directories:
     - '$HOME/node_modules'
@@ -15,16 +15,16 @@ jdk:
   - openjdk8
 matrix:
   include:
-  - scala: 2.12.10
+  - scala: 2.12.11
     jdk: openjdk11
     env: DISABLE_PUBLISH=true
-  - scala: 2.12.10
+  - scala: 2.12.11
     jdk: openjdk12
     env: DISABLE_PUBLISH=true
-  - scala: 2.13.1
+  - scala: 2.13.2
     jdk: openjdk11
     env: DISABLE_PUBLISH=true
-  - scala: 2.13.1
+  - scala: 2.13.2
     jdk: openjdk12
     env: DISABLE_PUBLISH=true
 script: ./travis.sh

--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ startYear in ThisBuild             := Some(2006)
 organizationName in ThisBuild      := "WorldWide Conferencing, LLC"
 
 val scala211Version = "2.11.12"
-val scala212Version = "2.12.10"
-val scala213Version = "2.13.1"
+val scala212Version = "2.12.11"
+val scala213Version = "2.13.2"
 
 val crossUpTo212 = Seq(scala212Version, scala211Version)
 val crossUpTo213 = scala213Version +: crossUpTo212
@@ -19,6 +19,8 @@ scalaVersion in ThisBuild          := scala212Version
 crossScalaVersions in ThisBuild    := crossUpTo212 // default everyone to 2.12 for now
 
 libraryDependencies in ThisBuild ++= Seq(specs2, specs2Matchers, specs2Mock, scalacheck, scalatest)
+
+scalacOptions in ThisBuild ++= Seq("-deprecation")
 
 // Settings for Sonatype compliance
 pomIncludeRepository in ThisBuild := { _ => false }
@@ -238,6 +240,7 @@ lazy val mapper =
         )
       }
     )
+    .settings(crossScalaVersions := crossUpTo213)
 
 lazy val record =
   persistenceProject("record")

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val crossUpTo213 = scala213Version +: crossUpTo212
 scalaVersion in ThisBuild          := scala212Version
 crossScalaVersions in ThisBuild    := crossUpTo212 // default everyone to 2.12 for now
 
-libraryDependencies in ThisBuild ++= Seq(specs2, specs2Matchers, specs2Mock, scalacheck, scalatest)
+libraryDependencies in ThisBuild ++= Seq(specs2, specs2Matchers, specs2Mock, scalacheck, scalactic, scalatest)
 
 scalacOptions in ThisBuild ++= Seq("-deprecation")
 
@@ -79,7 +79,7 @@ lazy val markdown =
     .settings(
       description := "Markdown Parser",
       parallelExecution in Test := false,
-      libraryDependencies ++= Seq(scalatest, junit, scala_xml, scala_parser)
+      libraryDependencies ++= Seq(scalatest, scalatest_junit, scala_xml, scala_parser)
     )
     .settings(crossScalaVersions := crossUpTo213)
 
@@ -162,7 +162,7 @@ lazy val webkit =
         specs2MatchersProv,
         jetty6,
         jwebunit,
-        mockito_all,
+        mockito_scalatest,
         jquery,
         jasmineCore,
         jasmineAjax
@@ -218,7 +218,7 @@ lazy val persistence: Seq[ProjectReference] =
 lazy val db =
   persistenceProject("db")
     .dependsOn(util, webkit)
-    .settings(libraryDependencies += mockito_all)
+    .settings(libraryDependencies += mockito_scalatest)
     .settings(crossScalaVersions := crossUpTo213)
 
 lazy val proto =

--- a/core/markdown/src/test/scala/net/liftweb/markdown/BaseParsersTest.scala
+++ b/core/markdown/src/test/scala/net/liftweb/markdown/BaseParsersTest.scala
@@ -19,7 +19,7 @@ package net.liftweb.markdown
  * Christoph Henkelmann http://henkelmann.eu/
  */
 
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import collection.SortedMap

--- a/core/markdown/src/test/scala/net/liftweb/markdown/BlockParsersTest.scala
+++ b/core/markdown/src/test/scala/net/liftweb/markdown/BlockParsersTest.scala
@@ -20,7 +20,7 @@ package net.liftweb.markdown
  */
 
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.{Matchers,FlatSpec}
 import scala.xml.{Group, NodeSeq}
 

--- a/core/markdown/src/test/scala/net/liftweb/markdown/InlineParsersTest.scala
+++ b/core/markdown/src/test/scala/net/liftweb/markdown/InlineParsersTest.scala
@@ -22,7 +22,7 @@ package net.liftweb.markdown
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 /**
  * Tests Inline Parsing, i.e. emphasis , strong text, links, escapes etc.

--- a/core/markdown/src/test/scala/net/liftweb/markdown/LineParsersTest.scala
+++ b/core/markdown/src/test/scala/net/liftweb/markdown/LineParsersTest.scala
@@ -21,7 +21,7 @@ package net.liftweb.markdown
 
 import org.scalatest.{Matchers,FlatSpec}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 /**
  * tests parsing of individual lines

--- a/core/markdown/src/test/scala/net/liftweb/markdown/LineTokenizerTest.scala
+++ b/core/markdown/src/test/scala/net/liftweb/markdown/LineTokenizerTest.scala
@@ -21,7 +21,7 @@ package net.liftweb.markdown
 
 import org.scalatest.{Matchers,FlatSpec}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 /**
  * Tests the Line Tokenizer that prepares input for parsing.

--- a/core/markdown/src/test/scala/net/liftweb/markdown/TransformerTest.scala
+++ b/core/markdown/src/test/scala/net/liftweb/markdown/TransformerTest.scala
@@ -21,7 +21,7 @@ package net.liftweb.markdown
 
 import org.scalatest.{Matchers,FlatSpec}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 /**
  * Tests the behavior of the complete parser, i.e. all parsing steps together.

--- a/persistence/db/src/test/scala/net/liftweb/db/DBSpec.scala
+++ b/persistence/db/src/test/scala/net/liftweb/db/DBSpec.scala
@@ -19,12 +19,10 @@ package db
 
 import org.specs2.mutable.Specification
 import org.specs2.mock.Mockito
-import org.mockito.Matchers._
 
-import net.liftweb.common._
-import net.liftweb.db._
-import net.liftweb.util.DefaultConnectionIdentifier
-import net.liftweb.util.ControlHelpers._
+import common._
+import util.DefaultConnectionIdentifier
+import util.ControlHelpers._
 
 import java.sql._
 
@@ -35,8 +33,8 @@ class DBSpec extends Specification with Mockito {
     def f(success: Boolean): Unit
   }
 
-  def  dBVendor(connection: Connection) = new ProtoDBVendor {
-    def createOne = {
+  def dBVendor(connection: Connection): ProtoDBVendor = new ProtoDBVendor {
+    def createOne: Box[Connection] = {
       connection.createStatement returns mock[PreparedStatement]
       Full(connection)
     }

--- a/persistence/mapper/src/main/scala-2.11/net/liftweb/mapper/OneToMany.scala
+++ b/persistence/mapper/src/main/scala-2.11/net/liftweb/mapper/OneToMany.scala
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2006-2011 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mapper
+
+
+private[mapper] object RecursiveType {
+  val rec: { type R0 <: Mapper[R0] } = null
+  type Rec = rec.R0
+}
+import net.liftweb.mapper.RecursiveType._
+
+/**
+ * Add this trait to a Mapper for managed one-to-many support
+ * For example: class Contact extends LongKeyedMapper[Contact] with OneToMany[Long, Contact] { ... }
+ * @tparam K the type of the primary key
+ * @tparam T the mapper type
+ * @author nafg
+ */
+trait OneToMany[K,T<:KeyedMapper[K, T]] extends KeyedMapper[K,T] { this: T =>
+
+  private[mapper] lazy val oneToManyFields: List[MappedOneToManyBase[Rec]] = {
+    new FieldFinder[MappedOneToManyBase[Rec]](
+      getSingleton,
+      net.liftweb.common.Logger(classOf[OneToMany[K,T]])
+    ).accessorMethods map (_.invoke(this).asInstanceOf[MappedOneToManyBase[Rec]])
+  }
+
+  /**
+   * An override for save to propagate the save to all children
+   * of this parent.
+   * Returns false as soon as the parent or a one-to-many field returns false.
+   * If they are all successful returns true.
+   */
+  override def save: Boolean = {
+    val ret = super.save &&
+      oneToManyFields.forall(_.save)
+    ret
+  }
+
+  /**
+   * An override for delete_! to propagate the deletion
+   * to all children of one-to-many fields implementing Cascade.
+   * Returns false as soon as the parent or a one-to-many field returns false.
+   * If they are all successful returns true.
+   */
+  override def delete_! : Boolean = DB.use(connectionIdentifier){ _ =>
+    if(oneToManyFields.forall{(_: MappedOneToManyBase[_ <: Mapper[_]]) match {
+      case f: Cascade[_] => f.delete_!
+      case _ => true
+    }
+    })
+      super.delete_!
+    else {
+      DB.rollback(connectionIdentifier)
+      false
+    }
+  }
+
+
+  /**
+   * This implicit allows a MappedForeignKey to be used as foreignKey function.
+   * Returns a function that takes a Mapper and looks up the actualField of field on the Mapper.
+   */
+  implicit def foreignKey[K, O<:Mapper[O], T<:KeyedMapper[K,T]](field: MappedForeignKey[K,O,T]): O=>MappedForeignKey[K,O,T] =
+    field.actualField(_).asInstanceOf[MappedForeignKey[K,O,T]]
+
+  /**
+   * Simple OneToMany support for children from the same table
+   */
+  class MappedOneToMany[O <: Mapper[O]](meta: MetaMapper[O], foreign: MappedForeignKey[K,O,T], qp: QueryParam[O]*)
+    extends MappedOneToManyBase[O](
+      ()=>{
+        val ret = meta.findAll(By(foreign, primaryKeyField.get) :: qp.toList : _*)
+        for(child <- ret) {
+          foreign.actualField(child).asInstanceOf[MappedForeignKey[K,O,T]].primeObj(net.liftweb.common.Full(OneToMany.this : T))
+        }
+        ret
+      },
+      foreign
+    )
+
+  /**
+   * This is the base class to use for fields that represent one-to-many or parent-child relationships.
+   * Maintains a list of children, tracking pending additions and deletions, and
+   * keeping their foreign key pointed to this mapper.
+   * Implements Buffer, so the children can be managed as one.
+   * Most users will use MappedOneToMany, however to support children from multiple tables
+   * it is necessary to use MappedOneToManyBase.
+   * @param reloadFunc A function that returns a sequence of children from storage.
+   * @param foreign A function that gets the MappedForeignKey on the child that refers to this parent
+   */
+  class MappedOneToManyBase[O <: Mapper[_]](val reloadFunc: () => Seq[O],
+                                            val foreign: O => MappedForeignKey[K,_,T]) extends scala.collection.mutable.Buffer[O] {
+    private var inited = false
+    private var _delegate: List[O] = _
+    /**
+     * children that were added before the parent was ever saved
+     */
+    private var unlinked: List[O] = Nil
+    protected def delegate: List[O] = {
+      if(!inited) {
+        refresh()
+        inited = true
+      }
+      _delegate
+    }
+    protected def delegate_=(d: List[O]): Unit = _delegate = d
+
+    /**
+     * Takes ownership of e. Sets e's foreign key to our primary key
+     */
+    protected def own(e: O): O = {
+      val f0 = foreign(e).asInstanceOf[Any]
+      f0 match {
+        case f: MappedLongForeignKey[O,T] with MappedForeignKey[K,_,T] =>
+          f.apply(OneToMany.this)
+        case f: MappedForeignKey[K,_,T] =>
+          f.set(OneToMany.this.primaryKeyField.get)
+      }
+      if(!OneToMany.this.saved_?)
+        unlinked ::= e
+      e
+    }
+    /**
+     * Relinquishes ownership of e. Resets e's foreign key to its default value.
+     */
+    protected def unown(e: O): O = {
+      val f = foreign(e)
+      f.set(f.defaultValue)
+      unlinked = unlinked filter {e.ne}
+      e
+    }
+    /**
+     * Returns the backing List
+     */
+    def all: List[O] = delegate
+
+    // 2.8: return this
+    def +=(elem: O): MappedOneToManyBase.this.type = {
+      delegate = delegate ++ List(own(elem))
+      this
+    }
+    // 2.7
+    //def readOnly = all
+    def length: Int = delegate.length
+    // 2.7
+    //def elements = delegate.elements
+    // 2.8
+    def iterator: Iterator[O] = delegate.iterator
+
+    def apply(n: Int): O = delegate(n)
+
+    // 2.7
+    /* def +:(elem: O) = {
+      delegate ::= own(elem)
+      this
+    } */
+    // 2.8
+    def +=:(elem: O): MappedOneToManyBase.this.type = {
+      delegate ::= own(elem)
+      this
+    }
+
+    override def indexOf[B >: O](e: B): Int = delegate.indexWhere(e.asInstanceOf[AnyRef].eq)
+
+    // 2.7
+    // def insertAll(n: Int, iter: Iterable[O]) {
+    // 2.8
+    def insertAll(n: Int, iter: Traversable[O]) {
+      val (before, after) = delegate.splitAt(n)
+      iter foreach own
+      delegate = before ++ iter ++ after
+    }
+
+    def update(n: Int, newelem: O): Unit = {
+      unown(delegate(n))
+      delegate = delegate.take(n) ++ List(own(newelem)) ++ delegate.drop(n+1)
+    }
+
+    def remove(n: Int): O = {
+      val e = unown(delegate(n))
+      delegate = delegate.filterNot(e.eq)
+      e
+    }
+
+    def clear(): Unit = {
+      while(delegate.nonEmpty)
+        remove(0)
+    }
+
+    /**
+     * Reloads the children from storage.
+     * NOTE: This may leave children in an inconsistent state.
+     * It is recommended to call save or clear() before calling refresh.
+     */
+    def refresh(): Unit = {
+      delegate = reloadFunc().toList
+      if(saved_?)
+        unlinked = Nil
+      else
+        unlinked = _delegate
+    }
+
+    /**
+     * Saves this "field," i.e., all the children it represents.
+     * Returns false as soon as save on a child returns false.
+     * Returns true if all children were saved successfully.
+     */
+    def save: Boolean = {
+      unlinked foreach {u =>
+        val f = foreign(u)
+        if(f.obj.map(_ eq OneToMany.this) openOr true) // obj is Empty or this
+        f.apply(OneToMany.this)
+      }
+      unlinked = Nil
+      delegate = delegate.filter {e =>
+        foreign(e).get == OneToMany.this.primaryKeyField.get ||
+          foreign(e).obj.map(_ eq OneToMany.this).openOr(false) // obj is this but not Empty
+      }
+      delegate.forall(_.save)
+    }
+
+    override def toString: String = {
+      val c = getClass.getSimpleName
+      val l = c.lastIndexOf("$")
+      c.substring(c.lastIndexOf("$",l-1)+1, l) + delegate.mkString("[",", ","]")
+    }
+  }
+
+  /**
+   * Adds behavior to delete orphaned fields before save.
+   */
+  trait Owned[O<:Mapper[_]] extends MappedOneToManyBase[O] {
+    var removed: List[O] = Nil
+    override def unown(e: O) = {
+      removed = e :: removed
+      super.unown(e)
+    }
+    override def own(e: O) = {
+      removed = removed filter {e.ne}
+      super.own(e)
+    }
+    override def save: Boolean = {
+      val unowned = removed.filter{ e =>
+        val f = foreign(e)
+        f.get == f.defaultValue
+      }
+      unowned foreach {_.delete_!}
+      super.save
+    }
+  }
+
+  /**
+   * Trait that indicates that the children represented
+   * by this field should be deleted when the parent is deleted.
+   */
+  trait Cascade[O<:Mapper[_]] extends MappedOneToManyBase[O] {
+    def delete_! : Boolean = {
+      delegate.forall { e =>
+        if(foreign(e).get ==
+          OneToMany.this.primaryKeyField.get) {
+          e.delete_!
+        }
+        else
+          true // doesn't constitute a failure
+      }
+    }
+  }
+}

--- a/persistence/mapper/src/main/scala-2.12/net/liftweb/mapper/FieldFinder.scala
+++ b/persistence/mapper/src/main/scala-2.12/net/liftweb/mapper/FieldFinder.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2006-2011 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mapper
+
+import scala.reflect.{ClassTag, classTag}
+
+class FieldFinder[T: ClassTag](metaMapper: AnyRef, logger: common.Logger) {
+
+  import java.lang.reflect._
+
+  logger.debug("Created FieldFinder for " + classTag[T].runtimeClass)
+
+  def isMagicObject(m: Method): Boolean = m.getReturnType.getName.endsWith("$" + m.getName + "$") && m.getParameterTypes.length == 0
+
+  def typeFilter: Class[_] => Boolean = classTag[T].runtimeClass.isAssignableFrom
+
+  /**
+   * Find the magic mapper fields on the superclass
+   */
+  def findMagicFields(onMagic: AnyRef, startingClass: Class[_]): List[Method] = {
+    // If a class name ends in $module, it's a subclass created for scala object instances
+    def deMod(in: String): String =
+      if (in.endsWith("$module")) in.substring(0, in.length - 7)
+      else in
+
+    // find the magic fields for the given superclass
+    def findForClass(clz: Class[_]): List[Method] = clz match {
+      case null => Nil
+      case c =>
+        // get the names of fields that represent the type we want
+
+        val fields = Map(c.getDeclaredFields
+          .filter { f =>
+            val ret = typeFilter(f.getType)
+            logger.trace("typeFilter(" + f.getType + "); T=" + classTag[T].runtimeClass)
+            ret
+          }
+          .map(f => (deMod(f.getName), f)): _*)
+
+        logger.trace("fields: " + fields)
+
+        // this method will find all the super classes and super-interfaces
+        def getAllSupers(clz: Class[_]): List[Class[_]] = clz match {
+          case null => Nil
+          case c =>
+            c :: c.getInterfaces.toList.flatMap(getAllSupers) :::
+              getAllSupers(c.getSuperclass)
+        }
+
+        // does the method return an actual instance of an actual class that's
+        // associated with this Mapper class
+        def validActualType(meth: Method): Boolean = {
+          try {
+            // invoke the method
+            meth.invoke(onMagic) match {
+              case null =>
+                logger.debug("Not a valid mapped field: %s".format(meth.getName))
+                false
+              case inst =>
+                // do we get a T of some sort back?
+                if (!typeFilter(inst.getClass)) false
+                else {
+                  // find out if the class name of the actual thing starts
+                  // with the name of this class or some superclass...
+                  // basically, is an inner class of this class
+                  getAllSupers(clz).exists(c => inst.getClass.getName.startsWith(c.getName))
+                }
+            }
+
+          } catch {
+            case e: Exception =>
+              logger.debug("Not a valid mapped field: %s, got exception: %s".format(meth.getName, e))
+              false
+          }
+        }
+
+        // find all the declared methods
+        val meths = c.getDeclaredMethods.toList.
+          filter(_.getParameterTypes.length == 0). // that take no parameters
+          filter(m => Modifier.isPublic(m.getModifiers)). // that are public
+          filter(m => fields.contains(m.getName) && // that are associated with private fields
+            fields(m.getName).getType == m.getReturnType).
+          filter(validActualType) // and have a validated type
+
+        meths ::: findForClass(clz.getSuperclass)
+    }
+
+    findForClass(startingClass).distinct
+  }
+
+  lazy val accessorMethods = findMagicFields(metaMapper, metaMapper.getClass.getSuperclass)
+}

--- a/persistence/mapper/src/main/scala-2.12/net/liftweb/mapper/ManyToMany.scala
+++ b/persistence/mapper/src/main/scala-2.12/net/liftweb/mapper/ManyToMany.scala
@@ -1,0 +1,217 @@
+package net.liftweb
+package mapper
+
+import common.{Empty, Full}
+
+import scala.annotation.tailrec
+
+/**
+ * Add this trait to a Mapper to add support for many-to-many relationships
+ *
+ * @author nafg
+ */
+trait ManyToMany extends BaseKeyedMapper {
+  this: KeyedMapper[_, _] =>
+
+  private[this] type K = TheKeyType
+  private[this] type T = KeyedMapperType
+
+  private var manyToManyFields: List[MappedManyToMany[_,_,_]] = Nil
+
+  /**
+   * An override for save to propagate the save to all children
+   * of this parent.
+   * Returns false as soon as the parent or a one-to-many field returns false.
+   * If they are all successful returns true.
+   */
+  abstract override def save: Boolean = {
+    super.save && manyToManyFields.forall(_.save)
+  }
+
+  /**
+   * An override for delete_! to propogate the deletion to all children
+   * of this parent.
+   * Returns false as soon as the parent or a one-to-many field returns false.
+   * If they are all successful returns true.
+   */
+  abstract override def delete_! : Boolean = {
+    super.delete_! &&
+      manyToManyFields.forall( _.delete_!)
+  }
+
+
+  /**
+   * This is the base class to extend for fields that track many-to-many relationships.
+   * @param joinMeta The singleton of the join table
+   * @param thisField The foreign key in the join table that refers to this mapper's primaryKey.
+   * @param otherField The foreign key in the join table that refers to the other mapper's primaryKey
+   * @param otherMeta The singleton of the other mapper
+   * @param qp Any QueryParams to limit entries in the join table (other than matching thisField to primaryKey)
+   * To limit children based on fields in the other table (not the join table), it is currently necessary
+   * to point the join mapper to a view which pulls the join table's fields as well as fields of the other table.
+   */
+  class MappedManyToMany[O<:Mapper[O], K2, T2 <: KeyedMapper[K2,T2]](
+    val joinMeta: MetaMapper[O],
+    thisField: MappedForeignKey[K,O,_ <: KeyedMapper[_,_]],
+    val otherField: MappedForeignKey[K2, O, T2],
+    val otherMeta: MetaMapper[T2],
+    val qp: QueryParam[O]*) extends scala.collection.mutable.Buffer[T2] {
+
+    def otherFK[A](join: O)(f: MappedForeignKey[K2,O,T2] => A): A =
+      otherField.actualField(join) match { case mfk: MappedForeignKey[K2,O,T2] => f(mfk) }
+
+    protected def children: List[T2] = joins.flatMap(otherFK(_)(_.obj))
+
+    protected var _joins: List[O] = _
+
+    /**
+     * Get the list of instances of joinMeta
+     */
+    def joins: List[O] = _joins // read only to the public
+    protected var removedJoins: List[O] = Nil
+
+    refresh
+    manyToManyFields ::= this
+
+    protected def isJoinForChild(e: T2)(join: O): Boolean = otherField.actualField(join).get == e.primaryKeyField.get
+
+    protected def joinForChild(e: T2): Option[O] = joins.find(isJoinForChild(e))
+
+    protected def own(e: T2): O = {
+      joinForChild(e).fold {
+        removedJoins
+          // first check if we can recycle a removed join
+          .find(otherField.actualField(_).get == e.primaryKeyField)
+          .fold{
+            val newJoin = joinMeta.create
+            thisField.actualField(newJoin) match {
+              case mfk: MappedForeignKey[K, O, T] => mfk.set(primaryKeyField.get.asInstanceOf[K])
+            }
+            otherFK(newJoin)(_.apply(e))
+            newJoin
+          }{ removedJoin =>
+            removedJoins = removedJoins filter removedJoin.ne
+            removedJoin // well, noLongerRemovedJoin...
+          }
+      }(join => join)
+    }
+
+    protected def unown(e: T2): Option[O] =
+      joinForChild(e).map{ join =>
+        removedJoins = join :: removedJoins
+        val o = otherField.actualField(join)
+        o.set(o.defaultValue)
+        thisField.actualField(join) match { case mfk => mfk set mfk.defaultValue }
+        join
+      }
+
+    /**
+     * Get the List backing this Buffer.
+     */
+    def all: List[T2] = children
+
+    def length: Int = children.length
+
+    def iterator: Iterator[T2] = children.iterator
+
+    protected def childAt(n: Int): T2 = children(n)
+    def apply(n: Int): T2 = childAt(n)
+    def indexOf(e: T2): Int = children.indexWhere(e.eq)
+
+    def insertAll(n: Int, traversable: Traversable[T2]) {
+      val ownedJoins = traversable map own
+      val n2 = joins.indexWhere(isJoinForChild(children(n)))
+      val before = joins.take(n2)
+      val after = joins.drop(n2)
+
+      _joins = before ++ ownedJoins ++ after
+    }
+
+    def +=:(elem: T2): MappedManyToMany.this.type = {
+      _joins ::= own(elem)
+      this
+    }
+
+    def +=(elem: T2): MappedManyToMany.this.type = {
+      _joins ++= List(own(elem))
+      this
+    }
+
+    def update(n: Int, newelem: T2): Unit = {
+      unown(childAt(n)) match {
+        case Some(join) =>
+          val n2 = joins.indexOf(join)
+          val (before, after) = (joins.take(n2), joins.drop(n2+1))
+          _joins = before ++ List(own(newelem)) ++ after
+        case None =>
+      }
+    }
+
+    def remove(n: Int): T2 = {
+      val child = childAt(n)
+      unown(child).foreach(join => _joins = joins filterNot join.eq)
+      child
+    }
+
+    override def remove(idx: Int, count: Int): Unit = {
+      if (count > 0) {
+        @tailrec
+        def loop(c: Int, a: List[T2]): List[T2] =
+          if (c == 0) childAt(idx) :: a
+          else loop(c - 1, childAt(idx + c) :: a)
+
+        val joins0 = loop(count - 1, Nil) flatMap unown
+        _joins = joins filterNot joins0.contains
+      }
+    }
+
+    def clear(): Unit = {
+      children foreach unown
+      _joins = Nil
+    }
+
+    /**
+     * Discard the cached state of this MappedManyToMany's children and reinitialize it from the database
+     */
+    def refresh: List[T2] = {
+      val by = new Cmp[O, TheKeyType](thisField, OprEnum.Eql, Full(primaryKeyField.get.asInstanceOf[K]), Empty, Empty)
+
+      _joins = joinMeta.findAll( (by :: qp.toList): _*)
+      all
+    }
+
+    /**
+     * Save the state of this MappedManyToMany to the database.
+     * This will do the following:
+     * 1) Prune join table instances whose "child" foreign key's value is its defaultValue, i.e., -1
+     * 2) Set all join table instances' "parent" foreign key
+     * 3) Delete all join table instances whose child instance was removed
+     * 4) Save all child instances
+     * 5) If step 3 succeeds save all join instances
+     * 6) Return true if steps 2-4 all returned true; otherwise false
+     */
+    def save: Boolean = {
+      _joins = joins.filter { join =>
+        otherFK(join)(f => f.get != f.defaultValue)
+      }
+      _joins foreach {
+        thisField.actualField(_).asInstanceOf[MappedForeignKey[K,O,X] forSome {type X <: KeyedMapper[K,X]}] set ManyToMany.this.primaryKeyField.get.asInstanceOf[K]
+      }
+
+      removedJoins.forall {_.delete_!} & ( // continue saving even if deleting fails
+        children.forall(_.save) &&
+          joins.forall(_.save)
+      )
+    }
+
+    /**
+     * Deletes all join rows, including those
+     * marked for removal.
+     * Returns true if both succeed, otherwise false
+     */
+    def delete_! : Boolean = {
+      removedJoins.forall(_.delete_!) &
+        joins.forall(_.delete_!)
+    }
+  }
+}

--- a/persistence/mapper/src/main/scala-2.12/net/liftweb/mapper/OneToMany.scala
+++ b/persistence/mapper/src/main/scala-2.12/net/liftweb/mapper/OneToMany.scala
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2006-2011 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mapper
+
+
+private[mapper] object RecursiveType {
+  val rec: { type R0 <: Mapper[R0] } = null
+  type Rec = rec.R0
+}
+import net.liftweb.mapper.RecursiveType._
+
+/**
+ * Add this trait to a Mapper for managed one-to-many support
+ * For example: class Contact extends LongKeyedMapper[Contact] with OneToMany[Long, Contact] { ... }
+ * @tparam K the type of the primary key
+ * @tparam T the mapper type
+ * @author nafg
+ */
+trait OneToMany[K,T<:KeyedMapper[K, T]] extends KeyedMapper[K,T] { this: T =>
+
+  private[mapper] lazy val oneToManyFields: List[MappedOneToManyBase[Rec]] = {
+    new FieldFinder[MappedOneToManyBase[Rec]](
+      getSingleton,
+      net.liftweb.common.Logger(classOf[OneToMany[K,T]])
+    ).accessorMethods map (_.invoke(this).asInstanceOf[MappedOneToManyBase[Rec]])
+  }
+
+  /**
+   * An override for save to propagate the save to all children
+   * of this parent.
+   * Returns false as soon as the parent or a one-to-many field returns false.
+   * If they are all successful returns true.
+   */
+  override def save: Boolean = {
+    val ret = super.save &&
+      oneToManyFields.forall(_.save)
+    ret
+  }
+
+  /**
+   * An override for delete_! to propagate the deletion
+   * to all children of one-to-many fields implementing Cascade.
+   * Returns false as soon as the parent or a one-to-many field returns false.
+   * If they are all successful returns true.
+   */
+  override def delete_! : Boolean = DB.use(connectionIdentifier){ _ =>
+    if(oneToManyFields.forall{(_: MappedOneToManyBase[_ <: Mapper[_]]) match {
+        case f: Cascade[_] => f.delete_!
+        case _ => true
+      }
+    })
+      super.delete_!
+    else {
+      DB.rollback(connectionIdentifier)
+      false
+    }
+  }
+
+
+  /**
+   * This implicit allows a MappedForeignKey to be used as foreignKey function.
+   * Returns a function that takes a Mapper and looks up the actualField of field on the Mapper.
+   */
+  implicit def foreignKey[K, O<:Mapper[O], T<:KeyedMapper[K,T]](field: MappedForeignKey[K,O,T]): O=>MappedForeignKey[K,O,T] =
+    field.actualField(_).asInstanceOf[MappedForeignKey[K,O,T]]
+
+  /**
+   * Simple OneToMany support for children from the same table
+   */
+  class MappedOneToMany[O <: Mapper[O]](meta: MetaMapper[O], foreign: MappedForeignKey[K,O,T], qp: QueryParam[O]*)
+    extends MappedOneToManyBase[O](
+      ()=>{
+        val ret = meta.findAll(By(foreign, primaryKeyField.get) :: qp.toList : _*)
+        for(child <- ret) {
+          foreign.actualField(child).asInstanceOf[MappedForeignKey[K,O,T]].primeObj(net.liftweb.common.Full(OneToMany.this : T))
+        }
+        ret
+      },
+      foreign
+    )
+
+  /**
+   * This is the base class to use for fields that represent one-to-many or parent-child relationships.
+   * Maintains a list of children, tracking pending additions and deletions, and
+   * keeping their foreign key pointed to this mapper.
+   * Implements Buffer, so the children can be managed as one.
+   * Most users will use MappedOneToMany, however to support children from multiple tables
+   * it is necessary to use MappedOneToManyBase.
+   * @param reloadFunc A function that returns a sequence of children from storage.
+   * @param foreign A function that gets the MappedForeignKey on the child that refers to this parent
+   */
+  class MappedOneToManyBase[O <: Mapper[_]](val reloadFunc: () => Seq[O],
+                                            val foreign: O => MappedForeignKey[K,_,T]) extends scala.collection.mutable.Buffer[O] {
+    private var inited = false
+    private var _delegate: List[O] = _
+    /**
+     * children that were added before the parent was ever saved
+    */
+    private var unlinked: List[O] = Nil
+    protected def delegate: List[O] = {
+      if(!inited) {
+        refresh()
+        inited = true
+      }
+      _delegate
+    }
+    protected def delegate_=(d: List[O]): Unit = _delegate = d
+
+    /**
+     * Takes ownership of e. Sets e's foreign key to our primary key
+     */
+    protected def own(e: O): O = {
+      val f0 = foreign(e).asInstanceOf[Any]
+      f0 match {
+        case f: MappedLongForeignKey[O,T] with MappedForeignKey[K,_,T] =>
+          f.apply(OneToMany.this)
+        case f: MappedForeignKey[K,_,T] =>
+          f.set(OneToMany.this.primaryKeyField.get)
+      }
+      if(!OneToMany.this.saved_?)
+         unlinked ::= e
+      e
+    }
+    /**
+     * Relinquishes ownership of e. Resets e's foreign key to its default value.
+     */
+    protected def unown(e: O): O = {
+      val f = foreign(e)
+      f.set(f.defaultValue)
+      unlinked = unlinked filter {e.ne}
+      e
+    }
+    /**
+     * Returns the backing List
+     */
+    def all: List[O] = delegate
+
+    // 2.8: return this
+    def +=(elem: O): MappedOneToManyBase.this.type = {
+      delegate = delegate ++ List(own(elem))
+      this
+    }
+    // 2.7
+    //def readOnly = all
+    def length: Int = delegate.length
+    // 2.7
+    //def elements = delegate.elements
+    // 2.8
+    def iterator: Iterator[O] = delegate.iterator
+
+    def apply(n: Int): O = delegate(n)
+
+    // 2.7
+    /* def +:(elem: O) = {
+      delegate ::= own(elem)
+      this
+    } */
+    // 2.8
+    def +=:(elem: O): MappedOneToManyBase.this.type = {
+      delegate ::= own(elem)
+      this
+    }
+
+    override def indexOf[B >: O](e: B): Int = delegate.indexWhere(e.asInstanceOf[AnyRef].eq)
+
+    // 2.7
+    // def insertAll(n: Int, iter: Iterable[O]) {
+    // 2.8
+    def insertAll(n: Int, iter: Traversable[O]) {
+      val (before, after) = delegate.splitAt(n)
+      iter foreach own
+      delegate = before ++ iter ++ after
+    }
+
+    def update(n: Int, newelem: O): Unit = {
+      unown(delegate(n))
+      delegate = delegate.take(n) ++ List(own(newelem)) ++ delegate.drop(n+1)
+    }
+
+    def remove(n: Int): O = {
+      val e = unown(delegate(n))
+      delegate = delegate.filterNot(e.eq)
+      e
+    }
+
+    def clear(): Unit = {
+      while(delegate.nonEmpty)
+        remove(0)
+    }
+
+    /**
+     * Reloads the children from storage.
+     * NOTE: This may leave children in an inconsistent state.
+     * It is recommended to call save or clear() before calling refresh.
+     */
+    def refresh(): Unit = {
+      delegate = reloadFunc().toList
+      if(saved_?)
+        unlinked = Nil
+      else
+        unlinked = _delegate
+    }
+
+    /**
+     * Saves this "field," i.e., all the children it represents.
+     * Returns false as soon as save on a child returns false.
+     * Returns true if all children were saved successfully.
+     */
+    def save: Boolean = {
+      unlinked foreach {u =>
+        val f = foreign(u)
+        if(f.obj.map(_ eq OneToMany.this) openOr true) // obj is Empty or this
+          f.apply(OneToMany.this)
+      }
+      unlinked = Nil
+      delegate = delegate.filter {e =>
+          foreign(e).get == OneToMany.this.primaryKeyField.get ||
+            foreign(e).obj.map(_ eq OneToMany.this).openOr(false) // obj is this but not Empty
+      }
+      delegate.forall(_.save)
+    }
+
+    override def toString: String = {
+      val c = getClass.getSimpleName
+      val l = c.lastIndexOf("$")
+      c.substring(c.lastIndexOf("$",l-1)+1, l) + delegate.mkString("[",", ","]")
+    }
+  }
+
+  /**
+   * Adds behavior to delete orphaned fields before save.
+   */
+  trait Owned[O<:Mapper[_]] extends MappedOneToManyBase[O] {
+    var removed: List[O] = Nil
+    override def unown(e: O) = {
+      removed = e :: removed
+      super.unown(e)
+    }
+    override def own(e: O) = {
+      removed = removed filter {e.ne}
+      super.own(e)
+    }
+    override def save: Boolean = {
+      val unowned = removed.filter{ e =>
+        val f = foreign(e)
+        f.get == f.defaultValue
+      }
+      unowned foreach {_.delete_!}
+      super.save
+    }
+  }
+
+  /**
+   * Trait that indicates that the children represented
+   * by this field should be deleted when the parent is deleted.
+   */
+  trait Cascade[O<:Mapper[_]] extends MappedOneToManyBase[O] {
+    def delete_! : Boolean = {
+      delegate.forall { e =>
+          if(foreign(e).get ==
+            OneToMany.this.primaryKeyField.get) {
+              e.delete_!
+            }
+          else
+            true // doesn't constitute a failure
+      }
+    }
+  }
+}

--- a/persistence/mapper/src/main/scala-2.13/net/liftweb/mapper/FieldFinder.scala
+++ b/persistence/mapper/src/main/scala-2.13/net/liftweb/mapper/FieldFinder.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2006-2011 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mapper
+
+import scala.reflect.{ClassTag, classTag}
+
+class FieldFinder[T: ClassTag](metaMapper: AnyRef, logger: common.Logger) {
+  import java.lang.reflect._
+
+  logger.debug("Created FieldFinder for " + classTag[T].runtimeClass)
+
+  def isMagicObject(m: Method): Boolean = m.getReturnType.getName.endsWith("$"+m.getName+"$") && m.getParameterTypes.length == 0
+
+  def typeFilter: Class[_]=>Boolean = classTag[T].runtimeClass.isAssignableFrom
+
+  /**
+    * Find the magic mapper fields on the superclass
+    */
+  def findMagicFields(onMagic: AnyRef, startingClass: Class[_]): List[Method] = {
+    // If a class name ends in $module, it's a subclass created for scala object instances
+    def deMod(in: String): String =
+      if (in.endsWith("$module")) in.substring(0, in.length - 7)
+      else in
+
+    // find the magic fields for the given superclass
+    def findForClass(clz: Class[_]): List[Method] = clz match {
+      case null => Nil
+      case c =>
+        // get the names of fields that represent the type we want
+
+        val fields = Map.from(c.getDeclaredFields
+                               .filter{f =>
+                                 val ret = typeFilter(f.getType)
+                                 logger.trace("typeFilter(" + f.getType + "); T=" + classTag[T].runtimeClass)
+                                 ret
+                               }
+                               .map(f => (deMod(f.getName), f)))
+
+        logger.trace("fields: " + fields)
+
+        // this method will find all the super classes and super-interfaces
+        def getAllSupers(clz: Class[_]): List[Class[_]] = clz match {
+          case null => Nil
+          case c =>
+            c :: c.getInterfaces.toList.flatMap(getAllSupers) :::
+            getAllSupers(c.getSuperclass)
+        }
+
+        // does the method return an actual instance of an actual class that's
+        // associated with this Mapper class
+        def validActualType(meth: Method): Boolean = {
+          try {
+            // invoke the method
+            meth.invoke(onMagic) match {
+              case null =>
+                logger.debug("Not a valid mapped field: %s".format(meth.getName))
+                false
+              case inst =>
+                // do we get a T of some sort back?
+                if (!typeFilter(inst.getClass)) false
+                else {
+                  // find out if the class name of the actual thing starts
+                  // with the name of this class or some superclass...
+                  // basically, is an inner class of this class
+                  getAllSupers(clz).exists(c => inst.getClass.getName.startsWith(c.getName))
+                }
+            }
+
+          } catch {
+            case e: Exception =>
+              logger.debug("Not a valid mapped field: %s, got exception: %s".format(meth.getName, e))
+              false
+          }
+        }
+
+        // find all the declared methods
+        val meths = c.getDeclaredMethods.toList.
+        filter(_.getParameterTypes.length == 0). // that take no parameters
+        filter(m => Modifier.isPublic(m.getModifiers)). // that are public
+        filter(m => fields.contains(m.getName) && // that are associated with private fields
+                fields(m.getName).getType == m.getReturnType).
+        filter(validActualType) // and have a validated type
+
+        meths ::: findForClass(clz.getSuperclass)
+    }
+
+    findForClass(startingClass).distinct
+  }
+
+  lazy val accessorMethods = findMagicFields(metaMapper, metaMapper.getClass.getSuperclass)
+}

--- a/persistence/mapper/src/main/scala-2.13/net/liftweb/mapper/ManyToMany.scala
+++ b/persistence/mapper/src/main/scala-2.13/net/liftweb/mapper/ManyToMany.scala
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2006-2011 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mapper
+
+import common._
+
+import scala.annotation.tailrec
+import scala.language.existentials
+
+/**
+ * Add this trait to a Mapper to add support for many-to-many relationships
+ * @author nafg
+ */
+trait ManyToMany extends BaseKeyedMapper {
+  this: KeyedMapper[_, _] =>
+
+  private[this] type K = TheKeyType
+  private[this] type T = KeyedMapperType
+
+  private var manyToManyFields: List[MappedManyToMany[_,_,_]] = Nil
+
+  /**
+   * An override for save to propagate the save to all children
+   * of this parent.
+   * Returns false as soon as the parent or a one-to-many field returns false.
+   * If they are all successful returns true.
+   */
+  abstract override def save: Boolean = {
+    super.save && manyToManyFields.forall(_.save)
+  }
+
+  /**
+   * An override for delete_! to propogate the deletion to all children
+   * of this parent.
+   * Returns false as soon as the parent or a one-to-many field returns false.
+   * If they are all successful returns true.
+   */
+  abstract override def delete_! : Boolean = {
+    super.delete_! &&
+      manyToManyFields.forall( _.delete_!)
+  }
+
+
+  /**
+   * This is the base class to extend for fields that track many-to-many relationships.
+   * @param joinMeta The singleton of the join table
+   * @param thisField The foreign key in the join table that refers to this mapper's primaryKey.
+   * @param otherField The foreign key in the join table that refers to the other mapper's primaryKey
+   * @param otherMeta The singleton of the other mapper
+   * @param qp Any QueryParams to limit entries in the join table (other than matching thisField to primaryKey)
+   * To limit children based on fields in the other table (not the join table), it is currently necessary
+   * to point the join mapper to a view which pulls the join table's fields as well as fields of the other table.
+   */
+  class MappedManyToMany[O<:Mapper[O], K2, T2 <: KeyedMapper[K2,T2]](
+    val joinMeta: MetaMapper[O],
+    thisField: MappedForeignKey[K,O,_ <: KeyedMapper[_,_]],
+    val otherField: MappedForeignKey[K2, O, T2],
+    val otherMeta: MetaMapper[T2],
+    val qp: QueryParam[O]*) extends scala.collection.mutable.Buffer[T2] {
+
+    def otherFK[A](join: O)(f: MappedForeignKey[K2,O,T2] => A): A =
+      otherField.actualField(join) match { case mfk: MappedForeignKey[K2,O,T2] => f(mfk) }
+
+    protected def children: List[T2] = joins.flatMap(otherFK(_)(_.obj))
+
+    protected var _joins: List[O] = _
+
+    /**
+     * Get the list of instances of joinMeta
+     */
+    def joins: List[O] = _joins // read only to the public
+    protected var removedJoins: List[O] = Nil
+
+    refresh
+    manyToManyFields ::= this
+
+    protected def isJoinForChild(e: T2)(join: O): Boolean = otherField.actualField(join).get == e.primaryKeyField.get
+
+    protected def joinForChild(e: T2): Option[O] = joins.find(isJoinForChild(e))
+
+    protected def own(e: T2): O = {
+      joinForChild(e).fold {
+        removedJoins
+          // first check if we can recycle a removed join
+          .find(otherField.actualField(_).get == e.primaryKeyField)
+          .fold{
+            val newJoin = joinMeta.create
+            thisField.actualField(newJoin) match {
+              case mfk: MappedForeignKey[K, O, T] => mfk.set(primaryKeyField.get.asInstanceOf[K])
+            }
+            otherFK(newJoin)(_.apply(e))
+            newJoin
+          }{ removedJoin =>
+            removedJoins = removedJoins filter removedJoin.ne
+            removedJoin // well, noLongerRemovedJoin...
+          }
+      }(join => join)
+    }
+
+    protected def unown(e: T2): Option[O] =
+      joinForChild(e).map{ join =>
+        removedJoins = join :: removedJoins
+        val o = otherField.actualField(join)
+        o.set(o.defaultValue)
+        thisField.actualField(join) match { case mfk => mfk set mfk.defaultValue }
+        join
+      }
+
+    /**
+     * Get the List backing this Buffer.
+     */
+    def all: List[T2] = children
+
+    def length: Int = children.length
+
+    def iterator: Iterator[T2] = children.iterator
+
+    protected def childAt(n: Int): T2 = children(n)
+    def apply(n: Int): T2 = childAt(n)
+    def indexOf(e: T2): Int = children.indexWhere(e.eq)
+
+    def insert(idx: Int, elem: T2): Unit = insertAll(idx, Seq(elem))
+
+    def insertAll(n: Int, traversable: IterableOnce[T2]): Unit = {
+      val ownedJoins = traversable.iterator.map(own)
+      val n2 = joins.indexWhere(isJoinForChild(children(n)))
+      val before = joins.take(n2)
+      val after = joins.drop(n2)
+
+      _joins = before ++ ownedJoins ++ after
+    }
+
+    def prepend(elem: T2): MappedManyToMany.this.type = {
+      _joins ::= own(elem)
+      this
+    }
+
+    def addOne(elem: T2): MappedManyToMany.this.type = {
+      _joins ++= List(own(elem))
+      this
+    }
+
+    def update(n: Int, newelem: T2): Unit = {
+      unown(childAt(n)) match {
+        case Some(join) =>
+          val n2 = joins.indexOf(join)
+          val (before, after) = (joins.take(n2), joins.drop(n2+1))
+          _joins = before ++ List(own(newelem)) ++ after
+        case None =>
+      }
+    }
+
+    def remove(n: Int): T2 = {
+      val child = childAt(n)
+      unown(child).foreach(join => _joins = joins filterNot join.eq)
+      child
+    }
+
+    override def remove(idx: Int, count: Int): Unit = {
+      if (count > 0) {
+        @tailrec
+        def loop(c: Int, a: List[T2]): List[T2] =
+          if (c == 0) childAt(idx) :: a
+          else loop(c - 1, childAt(idx + c) :: a)
+
+        val joins0 = loop(count - 1, Nil) flatMap unown
+        _joins = joins filterNot joins0.contains
+      }
+    }
+
+    override def patchInPlace(from: Int, patch: IterableOnce[T2], replaced: Int): MappedManyToMany.this.type = {
+      remove(from, replaced)
+      insertAll(from, patch)
+      this
+    }
+
+    def clear(): Unit = {
+      children foreach unown
+      _joins = Nil
+    }
+
+    /**
+     * Discard the cached state of this MappedManyToMany's children and reinitialize it from the database
+     */
+    def refresh: List[T2] = {
+      val by = new Cmp[O, TheKeyType](thisField, OprEnum.Eql, Full(primaryKeyField.get.asInstanceOf[K]), Empty, Empty)
+
+      _joins = joinMeta.findAll( (by :: qp.toList): _*)
+      all
+    }
+
+    /**
+     * Save the state of this MappedManyToMany to the database.
+     * This will do the following:
+     * 1) Prune join table instances whose "child" foreign key's value is its defaultValue, i.e., -1
+     * 2) Set all join table instances' "parent" foreign key
+     * 3) Delete all join table instances whose child instance was removed
+     * 4) Save all child instances
+     * 5) If step 3 succeeds save all join instances
+     * 6) Return true if steps 2-4 all returned true; otherwise false
+     */
+    def save: Boolean = {
+      _joins = joins.filter { join =>
+        otherFK(join)(f => f.get != f.defaultValue)
+      }
+      _joins foreach {
+        thisField.actualField(_).asInstanceOf[MappedForeignKey[K,O,X] forSome {type X <: KeyedMapper[K,X]}] set ManyToMany.this.primaryKeyField.get.asInstanceOf[K]
+      }
+
+      removedJoins.forall {_.delete_!} & ( // continue saving even if deleting fails
+        children.forall(_.save) &&
+          joins.forall(_.save)
+      )
+    }
+
+    /**
+     * Deletes all join rows, including those
+     * marked for removal.
+     * Returns true if both succeed, otherwise false
+     */
+    def delete_! : Boolean = {
+      removedJoins.forall(_.delete_!) &
+        joins.forall(_.delete_!)
+    }
+  }
+}

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/AjaxMapper.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/AjaxMapper.scala
@@ -29,7 +29,7 @@ trait AjaxEditableField[FieldType,OwnerType <: Mapper[OwnerType]] extends Mapped
     if (editableField) {
       <xml:group>{
         toForm.map { form =>
-          SHtml.ajaxEditable(super.asHtml, form, () => {fieldOwner.save; onSave; net.liftweb.http.js.JsCmds.Noop})
+          SHtml.ajaxEditable(super.asHtml, form, () => {fieldOwner.save; onSave(); net.liftweb.http.js.JsCmds.Noop})
         } openOr super.asHtml
       }</xml:group>
     } else {
@@ -37,7 +37,7 @@ trait AjaxEditableField[FieldType,OwnerType <: Mapper[OwnerType]] extends Mapped
     }
 
   /** This method is called when the element's data are saved. The default is to do nothing */
-  def onSave {}
+  def onSave(): Unit = {}
 
   /** This method allows you to do programmatic control of whether the field will display
    *  as editable. The default is true */

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/CRUDify.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/CRUDify.scala
@@ -17,12 +17,8 @@
 package net.liftweb
 package mapper
 
-import sitemap._
-import Loc._
-import http._
 import util._
 import common._
-import Helpers._
 
 import scala.xml._
 

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/DB.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/DB.scala
@@ -22,9 +22,6 @@ import http.S
 object DB extends db.DB1 {
   db.DB.queryCollector = {
     case (query, time) => 
-      query.statementEntries.foreach(
-        {case db.DBLogEntry(stmt, duration) => S.logQuery(stmt, duration)
-       }
-      )
+      query.statementEntries.foreach{ case db.DBLogEntry(stmt, duration) => S.logQuery(stmt, duration) }
   }
 }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedBinary.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedBinary.scala
@@ -40,7 +40,6 @@ abstract class MappedBinary[T<:Mapper[T]](val fieldOwner: T) extends MappedField
     value
   }
 
-
   def manifest: TypeTag[Array[Byte]] = typeTag[Array[Byte]]
 
   /**
@@ -84,23 +83,23 @@ abstract class MappedBinary[T<:Mapper[T]](val fieldOwner: T) extends MappedField
     def asSeq(v: T): Box[Seq[SourceFieldInfo]] = Empty
   })
 
-  def dbFieldClass = classOf[Array[Byte]]
+  def dbFieldClass: Class[Array[Byte]] = classOf[Array[Byte]]
 
   /**
   * Get the JDBC SQL Type for this field
   */
   //  def getTargetSQLType(field : String) = Types.BINARY
-  def targetSQLType = Types.BINARY
+  def targetSQLType: Int = Types.BINARY
 
   def defaultValue: Array[Byte] = null
   override def writePermission_? = true
   override def readPermission_? = true
 
-  protected def i_is_! = data.get
+  protected def i_is_! : Array[Byte] = data.get
 
-  protected def i_was_! = orgData.get
+  protected def i_was_! : Array[Byte] = orgData.get
 
-  protected[mapper] def doneWithSave() {orgData.setFrom(data)}
+  protected[mapper] def doneWithSave(): Unit = {orgData.setFrom(data)}
 
   protected def i_obscure_!(in : Array[Byte]) : Array[Byte] = {
     new Array[Byte](0)
@@ -202,23 +201,23 @@ abstract class MappedText[T<:Mapper[T]](val fieldOwner: T) extends MappedField[S
       def asSeq(v: T): Box[Seq[SourceFieldInfo]] = Empty
     })
 
-  def dbFieldClass = classOf[String]
+  def dbFieldClass: Class[String] = classOf[String]
 
   /**
   * Get the JDBC SQL Type for this field
   */
   //  def getTargetSQLType(field : String) = Types.BINARY
-  def targetSQLType = Types.VARCHAR
+  def targetSQLType: Int = Types.VARCHAR
 
   def defaultValue: String = null
   override def writePermission_? = true
   override def readPermission_? = true
 
-  protected def i_is_! = data.get
+  protected def i_is_! : String = data.get
 
-  protected def i_was_! = orgData.get
+  protected def i_was_! : String = orgData.get
 
-  protected[mapper] def doneWithSave() {orgData.setFrom(data)}
+  protected[mapper] def doneWithSave(): Unit = {orgData.setFrom(data)}
 
   def asJsExp: JsExp = JE.Str(get)
 
@@ -229,11 +228,11 @@ abstract class MappedText[T<:Mapper[T]](val fieldOwner: T) extends MappedField[S
 
   protected def i_obscure_!(in: String): String = ""
 
-    override def setFromAny(in: Any): String = {
+  override def setFromAny(in: Any): String = {
     in match {
       case JsonAST.JNull => this.set(null)
       case JsonAST.JString(str) => this.set(str)
-      case seq: Seq[_] if !seq.isEmpty => seq.map(setFromAny).apply(0)
+      case seq: Seq[_] if seq.nonEmpty => seq.map(setFromAny).head
       case (s: String) :: _ => this.set(s)
       case s :: _ => this.setFromAny(s)
       case null => this.set(null)
@@ -246,7 +245,6 @@ abstract class MappedText[T<:Mapper[T]](val fieldOwner: T) extends MappedField[S
   }
 
   def jdbcFriendly(field : String): Object = real_convertToJDBCFriendly(data.get)
-
 
   def real_convertToJDBCFriendly(value: String): Object = value match {
     case null => null
@@ -268,10 +266,7 @@ abstract class MappedText[T<:Mapper[T]](val fieldOwner: T) extends MappedField[S
 
   def buildSetLongValue(accessor : Method, columnName : String): (T, Long, Boolean) => Unit = null
   def buildSetStringValue(accessor : Method, columnName : String): (T, String) => Unit  = (inst, v) => doField(inst, accessor, {case f: MappedText[T] =>
-    val toSet = v match {
-      case null => null
-      case other => other
-    }
+    val toSet = v
     f.data() = toSet
     f.orgData() = toSet
   })
@@ -294,7 +289,7 @@ abstract class MappedFakeClob[T<:Mapper[T]](val fieldOwner: T) extends MappedFie
     value
   }
 
-  def dbFieldClass = classOf[String]
+  def dbFieldClass: Class[String] = classOf[String]
 
   def manifest: TypeTag[String] = typeTag[String]
 
@@ -344,17 +339,17 @@ abstract class MappedFakeClob[T<:Mapper[T]](val fieldOwner: T) extends MappedFie
   * Get the JDBC SQL Type for this field
   */
   //  def getTargetSQLType(field : String) = Types.BINARY
-  def targetSQLType = Types.BINARY
+  def targetSQLType: Int = Types.BINARY
 
   def defaultValue: String = null
   override def writePermission_? = true
   override def readPermission_? = true
 
-  protected def i_is_! = data.get
+  protected def i_is_! : String = data.get
 
-  protected def i_was_! = orgData.get
+  protected def i_was_! : String = orgData.get
 
-  protected[mapper] def doneWithSave() {orgData.setFrom(data)}
+  protected[mapper] def doneWithSave(): Unit = {orgData.setFrom(data)}
 
   protected def i_obscure_!(in: String): String = ""
 
@@ -365,12 +360,11 @@ abstract class MappedFakeClob[T<:Mapper[T]](val fieldOwner: T) extends MappedFie
     case str => JsonAST.JString(str)
   })
 
-
-    override def setFromAny(in: Any): String = {
+  override def setFromAny(in: Any): String = {
     in match {
       case JsonAST.JNull => this.set(null)
       case JsonAST.JString(str) => this.set(str)
-      case seq: Seq[_] if !seq.isEmpty => seq.map(setFromAny).apply(0)
+      case seq: Seq[_] if seq.nonEmpty => seq.map(setFromAny).head
       case (s: String) :: _ => this.set(s)
       case s :: _ => this.setFromAny(s)
       case null => this.set(null)
@@ -383,7 +377,6 @@ abstract class MappedFakeClob[T<:Mapper[T]](val fieldOwner: T) extends MappedFie
   }
 
   def jdbcFriendly(field : String): Object = real_convertToJDBCFriendly(data.get)
-
 
   def real_convertToJDBCFriendly(value: String): Object = value match {
     case null => null
@@ -403,11 +396,8 @@ abstract class MappedFakeClob[T<:Mapper[T]](val fieldOwner: T) extends MappedFie
   })
 
   def buildSetLongValue(accessor : Method, columnName : String): (T, Long, Boolean) => Unit = null
-  def buildSetStringValue(accessor : Method, columnName : String): (T, String) => Unit  = (inst, v) => doField(inst, accessor, {case f: MappedFakeClob[T] =>
-    val toSet = v match {
-      case null => null
-      case other => other
-    }
+  def buildSetStringValue(accessor : Method, columnName : String): (T, String) => Unit = (inst, v) => doField(inst, accessor, {case f: MappedFakeClob[T] =>
+    val toSet = v
     f.data() = toSet
     f.orgData() = toSet
   })
@@ -419,4 +409,3 @@ abstract class MappedFakeClob[T<:Mapper[T]](val fieldOwner: T) extends MappedFie
   */
   def fieldCreatorString(dbType: DriverType, colName: String): String = colName + " " + dbType.binaryColumnType + notNullAppender()
 }
-

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedBoolean.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedBoolean.scala
@@ -17,7 +17,7 @@
 package net.liftweb
 package mapper
 
-import java.sql.{ResultSet, Types}
+import java.sql.Types
 import java.lang.reflect.Method
 import net.liftweb.util.Helpers._
 import net.liftweb.http.{S, SHtml}
@@ -88,9 +88,9 @@ abstract class MappedBoolean[T<:Mapper[T]](val fieldOwner: T) extends MappedFiel
     })
 
 
-  protected def i_is_! = data openOr false
-  protected def i_was_! = orgData openOr false
-  protected[mapper] def doneWithSave() {orgData = data}
+  protected def i_is_! : Boolean = data openOr false
+  protected def i_was_! : Boolean = orgData openOr false
+  protected[mapper] def doneWithSave(): Unit = {orgData = data}
 
   protected def real_i_set_!(value : Boolean) : Boolean = {
     val boxed = Full(value)
@@ -103,7 +103,7 @@ abstract class MappedBoolean[T<:Mapper[T]](val fieldOwner: T) extends MappedFiel
   override def readPermission_? = true
   override def writePermission_? = true
 
-     def asJsonValue: Box[JsonAST.JValue] = Full(JsonAST.JBool(get))
+  def asJsonValue: Box[JsonAST.JValue] = Full(JsonAST.JBool(get))
 
   def real_convertToJDBCFriendly(value: Boolean): Object = new java.lang.Integer(if (value) 1 else 0)
 
@@ -136,7 +136,7 @@ abstract class MappedBoolean[T<:Mapper[T]](val fieldOwner: T) extends MappedFiel
     }
   }
 
-  private def allSet(in: Box[Boolean]) {
+  private def allSet(in: Box[Boolean]): Unit = {
     this.data = in
     this.orgData = in
   }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedDate.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedDate.scala
@@ -135,7 +135,7 @@ abstract class MappedDate[T<:Mapper[T]](val fieldOwner: T) extends MappedField[D
 
   protected def i_is_! = data.get
   protected def i_was_! = orgData.get
-  protected[mapper] def doneWithSave() {orgData.setFrom(data)}
+  protected[mapper] def doneWithSave(): Unit = {orgData.setFrom(data)}
 
   protected def i_obscure_!(in : Date) : Date = {
     new Date(0L)

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedDateTime.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedDateTime.scala
@@ -128,7 +128,7 @@ abstract class MappedDateTime[T<:Mapper[T]](val fieldOwner: T) extends MappedFie
 
   protected def i_is_! = data.get
   protected def i_was_! = orgData.get
-  protected[mapper] def doneWithSave() {orgData.setFrom(data)}
+  protected[mapper] def doneWithSave(): Unit = {orgData.setFrom(data)}
 
   protected def i_obscure_!(in : Date) : Date = {
     new Date(0L)

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedDecimal.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedDecimal.scala
@@ -138,7 +138,7 @@ abstract class MappedDecimal[T <: Mapper[T]] (val fieldOwner : T, val context : 
   protected def i_is_! = data
   protected def i_was_! = orgData
 
-  override def doneWithSave() {
+  override def doneWithSave(): Unit = {
     orgData = data
   }
 

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedDouble.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedDouble.scala
@@ -17,11 +17,10 @@
 package net.liftweb
 package mapper
 
-import java.sql.{ResultSet, Types}
+import java.sql.Types
 import java.lang.reflect.Method
 import net.liftweb.common._
 import net.liftweb.util._
-import Helpers._
 import java.util.Date
 import net.liftweb.http._
 import scala.xml.{Text, NodeSeq}
@@ -32,18 +31,18 @@ abstract class MappedDouble[T<:Mapper[T]](val fieldOwner: T) extends MappedField
 	private var data: Double = defaultValue
 	private var orgData: Double = defaultValue
 
-	private def st(in: Double) {
+	private def st(in: Double): Unit = {
 		data = in
 		orgData = in
 	}
 
 	def defaultValue: Double = 0.0
-	def dbFieldClass = classOf[Double]
+	def dbFieldClass: Class[Double] = classOf[Double]
 
-	protected def i_is_! = data
-	protected def i_was_! = orgData
+	protected def i_is_! : Double = data
+	protected def i_was_! : Double = orgData
 
-	override def doneWithSave() {
+	override def doneWithSave(): Unit = {
 		orgData = data
 	}
 
@@ -95,15 +94,15 @@ abstract class MappedDouble[T<:Mapper[T]](val fieldOwner: T) extends MappedField
 		in match {
 			case null => 0.0
 			case i: Int => i
-			case n: Long => n
+			case n: Long => n.toDouble
 			case n : Number => n.doubleValue
 			case (n: Number) :: _ => n.doubleValue
             case Full(n) => toDouble(n) // fixes issue 185
-            case x: EmptyBox => 0.0
+            case _: EmptyBox => 0.0
 			case Some(n) => toDouble(n)
 			case None => 0.0
 			case s: String => s.toDouble
-			case x :: xs => toDouble(x)
+			case x :: _ => toDouble(x)
 			case o => toDouble(o.toString)
 		}
 	}
@@ -111,7 +110,7 @@ abstract class MappedDouble[T<:Mapper[T]](val fieldOwner: T) extends MappedField
 	override def readPermission_? = true
 	override def writePermission_? = true
 
-	protected def i_obscure_!(in : Double) = defaultValue
+	protected def i_obscure_!(in : Double): Double = defaultValue
 
 	protected def real_i_set_!(value : Double): Double = {
 		if (value != data) {
@@ -146,17 +145,17 @@ abstract class MappedDouble[T<:Mapper[T]](val fieldOwner: T) extends MappedField
 	/**
 	* Get the JDBC SQL Type for this field
 	*/
-	def targetSQLType = Types.DOUBLE
+	def targetSQLType: Int = Types.DOUBLE
 	def jdbcFriendly(field : String) = new java.lang.Double(i_is_!)
 	def buildSetBooleanValue(accessor : Method, columnName : String) : (T, Boolean, Boolean) => Unit = null
 	def buildSetDateValue(accessor : Method, columnName : String) : (T, Date) => Unit =
-		(inst, v) => doField(inst, accessor, {case f: MappedDouble[T] => f.st(if (v == null) defaultValue else v.getTime)})
+		(inst, v) => doField(inst, accessor, {case f: MappedDouble[T] => f.st(if (v == null) defaultValue else v.getTime.toDouble)})
 
 	def buildSetStringValue(accessor: Method, columnName: String): (T, String) =>
 		Unit = (inst, v) => doField(inst, accessor, {case f: MappedDouble[T] => f.st(toDouble(v))})
 
 	def buildSetLongValue(accessor: Method, columnName : String) : (T, Long, Boolean) =>
-		Unit = (inst, v, isNull) => doField(inst, accessor, {case f: MappedDouble[T] => f.st(if (isNull) defaultValue else v)})
+		Unit = (inst, v, isNull) => doField(inst, accessor, {case f: MappedDouble[T] => f.st(if (isNull) defaultValue else v.toDouble)})
 
 	def buildSetActualValue(accessor: Method, data: AnyRef, columnName: String) : (T, AnyRef) =>
 		Unit = (inst, v) => doField(inst, accessor, {case f: MappedDouble[T] => f.st(toDouble(v))})

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedEmail.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedEmail.scala
@@ -17,11 +17,11 @@
 package net.liftweb
 package mapper
 
-import java.util.regex._
+import http.S
+import util.FieldError
+import proto._
+
 import scala.xml.Text
-import net.liftweb.http.{S}
-import net.liftweb.util.{FieldError}
-import net.liftweb.proto._
 
 object MappedEmail {
   def emailPattern = ProtoRules.emailRegexPattern.vend

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedForeignKey.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedForeignKey.scala
@@ -95,7 +95,7 @@ with LifecycleCallbacks {
   private def checkTypes(km: KeyedMapper[KeyType, _]): Boolean =
     km.getSingleton eq foreignMeta
 
-  override def equals(other: Any) = other match {
+  override def equals(other: Any): Boolean = other match {
     case km: KeyedMapper[KeyType, Other] if checkTypes(km) => this.get == km.primaryKeyField.get
     case _ => super.equals(other)
   }
@@ -124,7 +124,7 @@ with LifecycleCallbacks {
    */
   def cached_? : Boolean = synchronized{ _calcedObj}
 
-  override protected def dirty_?(b: Boolean) = synchronized { // issue 165
+  override protected def dirty_?(b: Boolean): Unit = synchronized { // issue 165
     // invalidate if the primary key has changed Issue 370
     if (_obj.isEmpty || (_calcedObj && _obj.isDefined &&
        _obj.openOrThrowException("_obj was just checked as full.").primaryKeyField.get != this.i_is_!)) {
@@ -151,13 +151,13 @@ with LifecycleCallbacks {
     _obj
   }
 
-  private[mapper] def _primeObj(obj: Box[Any]) =
+  private[mapper] def _primeObj(obj: Box[Any]): Unit =
     primeObj(obj.asInstanceOf[Box[Other]])
 
   /**
    * Prime the reference of this FK reference
    */
-  def primeObj(obj: Box[Other]) = synchronized {
+  def primeObj(obj: Box[Other]): Unit = synchronized {
     _obj = obj
     _calcedObj = true
   }
@@ -194,7 +194,7 @@ with LifecycleCallbacks {
    * sets the field's value from obj if it's set to the default (!defined_?).
    * Overrides LifecycleCallbacks.beforeSave
    */
-  override def beforeSave {
+  override def beforeSave: Unit = {
     if(!defined_?)
       for(o <- obj)
         set(o.primaryKeyField.get)
@@ -212,7 +212,7 @@ with LifecycleCallbacks {
 
 abstract class MappedLongForeignKey[T<:Mapper[T],O<:KeyedMapper[Long, O]](theOwner: T, _foreignMeta: => KeyedMetaMapper[Long, O])
 extends MappedLong[T](theOwner) with MappedForeignKey[Long,T,O] with BaseForeignKey {
-  def defined_? = i_is_! > 0L
+  def defined_? : Boolean = i_is_! > 0L
 
   def foreignMeta = _foreignMeta
 
@@ -255,7 +255,7 @@ extends MappedLong[T](theOwner) with MappedForeignKey[Long,T,O] with BaseForeign
    */
   def dbAddedForeignKey: Box[() => Unit] = Empty
 
-  override def toString = if (defined_?) super.toString else "NULL"
+  override def toString: String = if (defined_?) super.toString else "NULL"
 
   def findFor(key: KeyType): List[OwnerType] = theOwner.getSingleton.findAll(By(this, key))
 
@@ -272,7 +272,7 @@ extends MappedLong[T](theOwner) with MappedForeignKey[Long,T,O] with BaseForeign
 
 abstract class MappedStringForeignKey[T<:Mapper[T],O<:KeyedMapper[String, O]](override val fieldOwner: T, foreign: => KeyedMetaMapper[String, O],override val maxLen: Int)
 extends MappedString[T](fieldOwner, maxLen) with MappedForeignKey[String,T,O] with BaseForeignKey {
-  def defined_? = i_is_! ne null
+  def defined_? : Boolean = i_is_! ne null
 
   type KeyType = String
   type KeyedForeignType = O
@@ -297,7 +297,7 @@ extends MappedString[T](fieldOwner, maxLen) with MappedForeignKey[String,T,O] wi
    */
   def dbAddedForeignKey: Box[() => Unit] = Empty
 
-  override def toString = if (defined_?) super.toString else "NULL"
+  override def toString: String = if (defined_?) super.toString else "NULL"
 
   def set(v: Box[O]): T = {
     val toSet: String = v match {

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedInt.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedInt.scala
@@ -17,7 +17,7 @@
 package net.liftweb
 package mapper
 
-import java.sql.{ResultSet, Types}
+import java.sql.Types
 import java.lang.reflect.Method
 import net.liftweb.common._
 import net.liftweb.util._
@@ -30,7 +30,6 @@ import scala.xml.{Text, NodeSeq}
 import js._
 
 
-
 /**
  * Warning: Do not use unnamed Enumerations with 2.8.1 as this will cause too many items to be displayed in the dropdown.
  *
@@ -40,19 +39,19 @@ abstract class MappedEnum[T<:Mapper[T], ENUM <: Enumeration](val fieldOwner: T, 
   private var data: ENUM#Value = defaultValue
   private var orgData: ENUM#Value = defaultValue
   def defaultValue: ENUM#Value = enum.values.iterator.next
-  def dbFieldClass = classOf[ENUM#Value]
+  def dbFieldClass: Class[ENUM#Value] = classOf[ENUM#Value]
 
   /**
    * Get the JDBC SQL Type for this field
    */
-  def targetSQLType = Types.BIGINT
+  def targetSQLType: Int = Types.BIGINT
 
-  protected def i_is_! = data
-  protected def i_was_! = orgData
+  protected def i_is_! : ENUM#Value = data
+  protected def i_was_! : ENUM#Value = orgData
   /**
      * Called after the field is saved to the database
      */
-  override protected[mapper] def doneWithSave() {
+  override protected[mapper] def doneWithSave(): Unit = {
     orgData = data
   }
 
@@ -141,7 +140,7 @@ abstract class MappedEnum[T<:Mapper[T], ENUM <: Enumeration](val fieldOwner: T, 
 
   protected def i_obscure_!(in : ENUM#Value) = defaultValue
 
-  private def st(in: ENUM#Value) {
+  private def st(in: ENUM#Value): Unit = {
     data = in
     orgData = in
   }
@@ -251,12 +250,12 @@ abstract class MappedInt[T<:Mapper[T]](val fieldOwner: T) extends MappedField[In
   private var orgData: Int = defaultValue
 
   def defaultValue = 0
-  def dbFieldClass = classOf[Int]
+  def dbFieldClass: Class[Int] = classOf[Int]
 
   /**
    * Get the JDBC SQL Type for this field
    */
-  def targetSQLType = Types.INTEGER
+  def targetSQLType: Int = Types.INTEGER
 
   import scala.reflect.runtime.universe._
   def manifest: TypeTag[Int] = typeTag[Int]
@@ -302,12 +301,12 @@ abstract class MappedInt[T<:Mapper[T]](val fieldOwner: T) extends MappedField[In
       def asSeq(v: T): Box[Seq[SourceFieldInfo]] = Empty
     })
 
-  protected def i_is_! = data
-  protected def i_was_! = orgData
+  protected def i_is_! : Int = data
+  protected def i_was_! : Int = orgData
   /**
      * Called after the field is saved to the database
      */
-  override protected[mapper] def doneWithSave() {
+  override protected[mapper] def doneWithSave(): Unit = {
     orgData = data
   }
 
@@ -349,7 +348,7 @@ abstract class MappedInt[T<:Mapper[T]](val fieldOwner: T) extends MappedField[In
 
   protected def i_obscure_!(in : Int) = 0
 
-  private def st(in: Int) {
+  private def st(in: Int): Unit = {
     data = in
     orgData = in
   }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedLong.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedLong.scala
@@ -19,14 +19,16 @@ package mapper
 
 import java.sql.Types
 import java.lang.reflect.Method
-import net.liftweb.util.Helpers._
-import net.liftweb.util._
-import net.liftweb.common._
 import java.util.Date
+
+import common._
+import util.Helpers._
+import util._
+import http.SHtml
+import http.js._
+import json._
+
 import scala.xml.{Text, NodeSeq}
-import net.liftweb.http.{S, SHtml}
-import net.liftweb.http.js._
-import net.liftweb.json._
 
 
 abstract class MappedLongIndex[T<:Mapper[T]](theOwner: T) extends MappedLong[T](theOwner) with IndexedField[Long] {
@@ -80,21 +82,19 @@ abstract class MappedEnumList[T<:Mapper[T], ENUM <: Enumeration](val fieldOwner:
   private var orgData: Seq[ENUM#Value] = defaultValue
 
   def defaultValue: Seq[ENUM#Value] = Nil
-  def dbFieldClass = classOf[Seq[ENUM#Value]]
+  def dbFieldClass: Class[Seq[ENUM#Value]] = classOf[Seq[ENUM#Value]]
 
   /**
    * Get the JDBC SQL Type for this field
    */
-  def targetSQLType = Types.BIGINT
+  def targetSQLType: Int = Types.BIGINT
 
-  protected def i_is_! = data
-  protected def i_was_! = orgData
+  protected def i_is_! : Seq[ENUM#Value] = data
+  protected def i_was_! : Seq[ENUM#Value] = orgData
   /**
    * Called after the field is saved to the database
    */
-  override protected[mapper] def doneWithSave() {
-    orgData = data
-  }
+  override protected[mapper] def doneWithSave(): Unit = orgData = data
 
   /**
    * Get the source field metadata for the field
@@ -183,7 +183,7 @@ abstract class MappedEnumList[T<:Mapper[T], ENUM <: Enumeration](val fieldOwner:
 
   protected def i_obscure_!(in : Seq[ENUM#Value]) = Nil
 
-  private def st(in: Seq[ENUM#Value]) {
+  private def st(in: Seq[ENUM#Value]): Unit = {
     data = in
     orgData = in
   }
@@ -219,7 +219,7 @@ abstract class MappedEnumList[T<:Mapper[T], ENUM <: Enumeration](val fieldOwner:
  * Mix with MappedLong to give a default time of millis
  */
 trait DefaultMillis extends TypedField[Long] {
-  override def defaultValue = millis
+  override def defaultValue: Long = millis
 }
 
 
@@ -228,12 +228,12 @@ abstract class MappedNullableLong[T<:Mapper[T]](val fieldOwner: T) extends Mappe
   private var orgData: Box[Long] = defaultValue
 
   def defaultValue: Box[Long] = Empty
-  def dbFieldClass = classOf[Box[Long]]
+  def dbFieldClass: Class[Box[Long]] = classOf[Box[Long]]
 
   /**
    * Get the JDBC SQL Type for this field
    */
-  def targetSQLType = Types.BIGINT
+  def targetSQLType: Int = Types.BIGINT
 
   import scala.reflect.runtime.universe._
   def manifest: TypeTag[Box[Long]] = typeTag[Box[Long]]
@@ -280,12 +280,12 @@ abstract class MappedNullableLong[T<:Mapper[T]](val fieldOwner: T) extends Mappe
     })
 
 
-  protected def i_is_! = data
-  protected def i_was_! = orgData
+  protected def i_is_! : Box[Long] = data
+  protected def i_was_! : Box[Long] = orgData
   /**
    * Called after the field is saved to the database
    */
-  override protected[mapper] def doneWithSave() {
+  override protected[mapper] def doneWithSave(): Unit = {
     orgData = data
   }
 
@@ -336,7 +336,7 @@ abstract class MappedNullableLong[T<:Mapper[T]](val fieldOwner: T) extends Mappe
 
   protected def i_obscure_!(in: Box[Long]) = defaultValue
 
-  private def st(in: Box[Long]) {
+  private def st(in: Box[Long]): Unit = {
     data = in
     orgData = in
   }
@@ -410,19 +410,19 @@ abstract class MappedLong[T<:Mapper[T]](val fieldOwner: T) extends MappedField[L
     })
 
   def defaultValue: Long = 0L
-  def dbFieldClass = classOf[Long]
+  def dbFieldClass: Class[Long] = classOf[Long]
 
   /**
    * Get the JDBC SQL Type for this field
    */
-  def targetSQLType = Types.BIGINT
+  def targetSQLType: Int = Types.BIGINT
 
-  protected def i_is_! = data
-  protected def i_was_! = orgData
+  protected def i_is_! : Long = data
+  protected def i_was_! : Long = orgData
   /**
    * Called after the field is saved to the database
    */
-  override protected[mapper] def doneWithSave() {
+  override protected[mapper] def doneWithSave(): Unit = {
     orgData = data
   }
 
@@ -468,7 +468,7 @@ abstract class MappedLong[T<:Mapper[T]](val fieldOwner: T) extends MappedField[L
 
   protected def i_obscure_!(in : Long) = defaultValue
 
-  private def st(in: Long) {
+  private def st(in: Long): Unit = {
     data = in
     orgData = in
   }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedPassword.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedPassword.scala
@@ -183,7 +183,7 @@ extends MappedField[String, T] {
   /**
    * Called after the field is saved to the database
    */
-  override protected[mapper] def doneWithSave() {
+  override protected[mapper] def doneWithSave(): Unit = {
   }
 
   protected def i_obscure_!(in : String) : String = in

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedPostalCode.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedPostalCode.scala
@@ -68,17 +68,16 @@ object Countries extends Enumeration(1) {
   def I18NCountry = new I18NCountry
 
   class I18NCountry extends Val {
-    override def toString() =
-    S.?("country_" + id)
+    override def toString(): String = S.?("country_" + id)
   }
 }
 
 abstract class MappedLocale[T <: Mapper[T]](owner: T) extends MappedString[T](owner, 16) {
-  override def defaultValue = Locale.getDefault.toString
+  override def defaultValue: String = Locale.getDefault.toString
 
   def isAsLocale: Locale = Locale.getAvailableLocales.filter(_.toString == get).toList match {
     case Nil => Locale.getDefault
-    case x :: xs => x
+    case x :: _ => x
   }
 
   override def _toForm: Box[Elem] =
@@ -89,7 +88,7 @@ abstract class MappedLocale[T <: Mapper[T]](owner: T) extends MappedString[T](ow
 }
 
 abstract class MappedTimeZone[T <: Mapper[T]](owner: T) extends MappedString[T](owner, 32) {
-  override def defaultValue = TimeZone.getDefault.getID
+  override def defaultValue: String = TimeZone.getDefault.getID
 
   def isAsTimeZone: TimeZone = TimeZone.getTimeZone(get) match {
     case null => TimeZone.getDefault

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedString.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedString.scala
@@ -17,22 +17,18 @@
 package net.liftweb
 package mapper
 
-import java.sql.{ResultSet, Types}
+import java.sql.Types
 import java.lang.reflect.Method
-import util._
-import net.liftweb.common.{Box, Full, Empty, Failure}
 import java.util.Date
-import java.util.regex._
-import scala.xml.{NodeSeq, Text, Elem}
-import net.liftweb.http.{S}
-import net.liftweb.http.js._
-import net.liftweb.json._
+
+import util._
+import common.{Box, Full, Empty, Failure}
+import http.S
+import http.js._
+import json._
 import S._
-import common.Full
-import scala.Some
-import common.Full
-import scala.Some
-import util.SourceFieldMetadataRep
+
+import scala.xml.{NodeSeq, Text, Elem}
 
 /**
  * Just like MappedString, except it's defaultValue is "" and the length is auto-cropped to
@@ -62,7 +58,7 @@ abstract class MappedString[T<:Mapper[T]](val fieldOwner: T,val maxLen: Int) ext
   private val data: FatLazy[String] =  FatLazy(defaultValue) // defaultValue
   private val orgData: FatLazy[String] =  FatLazy(defaultValue) // defaultValue
 
-  def dbFieldClass = classOf[String]
+  def dbFieldClass: Class[String] = classOf[String]
 
   import scala.reflect.runtime.universe._
   def manifest: TypeTag[String] = typeTag[String]
@@ -123,15 +119,15 @@ abstract class MappedString[T<:Mapper[T]](val fieldOwner: T,val maxLen: Int) ext
   /**
    * Get the JDBC SQL Type for this field
    */
-  def targetSQLType = Types.VARCHAR
+  def targetSQLType: Int = Types.VARCHAR
 
   def defaultValue = ""
 
   override def writePermission_? = true
   override def readPermission_? = true
 
-  protected def i_is_! = data.get
-  protected def i_was_! = orgData.get
+  protected def i_is_! : String = data.get
+  protected def i_was_! : String = orgData.get
 
   def asJsonValue: Box[JsonAST.JValue] = Full(get match {
     case null => JsonAST.JNull
@@ -141,7 +137,7 @@ abstract class MappedString[T<:Mapper[T]](val fieldOwner: T,val maxLen: Int) ext
   /**
    * Called after the field is saved to the database
    */
-  override protected[mapper] def doneWithSave() {
+  override protected[mapper] def doneWithSave(): Unit = {
     orgData.setFrom(data)
   }
 
@@ -167,7 +163,7 @@ abstract class MappedString[T<:Mapper[T]](val fieldOwner: T,val maxLen: Int) ext
   override def setFromAny(in: Any): String = {
     in match {
       case JsonAST.JNull => this.set(null) 
-      case seq: Seq[_] if !seq.isEmpty => seq.map(setFromAny).apply(0)
+      case seq: Seq[_] if seq.nonEmpty => seq.map(setFromAny).head
       case (s: String) :: _ => this.set(s)
       case s :: _ => this.setFromAny(s)
       case JsonAST.JString(v) => this.set(v)
@@ -188,7 +184,7 @@ abstract class MappedString[T<:Mapper[T]](val fieldOwner: T,val maxLen: Int) ext
 
   def real_convertToJDBCFriendly(value: String): Object = value
 
-  private def wholeSet(in: String) {
+  private def wholeSet(in: String): Unit = {
     this.data() = in
     this.orgData() = in
   }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedTextarea.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedTextarea.scala
@@ -17,11 +17,10 @@
 package net.liftweb
 package mapper
 
-import scala.xml.{NodeSeq, Elem}
-import net.liftweb.http.S
-import net.liftweb.http.S._
-import net.liftweb.util._
-import net.liftweb.common._
+import http.S
+import common._
+
+import scala.xml.Elem
 
 abstract class MappedTextarea[T<:Mapper[T]](owner : T, maxLen: Int) extends MappedString[T](owner, maxLen) {
   /**
@@ -37,7 +36,7 @@ abstract class MappedTextarea[T<:Mapper[T]](owner : T, maxLen: Int) extends Mapp
 	     case s => s}}</textarea>))}
   }
 
-  override def toString = {
+  override def toString: String = {
     val v = get
     if (v == null || v.length < 100) super.toString
     else v.substring(0,40)+" ... "+v.substring(v.length - 40)

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedTime.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedTime.scala
@@ -17,16 +17,14 @@
 package net.liftweb
 package mapper
 
-import java.sql.{ResultSet, Types}
+import java.sql.Types
 import java.util.Date
 import java.lang.reflect.Method
 
-import net.liftweb._
 import util._
 import common._
 import Helpers._
 import http._
-import S._
 import js._
 import json._
 
@@ -136,7 +134,7 @@ abstract class MappedTime[T<:Mapper[T]](val fieldOwner: T) extends MappedField[D
 
   protected def i_is_! = data.get
   protected def i_was_! = orgData.get
-  protected[mapper] def doneWithSave() {orgData.setFrom(data)}
+  protected[mapper] def doneWithSave(): Unit = {orgData.setFrom(data)}
 
   protected def i_obscure_!(in : Date) : Date = {
     new Date(0L)

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedUniqueId.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/MappedUniqueId.scala
@@ -17,12 +17,12 @@
 package net.liftweb
 package mapper
 
-import net.liftweb.common._
-import net.liftweb.util._
+import common._
+import util._
 import Helpers._
-import net.liftweb.http.{S, SHtml}
+import http.{S, SHtml}
+
 import scala.xml.NodeSeq
-import net.liftweb.http.js._
 
 abstract class MappedUniqueId[T<:Mapper[T]](override val fieldOwner: T, override val maxLen: Int) extends MappedString[T](fieldOwner, maxLen) {
   override def writePermission_? = false

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/Mapper.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/Mapper.scala
@@ -17,15 +17,15 @@
 package net.liftweb
 package mapper
 
+import java.util.Date
+
 import scala.xml.{Elem, NodeSeq}
-import net.liftweb.http.S
-import net.liftweb.http.js._
+import http.S
+import http.js._
 import util._
-import net.liftweb.common.{Box, Empty, Full, ParamFailure}
+import common.{Box, Empty, Full, ParamFailure}
+
 import collection.mutable.StringBuilder
-import net.liftweb.util
-import common.Full
-import common.Full
 
 trait BaseMapper extends FieldContainer {
   type MapperType <: Mapper[MapperType]
@@ -85,7 +85,7 @@ trait Mapper[A<:Mapper[A]] extends BaseMapper with Serializable with SourceInfo 
     this
   }
 
-  def save(): Boolean = {
+  def save: Boolean = {
     runSafe {
       getSingleton.save(this)
     }
@@ -161,7 +161,7 @@ trait Mapper[A<:Mapper[A]] extends BaseMapper with Serializable with SourceInfo 
   def formFields: List[MappedField[_, A]] =
   getSingleton.formFields(this)
 
-   def allFields: scala.collection.Seq[BaseField] = formFields
+  def allFields: Seq[BaseField] = formFields
 
   /**
    * map the fields titles and forms to generate a list
@@ -176,7 +176,7 @@ trait Mapper[A<:Mapper[A]] extends BaseMapper with Serializable with SourceInfo 
    * @param func called with displayHtml, fieldId, form
    */
   def flatMapFieldTitleForm[T]
-  (func: (NodeSeq, Box[NodeSeq], NodeSeq) => scala.collection.Seq[T]): List[T] =
+  (func: (NodeSeq, Box[NodeSeq], NodeSeq) => Seq[T]): List[T] =
   getSingleton.flatMapFieldTitleForm(this, func)
 
     /**
@@ -184,7 +184,7 @@ trait Mapper[A<:Mapper[A]] extends BaseMapper with Serializable with SourceInfo 
    * @param func called with displayHtml, fieldId, form
    */
   def flatMapFieldTitleForm2[T]
-  (func: (NodeSeq, MappedField[_, A], NodeSeq) => scala.collection.Seq[T]): List[T] =
+  (func: (NodeSeq, MappedField[_, A], NodeSeq) => Seq[T]): List[T] =
   getSingleton.flatMapFieldTitleForm2(this, func)
 
   /**
@@ -225,7 +225,7 @@ trait Mapper[A<:Mapper[A]] extends BaseMapper with Serializable with SourceInfo 
 
   def toForm(button: Box[String], redoSnippet: NodeSeq => NodeSeq, onSuccess: A => Unit): NodeSeq = {
     val snipName = S.currentSnippet
-    def doSubmit() {
+    def doSubmit(): Unit = {
       this.validate match {
         case Nil => onSuccess(this)
         case xs => S.error(xs)
@@ -247,25 +247,18 @@ trait Mapper[A<:Mapper[A]] extends BaseMapper with Serializable with SourceInfo 
 
   def dirty_? : Boolean = getSingleton.dirty_?(this)
 
-  override def toString = {
-    val ret = new StringBuilder
-
-    ret.append(this.getClass.getName)
-
-    ret.append("={")
-
-    ret.append(getSingleton.appendFieldToStrings(this))
-
-    ret.append("}")
-
-    ret.toString
-  }
+  override def toString: String =
+    new StringBuilder(this.getClass.getName)
+      .append("={")
+      .append(getSingleton.appendFieldToStrings(this))
+      .append("}")
+      .toString
 
   def toXml: Elem = {
     getSingleton.toXml(this)
   }
 
-  def checkNames {
+  def checkNames(): Unit = {
     runSafe {
       getSingleton match {
         case null =>
@@ -304,11 +297,11 @@ trait Mapper[A<:Mapper[A]] extends BaseMapper with Serializable with SourceInfo 
    */
   def fieldTransforms = fieldTransforms_i
 
-  def appendFieldTransform(transform: CssSel) {
+  def appendFieldTransform(transform: CssSel): Unit = {
     fieldTransforms_i = fieldTransforms_i :+ transform
   }
 
-  def prependFieldTransform(transform: CssSel) {
+  def prependFieldTransform(transform: CssSel): Unit = {
     fieldTransforms_i = transform +: fieldTransforms_i
   }
 
@@ -405,9 +398,9 @@ trait UpdatedTrait {
   lazy val updatedAt: MyUpdatedAt = new MyUpdatedAt(this)
 
   protected class MyUpdatedAt(obj: self.type) extends MappedDateTime(obj.asInstanceOf[MapperType]) with LifecycleCallbacks {
-    override def beforeSave() {super.beforeSave; this.set(Helpers.now)}
-    override def defaultValue = Helpers.now
-       override def dbIndexed_? = updatedAtIndexed_?
+    override def beforeSave: Unit = {super.beforeSave; this.set(Helpers.now)}
+    override def defaultValue: Date = Helpers.now
+    override def dbIndexed_? : Boolean = updatedAtIndexed_?
   }
 
 }
@@ -429,7 +422,7 @@ trait KeyedMapper[KeyType, OwnerType<:KeyedMapper[KeyType, OwnerType]] extends M
   def primaryKeyField: MappedField[KeyType, OwnerType] with IndexedField[KeyType]
   def getSingleton: KeyedMetaMapper[KeyType, OwnerType];
 
-  override def comparePrimaryKeys(other: OwnerType) = primaryKeyField.get == other.primaryKeyField.get
+  override def comparePrimaryKeys(other: OwnerType): Boolean = primaryKeyField.get == other.primaryKeyField.get
 
   def reload: OwnerType = getSingleton.find(By(primaryKeyField, primaryKeyField.get)) openOr this
 

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoExtendedSession.scala
@@ -17,16 +17,14 @@
 package net.liftweb
 package mapper
 
-import net.liftweb._
-import net.liftweb.http.provider._
+import http.provider._
 import common._
 import util._
 import http._
 import Helpers._
 
 
-trait ProtoExtendedSession[T <: ProtoExtendedSession[T]] extends
-KeyedMapper[Long, T] {
+trait ProtoExtendedSession[T <: ProtoExtendedSession[T]] extends KeyedMapper[Long, T] {
   self: T =>
 
   override def primaryKeyField: MappedLongIndex[T] = id
@@ -95,16 +93,16 @@ KeyedMetaMapper[Long, T] with ProtoSessionCookiePath {
 
   def recoverUserId: Box[String]
 
-  def userDidLogin(uid: UserType) {
+  def userDidLogin(uid: UserType): Unit = {
     userDidLogout(Full(uid))
-    val inst = create.userId(uid.userIdAsString).saveMe
+    val inst = create.userId(uid.userIdAsString).saveMe()
     val cookie = HTTPCookie(CookieName, inst.cookieId.get).
     setMaxAge(((inst.expiration.get - millis) / 1000L).toInt).
     setPath(sessionCookiePath)
     S.addCookie(cookie)
   }
 
-  def userDidLogout(uid: Box[UserType]) {
+  def userDidLogout(uid: Box[UserType]): Unit = {
     for (cook <- S.findCookie(CookieName)) {
       S.deleteCookie(cook)
       find(By(cookieId, cook.value openOr "")).foreach(_.delete_!)

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoTag.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoTag.scala
@@ -35,7 +35,7 @@ trait MetaProtoTag[ModelType <: ProtoTag[ModelType]] extends KeyedMetaMapper[Lon
     else {
       find(By(name, tag)) match {
         case Full(t) => tagCache(tag) = t; t
-        case _ => val ret: ModelType = (createInstance).name(tag).saveMe
+        case _ => val ret: ModelType = createInstance.name(tag).saveMe
           tagCache(tag) = ret
           ret
       }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoUser.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/ProtoUser.scala
@@ -17,19 +17,12 @@
 package net.liftweb
 package mapper
 
-import net.liftweb.http._
-import js._
-import JsCmds._
-import scala.xml.{NodeSeq, Node, Text, Elem}
-import scala.xml.transform._
-import net.liftweb.sitemap._
-import net.liftweb.sitemap.Loc._
-import net.liftweb.util.Helpers._
-import net.liftweb.util._
-import net.liftweb.common._
-import net.liftweb.util.Mailer._
-import S._
-import net.liftweb.proto.{ProtoUser => GenProtoUser}
+import http._
+import util._
+import common._
+import proto.{ProtoUser => GenProtoUser}
+
+import scala.xml.{NodeSeq, Text}
 
 /**
  * ProtoUser is a base class that gives you a "User" that has a first name,

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/package.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/package.scala
@@ -15,6 +15,7 @@
  */
 
 package net.liftweb
+
 package object mapper {
   type SuperConnection = db.SuperConnection
   type ConnectionIdentifier = util.ConnectionIdentifier
@@ -23,7 +24,7 @@ package object mapper {
   type DBLogEntry = db.DBLogEntry
   type StandardDBVendor = db.StandardDBVendor
 
-  def DBLogEntry = db.DBLogEntry
-  def DefaultConnectionIdentifier = util.DefaultConnectionIdentifier
-  def DriverType = db.DriverType
+  def DBLogEntry: db.DBLogEntry.type = db.DBLogEntry
+  def DefaultConnectionIdentifier: util.DefaultConnectionIdentifier.type = util.DefaultConnectionIdentifier
+  def DriverType: db.DriverType.type = db.DriverType
 }

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/view/Paginator.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/view/Paginator.scala
@@ -17,14 +17,7 @@ package net.liftweb
 package mapper
 package view
 
-import scala.xml.{NodeSeq, Text, Elem}
-import net.liftweb.common.Loggable
-import net.liftweb.http.{S,DispatchSnippet,Paginator,PaginatorSnippet,
-  SortedPaginator,SortedPaginatorSnippet}
-import net.liftweb.http.S.?
-import net.liftweb.util.Helpers._
-import net.liftweb.mapper.{Mapper, MetaMapper, MappedField,
-         QueryParam, OrderBy, StartAt, MaxRows, Ascending, Descending}
+import net.liftweb.http.{ Paginator, PaginatorSnippet, SortedPaginator, SortedPaginatorSnippet }
 
 /**
  * Helper for when using paginators with a ModelSnippet.
@@ -52,8 +45,8 @@ class MapperPaginator[T <: Mapper[T]](val meta: MetaMapper[T]) extends Paginator
    */
   var constantParams: Seq[QueryParam[T]] = Nil
 
-  def count = meta.count(constantParams: _*)
-  def page = meta.findAll(constantParams ++ Seq[QueryParam[T]](MaxRows(itemsPerPage), StartAt(first)): _*)
+  def count: Long = meta.count(constantParams: _*)
+  def page: Seq[T] = meta.findAll(constantParams ++ Seq[QueryParam[T]](MaxRows(itemsPerPage), StartAt(first)): _*)
 }
 
 /**
@@ -77,7 +70,7 @@ class SortedMapperPaginator[T <: Mapper[T]](meta: MetaMapper[T],
     val headers = _headers.toList
     sort = (headers.indexWhere{case (_,`initialSort`)=>true; case _ => false}, true)
 
-    override def page = meta.findAll(constantParams ++ Seq[QueryParam[T]](mapperSort, MaxRows(itemsPerPage), StartAt(first)): _*)
+    override def page: Seq[T] = meta.findAll(constantParams ++ Seq[QueryParam[T]](mapperSort, MaxRows(itemsPerPage), StartAt(first)): _*)
     private def mapperSort = sort match {
       case (fieldIndex, ascending) =>
         OrderBy(

--- a/persistence/mapper/src/main/scala/net/liftweb/mapper/view/Util.scala
+++ b/persistence/mapper/src/main/scala/net/liftweb/mapper/view/Util.scala
@@ -18,17 +18,11 @@ package net.liftweb
 package mapper 
 package view 
 
-import net.liftweb.mapper.{Mapper,
-                           MappedField
-}
+import common.Full
+import util._
+import Helpers._
 
-import net.liftweb.common.{Full, Box}
-import net.liftweb.util._
-  import Helpers._
-
-
-import scala.xml.{NodeSeq, Elem}
-
+import scala.xml.NodeSeq
 
 /**
  * Provides a number of methods that make complex Mapper-based view snippets
@@ -90,7 +84,7 @@ object Util {
       val bind: Seq[CssSel] =
         if (fieldsAttribute.nonEmpty) {
           for {
-            fieldName <- fieldsAttribute.text.split("\\s+")
+            fieldName <- fieldsAttribute.text.split("\\s+").toIndexedSeq
             // the following hackery is brought to you by the Scala compiler not
             // properly typing MapperField[_, T] in the context of the for
             // comprehension
@@ -108,11 +102,11 @@ object Util {
       bind.map(_(ns))
     }
   }
+
   def eachField[T<:net.liftweb.mapper.Mapper[T]](
     mapper: T,
-    fn:MappedField[_,T]=>CssSel
-  ): NodeSeq=>NodeSeq = eachField(mapper, fn, (f:MappedField[_,T])=>true)
+    fn: MappedField[_,T] => CssSel
+  ): NodeSeq => NodeSeq = eachField(mapper, fn, (_: MappedField[_,T]) => true)
 
-  
 }
 

--- a/persistence/mapper/src/test/scala/bootstrap/liftweb/Boot.scala
+++ b/persistence/mapper/src/test/scala/bootstrap/liftweb/Boot.scala
@@ -16,19 +16,15 @@
 
 package bootstrap.liftweb
 
-import net.liftweb.util._
-import net.liftweb.common._
 import net.liftweb.http._
 import net.liftweb.sitemap._
-import net.liftweb.sitemap.Loc._
-import Helpers._
 
 /**
   * A class that's instantiated early and run.  It allows the application
   * to modify lift's environment
   */
 class Boot {
-  def boot {
+  def boot(): Unit = {
     // where to search snippet
     LiftRules.addToPackages("net.liftweb.webapptest")
 

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/DBProviders.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/DBProviders.scala
@@ -36,27 +36,17 @@ object DbProviders {
   trait Provider {
     def name: String
     def setupDB: Unit
-    def required_? = Props.getBool(propsPrefix+"required", false)
+    def required_? : Boolean = Props.getBool(propsPrefix+"required", false)
     def propName: String
-    lazy val propsPrefix = "mapper.test."+propName+"."
+    lazy val propsPrefix: String = "mapper.test."+propName+"."
   }
 
   trait FileDbSetup {
     def filePath : String
     def vendor : Vendor
 
-    def setupDB {
+    def setupDB: Unit = {
       val f = new File(filePath)
-
-      def deleteIt(file: File) {
-        if (file.exists) {
-          if (file.isDirectory) file.listFiles.foreach{f => deleteIt(f)}
-          file.delete
-        }
-      }
-
-      // deleteIt(f)
-
       DB.defineConnectionManager(DefaultConnectionIdentifier, vendor)
       DB.defineConnectionManager(SnakeConnectionIdentifier, vendor)
     }
@@ -65,11 +55,11 @@ object DbProviders {
   trait DbSetup {
     def vendor : Vendor
 
-    def setupDB {
+    def setupDB: Unit = {
       DB.defineConnectionManager(DefaultConnectionIdentifier, vendor)
       DB.defineConnectionManager(SnakeConnectionIdentifier, vendor)
 
-      def deleteAllTables {
+      def deleteAllTables: Unit = {
         DB.use(DefaultConnectionIdentifier) {
           conn =>
           val md = conn.getMetaData
@@ -92,7 +82,7 @@ object DbProviders {
       Full(mkConn)
     }
 
-    def releaseConnection(conn: Connection) {
+    def releaseConnection(conn: Connection): Unit = {
       try {
         conn.close
       } catch {

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/DbSpec.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/DbSpec.scala
@@ -33,7 +33,7 @@ class DbSpec extends Specification  {
   val provider = DbProviders.H2MemoryProvider
   val logF = Schemifier.infoF _
   
-  def cleanup() {
+  def cleanup(): Unit = {
     provider.setupDB
     Schemifier.destroyTables_!!(DefaultConnectionIdentifier, logF ,  User)
     Schemifier.schemify(true, logF, DefaultConnectionIdentifier, User)

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/ItemsListSpec.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/ItemsListSpec.scala
@@ -19,10 +19,7 @@ package mapper
 
 import org.specs2.mutable.Specification
 
-import common._
-import json._
 import util._
-import Helpers._
 import view._
 
 

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/ManyToManySpecs.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/ManyToManySpecs.scala
@@ -29,13 +29,13 @@ class ManyToManySpec extends Specification  {
   val provider = DbProviders.H2MemoryProvider
 
   private def ignoreLogger(f: => AnyRef): Unit = ()
-  def setupDB {
+  def setupDB: Unit = {
     MapperRules.createForeignKeys_? = c => false
     provider.setupDB
     Schemifier.destroyTables_!!(ignoreLogger _,  PersonCompany, Company, Person)
     Schemifier.schemify(true, ignoreLogger _, Person, Company, PersonCompany)
   }
-  def createPerson = {
+  def createPerson: Person = {
     val person = new Person
     person.save
     val companies = (1 to 10).toList map { i =>

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/MappedBooleanSpec.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/MappedBooleanSpec.scala
@@ -32,7 +32,7 @@ class MappedBooleanSpec extends Specification  {
   val provider = DbProviders.H2MemoryProvider
   
   private def ignoreLogger(f: => AnyRef): Unit = ()
-  def setupDB {
+  def setupDB: Unit = {
     provider.setupDB
     Schemifier.destroyTables_!!(ignoreLogger _,  Dog2, User)
     Schemifier.schemify(true, ignoreLogger _, Dog2, User)

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/MappedDecimalSpec.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/MappedDecimalSpec.scala
@@ -32,7 +32,7 @@ class MappedDecimalSpec extends Specification  {
   val provider = DbProviders.H2MemoryProvider
 
   private def ignoreLogger(f: => AnyRef): Unit = ()
-  def setupDB {
+  def setupDB: Unit = {
     provider.setupDB
     Schemifier.destroyTables_!!(ignoreLogger _,  Dog, User)
     Schemifier.schemify(true, ignoreLogger _, Dog, User)

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/MappedEnumSpec.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/MappedEnumSpec.scala
@@ -19,8 +19,6 @@ package mapper
 
 import org.specs2.mutable.Specification
 
-import common._
-
 object MyEnum extends Enumeration {
   val a = Value
   val b = Value

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/MappedLongForeignKeySpec.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/MappedLongForeignKeySpec.scala
@@ -20,7 +20,6 @@ package mapper
 import org.specs2.mutable.Specification
 
 import common._
-import util._
 
 
 /**
@@ -35,7 +34,7 @@ class MappedLongForeignKeySpec extends Specification with org.specs2.specificati
 
   def provider = DbProviders.H2MemoryProvider
 
-  def before = MapperSpecsModel.cleanup()
+  def before: Unit = MapperSpecsModel.cleanup()
 
   "MappedLongForeignKey" should {
       (try {

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/MapperSpecsModel.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/MapperSpecsModel.scala
@@ -58,7 +58,7 @@ object MapperSpecsModel {
 
   MapperRules.displayNameCalculator.default.set(displayNameCalculator _)
 
-  def setup() {
+  def setup(): Unit = {
     // For now, do nothing. Just force this object to load
   }
 
@@ -66,7 +66,7 @@ object MapperSpecsModel {
 
   private def ignoreLogger(f: => AnyRef): Unit = ()
 
-  def cleanup() {
+  def cleanup(): Unit = {
     // Snake connection doesn't create FK constraints (put this here to be absolutely sure it gets set before Schemify)
     MapperRules.createForeignKeys_? = c => {
       c.jndiName != "snake"
@@ -81,9 +81,9 @@ object MapperSpecsModel {
 
 
 object SampleTag extends SampleTag with LongKeyedMetaMapper[SampleTag] {
-  override def dbAddTable = Full(populate _)
+  override def dbAddTable = Full(populate)
 
-  private def populate {
+  private def populate(): Unit = {
     val samp = SampleModel.findAll()
     val tags = List("Hello", "Moose", "Frog", "WooHoo", "Sloth",
                     "Meow", "Moof")
@@ -111,13 +111,13 @@ object SampleStatus extends Enumeration {
 }
 
 object SampleModel extends SampleModel with KeyedMetaMapper[Long, SampleModel] {
-  override def dbAddTable = Full(populate _)
+  override def dbAddTable = Full(populate)
 
   def encodeAsJson(in: SampleModel): JsonAST.JObject = encodeAsJSON_!(in)
 
   def buildFromJson(json: JsonAST.JObject): SampleModel = decodeFromJSON_!(json, false)
 
-  private def populate {
+  private def populate(): Unit = {
     create.firstName("Elwood").save
     create.firstName("Madeline").save
     create.firstName("Archer").status(SampleStatus.Disabled).save
@@ -148,9 +148,9 @@ class SampleModel extends KeyedMapper[Long, SampleModel] {
 
 
 object SampleTagSnake extends SampleTagSnake with LongKeyedMetaMapper[SampleTagSnake] {
-  override def dbAddTable = Full(populate _)
+  override def dbAddTable = Full(populate)
 
-  private def populate {
+  private def populate(): Unit = {
     val samp = SampleModelSnake.findAll()
     val tags = List("Hello", "Moose", "Frog", "WooHoo", "Sloth",
                     "Meow", "Moof")
@@ -179,13 +179,13 @@ class SampleTagSnake extends LongKeyedMapper[SampleTagSnake] with IdPK {
 
 
 object SampleModelSnake extends SampleModelSnake with KeyedMetaMapper[Long, SampleModelSnake] {
-  override def dbAddTable = Full(populate _)
+  override def dbAddTable = Full(populate)
 
   def encodeAsJson(in: SampleModelSnake): JsonAST.JObject = encodeAsJSON_!(in)
 
   def buildFromJson(json: JsonAST.JObject): SampleModelSnake = decodeFromJSON_!(json, false)
 
-  private def populate {
+  private def populate(): Unit = {
     create.firstName("Elwood").save
     create.firstName("Madeline").save
     create.firstName("Archer").save
@@ -220,9 +220,9 @@ class SampleModelSnake extends KeyedMapper[Long, SampleModelSnake] {
  * The singleton that has methods for accessing the database
  */
 object User extends User with MetaMegaProtoUser[User] {
-  override def dbAddTable = Full(populate _)
+  override def dbAddTable = Full(populate)
 
-  private def populate {
+  private def populate(): Unit = {
     create.firstName("Elwood").save
     create.firstName("Madeline").save
     create.firstName("Archer").save
@@ -277,9 +277,9 @@ class Dog extends LongKeyedMapper[Dog] with IdPK {
 
 
 object Dog extends Dog with LongKeyedMetaMapper[Dog] {
-  override def dbAddTable = Full(populate _)
+  override def dbAddTable = Full(populate)
 
-  private def populate {
+  private def populate(): Unit = {
     create.name("Elwood").save
     create.name("Madeline").save
     create.name("Archer").save
@@ -306,10 +306,10 @@ class Mixer extends LongKeyedMapper[Mixer] with IdPK {
 
 
 object Mixer extends Mixer with LongKeyedMetaMapper[Mixer] {
-  override def dbAddTable = Full(populate _)
+  override def dbAddTable = Full(populate)
   override def dbTableName = "MIXME_UP"
 
-  private def populate {
+  private def populate(): Unit = {
     create.name("Elwood").weight(33).save
     create.name("Madeline").weight(44).save
     create.name("Archer").weight(105).save
@@ -321,7 +321,7 @@ object Thing extends Thing with KeyedMetaMapper[String, Thing] {
 
   import java.util.UUID
   override def beforeCreate = List((thing: Thing) => {
-    thing.thing_id(UUID.randomUUID().toString())
+    thing.thing_id(UUID.randomUUID().toString)
   })
 }
 
@@ -401,9 +401,9 @@ class Dog2 extends LongKeyedMapper[Dog2] with CreatedUpdated {
 
 object Dog2 extends Dog2 with LongKeyedMetaMapper[Dog2] {
   override def dbTableName = "DOG2"
-  override def dbAddTable = Full(populate _)
+  override def dbAddTable = Full(populate)
 
-  private def populate {
+  private def populate(): Unit = {
     create.name("Elwood").actualAge(66).save
     create.name("Madeline").save
     create.name("Archer").save

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/OneToManySpecs.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/OneToManySpecs.scala
@@ -26,7 +26,7 @@ class OneToManySpecs extends Specification  {
   val provider = DbProviders.H2MemoryProvider
 
   private def ignoreLogger(f: => AnyRef): Unit = ()
-  def setupDB {
+  def setupDB: Unit = {
     MapperRules.createForeignKeys_? = c => false
     provider.setupDB
     Schemifier.destroyTables_!!(ignoreLogger _,  Contact, Phone)

--- a/persistence/mapper/src/test/scala/net/liftweb/mapper/SchemifierSpec.scala
+++ b/persistence/mapper/src/test/scala/net/liftweb/mapper/SchemifierSpec.scala
@@ -19,8 +19,6 @@ package mapper
 
 import org.specs2.mutable.Specification
 
-import common._
-
 
 /**
  * Systems under specification for Schemifier.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,7 +43,7 @@ object Dependencies {
   lazy val squeryl                = "org.squeryl"               %% "squeryl"            % "0.9.5-7"
   lazy val slf4j_api              = "org.slf4j"                  % "slf4j-api"          % slf4jVersion
   lazy val scala_xml              = "org.scala-lang.modules"     %% "scala-xml"         % "1.2.0"
-  lazy val scala_parallel_collections =  "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0"
+  lazy val scala_parallel_collections = "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0"
   lazy val rhino                  = "org.mozilla"                % "rhino"              % "1.7.10"
   lazy val scala_parser           = "org.scala-lang.modules"     %% "scala-parser-combinators" % "1.1.2"
   lazy val xerces                 = "xerces" % "xercesImpl" % "2.11.0"
@@ -55,40 +55,36 @@ object Dependencies {
 
   // Provided scope:
   // Scope provided by container, available only in compile and test classpath, non-transitive by default.
-  lazy val logback         = "ch.qos.logback"    % "logback-classic"       % "1.2.3"        % "provided"
-  lazy val log4j           = "log4j"             % "log4j"                 % "1.2.17"       % "provided"
-  lazy val slf4j_log4j12   = "org.slf4j"         % "slf4j-log4j12"         % slf4jVersion   % "provided"
-  lazy val persistence_api = "javax.persistence" % "persistence-api"       % "1.0.2"        % "provided"
-  lazy val servlet_api     = "javax.servlet"     % "javax.servlet-api"     % "3.1.0"        % "provided"
-  lazy val jquery          = "org.webjars.bower" % "jquery"                % "1.11.3"       % "provided"
-  lazy val jasmineCore     = "org.webjars.bower" % "jasmine-core"          % "2.4.1"        % "provided"
-  lazy val jasmineAjax     = "org.webjars.bower" % "jasmine-ajax"          % "3.2.0"        % "provided"
+  lazy val logback         = "ch.qos.logback"    % "logback-classic"       % "1.2.3"        % Provided
+  lazy val log4j           = "log4j"             % "log4j"                 % "1.2.17"       % Provided
+  lazy val slf4j_log4j12   = "org.slf4j"         % "slf4j-log4j12"         % slf4jVersion   % Provided
+  lazy val persistence_api = "javax.persistence" % "persistence-api"       % "1.0.2"        % Provided
+  lazy val servlet_api     = "javax.servlet"     % "javax.servlet-api"     % "3.1.0"        % Provided
+  lazy val jquery          = "org.webjars.bower" % "jquery"                % "1.11.3"       % Provided
+  lazy val jasmineCore     = "org.webjars.bower" % "jasmine-core"          % "2.4.1"        % Provided
+  lazy val jasmineAjax     = "org.webjars.bower" % "jasmine-ajax"          % "3.2.0"        % Provided
 
 
+  // Test scope:
+  // Scope available only in test classpath, non-transitive by default.
+  lazy val jetty6     = "org.mortbay.jetty"        % "jetty"                    % "6.1.26"   % Test
+  lazy val jwebunit   = "net.sourceforge.jwebunit" % "jwebunit-htmlunit-plugin" % "2.5"      % Test
+  lazy val derby      = "org.apache.derby"         % "derby"                    % "10.7.1.1" % Test
+  lazy val h2database = "com.h2database"           % "h2"                       % "1.2.147"  % Test
 
-  // Runtime scope:
-  // Scope provided in runtime, available only in runtime and test classpath, not compile classpath, non-transitive by default.
-  lazy val derby      = "org.apache.derby" % "derby" % "10.7.1.1" % "test" //% "optional"
-  lazy val h2database = "com.h2database"   % "h2"    % "1.2.147"  % "test" //% "optional"
+  lazy val specs2      = "org.specs2"        %% "specs2-core"          % "4.9.4"         % Test
+  lazy val scalacheck  = "org.specs2"        %% "specs2-scalacheck"    % specs2.revision % Test
+  lazy val specs2Prov  = "org.specs2"        %% "specs2-core"          % specs2.revision % Provided
+  lazy val specs2Matchers = "org.specs2"     %% "specs2-matcher-extra" % specs2.revision % Test
+  lazy val specs2MatchersProv = "org.specs2" %% "specs2-matcher-extra" % specs2.revision % Provided
+  lazy val specs2Mock  = "org.specs2"        %% "specs2-mock"          % specs2.revision % Test
+
+  lazy val scalactic       = "org.scalactic"     %% "scalactic"  % "3.1.2"   % Test
+  lazy val scalatest       = "org.scalatest"     %% "scalatest"  % "3.1.2"   % Test
+  lazy val scalatest_junit = "org.scalatestplus" %% "junit-4-12" % "3.1.2.0" % Test
+  lazy val mockito_scalatest = "org.mockito" %% "mockito-scala-scalatest" % "1.14.3" % Test
 
   // Aliases
   lazy val h2 = h2database
 
-  // Test scope:
-  // Scope available only in test classpath, non-transitive by default.
-  // TODO: See if something alternative with lesser footprint can be used instead of mega heavy apacheds
-  lazy val apacheds    = "org.apache.directory.server" % "apacheds-server-integ"    % "1.5.5"  % "test" // TODO: 1.5.7
-  lazy val jetty6      = "org.mortbay.jetty"           % "jetty"                    % "6.1.26" % "test"
-  lazy val jwebunit    = "net.sourceforge.jwebunit"    % "jwebunit-htmlunit-plugin" % "2.5"    % "test"
-  lazy val mockito_all = "org.mockito"                 % "mockito-all"              % "1.9.0"  % "test"
-
-  lazy val specs2      = "org.specs2"        %% "specs2-core"          % "4.7.0"         % "test"
-  lazy val scalacheck  = "org.specs2"        %% "specs2-scalacheck"    % specs2.revision % "test"
-  lazy val specs2Prov  = "org.specs2"        %% "specs2-core"          % specs2.revision % "provided"
-  lazy val specs2Matchers = "org.specs2"     %% "specs2-matcher-extra" % specs2.revision % "test"
-  lazy val specs2MatchersProv = "org.specs2" %% "specs2-matcher-extra" % specs2.revision % "provided"
-  lazy val specs2Mock  = "org.specs2"        %% "specs2-mock"          % specs2.revision % "test"
-
-  lazy val scalatest   = "org.scalatest" %% "scalatest" % "3.0.8" % "test"
-  lazy val junit       = "junit"         % "junit"      % "4.8.2" % "test"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.3.12

--- a/web/webkit/src/main/scala/net/liftweb/http/Paginator.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Paginator.scala
@@ -42,7 +42,7 @@ trait Paginator[T] extends Loggable {
   /**
    * The record number this page starts at. Zero-based.
    */
-  def first = 0L
+  def first: Long = 0L
   /**
    * The items displayed on the current page
    */
@@ -84,21 +84,20 @@ trait SortedPaginator[T, C] extends Paginator[T] {
    * Pair of (column index, ascending)
    */
   type SortState = (Int, Boolean)
-    /**
-     * The sort headers: pairs of column labels, and column identifier objects of type C.
-     */
-    def headers: List[(String, C)]
+  /**
+   * The sort headers: pairs of column labels, and column identifier objects of type C.
+   */
+  def headers: List[(String, C)]
 
-  protected var _sort = (0, true)
-    /**
-     * Get the current sort state: Pair of (column index, ascending?)
-     */
-    def sort: SortState = _sort
+  protected var _sort: SortState = (0, true)
+  /**
+   * Get the current sort state: Pair of (column index, ascending?)
+   */
+  def sort: SortState = _sort
   /**
    * Set the current sort state: Pair of (column index, ascending?)
    */
-  def sort_=(s: SortState) = _sort = s
-
+  def sort_=(s: SortState): Unit = _sort = s
   /**
    * Returns a new SortState based on a column index.
    * If the paginator is already sorted by that column, it
@@ -111,8 +110,8 @@ trait SortedPaginator[T, C] extends Paginator[T] {
   def sortedBy(column: Int): SortState = sort match {
     case (`column`, true) =>  // descending is only if it was already sorted ascending
       (column, false)
-      case _ =>
-        (column, true)
+    case _ =>
+      (column, true)
   }
 }
 
@@ -174,11 +173,11 @@ trait PaginatorSnippet[T] extends Paginator[T] {
   /**
    * Overrides the super's implementation so the first record can be overridden by a URL query parameter.
    */
-  override def first = S.param(offsetParam).map(toLong) openOr _first max 0
+  override def first: Long = S.param(offsetParam).map(toLong) openOr _first max 0
   /**
    * Sets the default starting record of the page (URL query parameters take precedence over this)
    */
-  def first_=(f: Long) = _first = f max 0 min (count-1)
+  def first_=(f: Long): Unit = _first = f max 0 min (count-1)
   /**
    * Returns a URL used to link to a page starting at the given record offset.
    */
@@ -271,18 +270,18 @@ trait SortedPaginatorSnippet[T, C] extends SortedPaginator[T, C] with PaginatorS
   /**
    * Calculates the page url taking sorting into account.
    */
-  def sortedPageUrl(offset: Long, sort: (Int, Boolean)) = sort match {
-    case (col, ascending) =>
-      appendParams(super.pageUrl(offset), List(sortParam->col.toString, ascendingParam->ascending.toString))
+  def sortedPageUrl(offset: Long, sort: (Int, Boolean)): String = {
+    val (col, ascending) = sort
+    appendParams(super.pageUrl(offset), List(sortParam -> col.toString, ascendingParam -> ascending.toString))
   }
   /**
    * Overrides pageUrl and delegates to sortedPageUrl using the current sort
    */
-  override def pageUrl(offset: Long) = sortedPageUrl(offset, sort)
+  override def pageUrl(offset: Long): String = sortedPageUrl(offset, sort)
   /**
    * Overrides sort, giving the URL query parameters precedence
    */
-  override def sort = super.sort match {
+  override def sort: SortState = super.sort match {
     case (col, ascending) => (
       S.param("sort").map(toInt) openOr col,
       S.param("asc").map(toBoolean) openOr ascending


### PR DESCRIPTION
- Lift-mapper was updated for supporting Scala 2.13
- All deprecation warnings of compiler were fixed
- Scala versions were bumped to 2.12.11 and 2.13.2
- Sbt version was bumped to 1.3.12
