### PR TITLE
Update lift-mongodb and lift-mongodb-record for deprecations in the m…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -257,6 +257,7 @@ lazy val mongodb =
   persistenceProject("mongodb")
     .dependsOn(json_ext, util)
     .settings(
+      crossScalaVersions := crossUpTo213,
       parallelExecution in Test := false,
       libraryDependencies ++= Seq(mongo_java_driver, mongo_java_driver_async),
       initialize in Test := {
@@ -270,4 +271,7 @@ lazy val mongodb =
 lazy val mongodb_record =
   persistenceProject("mongodb-record")
     .dependsOn(record, mongodb)
-    .settings(parallelExecution in Test := false)
+    .settings(
+      crossScalaVersions := crossUpTo213,
+      parallelExecution in Test := false
+    )

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoRecord.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoRecord.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,23 +30,24 @@ import scala.concurrent.Future
 trait MongoRecord[MyType <: MongoRecord[MyType]] extends BsonRecord[MyType] {
   self: MyType =>
 
-  /*
-  * Every MongoRecord must have an _id field. Use a MongoPkField to
-  * satisfy this.
-
-  * This may change to type MandatoryTypedField in the
-  * future (once MongoId is removed.)
-  */
+  /**
+   * Every MongoRecord must have an _id field. Use a MongoPkField to
+   * satisfy this.
+   *
+   * This may change to type MandatoryTypedField in the
+   * future (once MongoId is removed.)
+   */
   def id: Any
 
   /**
-  * The meta record (the object that contains the meta result for this type)
-  */
+   * The meta record (the object that contains the meta result for this type)
+   */
   def meta: MongoMetaRecord[MyType]
 
   /**
-  * Save the instance and return the instance
-  */
+   * Save the instance and return the instance
+   */
+  @deprecated("Set WriteConcern in MongoClientOptions or on the MongoMetaRecord", "3.4.2")
   def save(concern: WriteConcern): MyType = {
     runSafe {
       meta.save(this, concern)
@@ -55,30 +56,39 @@ trait MongoRecord[MyType <: MongoRecord[MyType]] extends BsonRecord[MyType] {
   }
 
   /**
-    * Inserts record and returns Future that completes when mongo driver finishes operation
-    */
+   * Inserts record and returns Future that completes when mongo driver finishes operation
+   */
+  @deprecated("No longer supported. This will be removed in Lift 4.", "3.4.2")
   def insertAsync():Future[Boolean] = {
     runSafe {
       meta.insertAsync(this)
     }
   }
 
- /**
-  * Save the instance and return the instance
-  */
+  /**
+   * Save the instance and return the instance
+   */
   override def saveTheRecord(): Box[MyType] = saveBox()
 
   /**
-  * Save the instance and return the instance
-  * @param safe - if true will use WriteConcern ACKNOWLEDGED else UNACKNOWLEDGED
-  */
+   * Save the instance and return the instance
+   * @param safe - if true will use WriteConcern ACKNOWLEDGED else UNACKNOWLEDGED
+   */
+  @deprecated("Set WriteConcern in MongoClientOptions or on the MongoMetaRecord", "3.4.2")
   def save(safe: Boolean = true): MyType = {
     save(if (safe) WriteConcern.ACKNOWLEDGED else WriteConcern.UNACKNOWLEDGED)
   }
 
+  def save(): MyType = {
+    runSafe {
+      meta.save(this)
+    }
+    this
+  }
+
   /**
-    * Try to save the instance and return the instance in a Box.
-    */
+   * Try to save the instance and return the instance in a Box.
+   */
   def saveBox(): Box[MyType] = tryo {
     runSafe {
       meta.save(this)
@@ -87,8 +97,9 @@ trait MongoRecord[MyType <: MongoRecord[MyType]] extends BsonRecord[MyType] {
   }
 
   /**
-    * Update only the dirty fields
-    */
+   * Update only the dirty fields
+   */
+  @deprecated("Use updateOne, or replaceOne instead", "3.4.2")
   def update: MyType = {
     runSafe {
       meta.update(this)
@@ -97,8 +108,9 @@ trait MongoRecord[MyType <: MongoRecord[MyType]] extends BsonRecord[MyType] {
   }
 
   /**
-    * Try to update only the dirty fields
-    */
+   * Try to update only the dirty fields
+   */
+  @deprecated("Use updateOne, or replaceOne instead", "3.4.2")
   def updateBox: Box[MyType] = tryo {
     runSafe {
       meta.update(this)
@@ -107,8 +119,8 @@ trait MongoRecord[MyType <: MongoRecord[MyType]] extends BsonRecord[MyType] {
   }
 
   /**
-    * Delete the instance from backing store
-    */
+   * Delete the instance from backing store
+   */
   def delete_! : Boolean = {
     runSafe {
       meta.delete_!(this)
@@ -116,8 +128,8 @@ trait MongoRecord[MyType <: MongoRecord[MyType]] extends BsonRecord[MyType] {
   }
 
   /**
-    * Try to delete the instance from backing store
-    */
+   * Try to delete the instance from backing store
+   */
   def deleteBox_! : Box[Boolean] = tryo {
     runSafe {
       meta.delete_!(this)

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoRecordRules.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoRecordRules.scala
@@ -25,6 +25,9 @@ import org.bson.Transformer
 import org.bson.codecs.BsonTypeClassMap
 import org.bson.codecs.configuration.CodecRegistry
 
+/**
+ * MongoRecordRules holds Lift Mongo Record's configuration.
+ */
 object MongoRecordRules extends SimpleInjector {
   /**
    * The default CodecRegistry used.

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoRecordRules.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/MongoRecordRules.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+
+import net.liftweb.mongodb.record.codecs.RecordCodec
+import net.liftweb.util.SimpleInjector
+
+import org.bson.Transformer
+import org.bson.codecs.BsonTypeClassMap
+import org.bson.codecs.configuration.CodecRegistry
+
+object MongoRecordRules extends SimpleInjector {
+  /**
+   * The default CodecRegistry used.
+   */
+  val defaultCodecRegistry = new Inject[CodecRegistry](RecordCodec.defaultLegacyRegistry) {}
+
+  /**
+   * The default BsonTypeClassMap used.
+   */
+  val defaultBsonTypeClassMap = new Inject[BsonTypeClassMap](RecordCodec.defaultLegacyBsonTypeClassMap) {}
+
+  /**
+   * The default transformer used
+   */
+   val defaultTransformer = new Inject[Transformer](RecordCodec.defaultTransformer) {}
+}

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/codecs/CollectibleRecordCodec.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/codecs/CollectibleRecordCodec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb.mongodb
+package record
+package codecs
+
+import scala.collection.mutable
+import java.util.{Calendar, ArrayList, List => JavaList, Map => JavaMap, UUID}
+import java.util.regex.Pattern
+import java.util.Arrays.asList
+
+import net.liftweb.common._
+import net.liftweb.mongodb.codecs._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.{Field, MandatoryTypedField, MetaRecord, Record}
+import net.liftweb.util.Helpers.tryo
+
+import org.bson._
+import org.bson.codecs._
+import org.bson.codecs.configuration.{CodecRegistry, CodecRegistries}
+import com.mongodb._
+import com.mongodb.client.gridfs.codecs.GridFSFileCodecProvider
+
+/**
+ * A Collectible (requires an _id field) codec for Record instances.
+ */
+object CollectibleRecordCodec {
+  private val idFieldName: String = "_id"
+}
+
+case class CollectibleRecordCodec[T <: Record[T]](
+  metaRecord: MetaRecord[T],
+  codecRegistry: CodecRegistry = RecordCodec.defaultLegacyRegistry,
+  bsonTypeClassMap: BsonTypeClassMap = RecordCodec.defaultLegacyBsonTypeClassMap,
+  valueTransformer: Transformer = RecordCodec.defaultTransformer
+)
+  extends RecordTypedCodec[T]
+  with CollectibleCodec[T]
+{
+  override def getEncoderClass(): Class[T] = metaRecord.createRecord.getClass.asInstanceOf[Class[T]]
+
+  /**
+   * Fields must be predefined on Records so there's no way to add one if missing.
+   */
+  def generateIdIfAbsentFromDocument(rec: T): T = {
+    rec
+  }
+
+  private def findIdField(rec: T): Option[Field[_, T]] = {
+    rec.fieldByName(CollectibleRecordCodec.idFieldName).toOption
+  }
+
+  def documentHasId(rec: T): Boolean = {
+    findIdField(rec).nonEmpty
+  }
+
+  def getDocumentId(rec: T): BsonValue = {
+    if (!documentHasId(rec)) {
+      throw new IllegalStateException("The rec does not contain an _id")
+    }
+
+    findIdField(rec) match {
+      case Some(field: Field[_, T] with MandatoryTypedField[_]) =>
+        val idHoldingDocument = new BsonDocument()
+        val writer = new BsonDocumentWriter(idHoldingDocument)
+        writer.writeStartDocument()
+        writer.writeName(CollectibleRecordCodec.idFieldName)
+
+        writeValue(writer, EncoderContext.builder().build(), field.value.asInstanceOf[Object])
+
+        writer.writeEndDocument()
+        idHoldingDocument.get(CollectibleRecordCodec.idFieldName)
+      case _ =>
+        throw new IllegalStateException("The _id field could not be found")
+    }
+  }
+}

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/codecs/RecordCodec.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/codecs/RecordCodec.scala
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb.mongodb
+package record
+package codecs
+
+import scala.collection.mutable
+
+import java.util.{Calendar, GregorianCalendar, ArrayList, List => JavaList, Map => JavaMap, UUID}
+import java.util.regex.Pattern
+import java.util.Arrays.asList
+
+import net.liftweb.common._
+import net.liftweb.mongodb.codecs._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.{Field, MandatoryTypedField, MetaRecord, Record}
+import net.liftweb.record.field._
+import net.liftweb.record.field.joda.JodaTimeTypedField
+import net.liftweb.util.Helpers.tryo
+
+import org.bson._
+import org.bson.codecs.{BsonTypeCodecMap, Codec, Decoder, DecoderContext, Encoder, EncoderContext}
+import org.bson.codecs.configuration.{CodecRegistry, CodecRegistries}
+import com.mongodb._
+
+import org.joda.time.DateTime
+
+/**
+ * A codec for Record instances.
+ */
+object RecordCodec {
+
+  val defaultLegacyBsonTypeClassMap: BsonTypeClassMap =
+    BsonTypeClassMap(
+      (BsonType.REGULAR_EXPRESSION -> classOf[Pattern]),
+      (BsonType.BINARY -> classOf[Array[Byte]]),
+      (BsonType.DOCUMENT, classOf[BsonDocument])
+    )
+
+  val defaultLegacyRegistry: CodecRegistry = CodecRegistries.fromRegistries(
+    MongoClientSettings.getDefaultCodecRegistry(),
+    CodecRegistries.fromCodecs(BigDecimalStringCodec(), CalendarCodec(), JodaDateTimeCodec())
+  )
+
+  val defaultBsonTypeClassMap: BsonTypeClassMap =
+    BsonTypeClassMap(
+      (BsonType.BINARY -> classOf[Array[Byte]]),
+      (BsonType.DECIMAL128 -> classOf[BigDecimal]),
+      (BsonType.DOCUMENT, classOf[BsonDocument])
+    )
+
+  val defaultRegistry: CodecRegistry = CodecRegistries.fromRegistries(
+    MongoClientSettings.getDefaultCodecRegistry(),
+    CodecRegistries.fromCodecs(BigDecimalCodec())
+  )
+
+  val defaultTransformer: Transformer = new Transformer() {
+    override def transform(value: Object): Object = value
+  }
+}
+
+/**
+ * A Codec trait for Record typed instances
+ */
+trait RecordTypedCodec[T <: Record[T]] extends Codec[T] with Loggable {
+  def metaRecord: MetaRecord[T]
+  def codecRegistry: CodecRegistry
+  def bsonTypeClassMap: BsonTypeClassMap
+  def valueTransformer: Transformer
+
+  lazy val bsonTypeCodecMap = new BsonTypeCodecMap(bsonTypeClassMap, codecRegistry)
+
+  private val uuidClass = classOf[UUID]
+
+  def decode(reader: BsonReader, decoderContext: DecoderContext): T = {
+    val rec: T = metaRecord.createRecord
+
+    reader.readStartDocument()
+
+    while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+      val fieldName: String = reader.readName()
+
+      // find the field and set it
+      rec.fieldByName(fieldName) match {
+        case Full(field) =>
+          readAndSetFieldValue(reader, decoderContext, field) match {
+            case f: Failure =>
+              logger.error(f)
+            case _ =>
+          }
+        case _ =>
+          // this field is not in the Record, skip it
+          reader.skipValue()
+      }
+    }
+
+    reader.readEndDocument()
+
+    rec.runSafe {
+      rec.fields.foreach(_.resetDirty)
+    }
+
+    rec
+  }
+
+  /**
+   * Read the Bson data and set the Field.
+   */
+  private def readAndSetFieldValue(reader: BsonReader, decoderContext: DecoderContext, field: Field[_, T]): Box[Any] = {
+    val currentBsonType = reader.getCurrentBsonType
+
+    def readNext(): Any = {
+      bsonTypeCodecMap.get(currentBsonType).decode(reader, decoderContext)
+    }
+
+    field match {
+      case f: BsonableField[_] =>
+        f.setFromBsonReader(reader, decoderContext, codecRegistry, bsonTypeCodecMap)
+      case f: DateTimeTypedField if currentBsonType == BsonType.DATE_TIME => // Calendar
+        f.setBox(tryo(CalendarCodec().decode(reader, decoderContext).asInstanceOf[Calendar]))
+      case f: JodaTimeTypedField if currentBsonType == BsonType.DATE_TIME => // joda.DateTime
+        f.setBox(tryo(JodaDateTimeCodec().decode(reader, decoderContext).asInstanceOf[DateTime]))
+      case f: DecimalTypedField if currentBsonType == BsonType.STRING =>
+        f.setFromString(readNext().asInstanceOf[String])
+      case f: EnumTypedField[_] if currentBsonType == BsonType.INT32 =>
+        f.setFromInt(readNext().asInstanceOf[Int])
+      case f: EnumNameTypedField[_] if currentBsonType == BsonType.STRING =>
+        f.setFromString(readNext().asInstanceOf[String])
+      case _ =>
+        (currentBsonType match {
+          case BsonType.NULL =>
+            reader.readNull()
+            Empty
+          case BsonType.BINARY if BsonBinarySubType.isUuid(reader.peekBinarySubType) && reader.peekBinarySize == 16 =>
+            tryo(codecRegistry.get(uuidClass).decode(reader, decoderContext))
+          case bsonType: BsonType =>
+            tryo(valueTransformer.transform(readNext))
+        }) match {
+          case Full(v: field.MyType) =>
+            field.setBox(Full(v))
+          case Empty =>
+            field.setBox(Empty)
+          case f: Failure =>
+            field.setBox(Failure(s"Error reading Bson value: ${reader.getCurrentBsonType}", Empty, f))
+        }
+    }
+  }
+
+  private def readValue(reader: BsonReader, decoderContext: DecoderContext): Any = {
+    reader.getCurrentBsonType match {
+      case BsonType.NULL =>
+        reader.readNull()
+        null
+      case BsonType.ARRAY =>
+        readList(reader, decoderContext)
+      case BsonType.DOCUMENT =>
+        readMap(reader, decoderContext)
+      case BsonType.BINARY if BsonBinarySubType.isUuid(reader.peekBinarySubType) && reader.peekBinarySize == 16 =>
+        codecRegistry.get(uuidClass).decode(reader, decoderContext)
+      case bsonType: BsonType =>
+        valueTransformer.transform(bsonTypeCodecMap.get(bsonType).decode(reader, decoderContext))
+    }
+  }
+
+  private def readMap(reader: BsonReader, decoderContext: DecoderContext): Map[String, _] = {
+    val map = mutable.Map[String, Any]()
+    reader.readStartDocument()
+    while (reader.readBsonType ne BsonType.END_OF_DOCUMENT) {
+      map += (reader.readName -> readValue(reader, decoderContext))
+    }
+    reader.readEndDocument()
+    map.toMap
+  }
+
+  private def readList(reader: BsonReader, decoderContext: DecoderContext): List[_] = {
+    reader.readStartArray()
+    val list = mutable.ListBuffer[Any]()
+    while (reader.readBsonType ne BsonType.END_OF_DOCUMENT) {
+      list.append(readValue(reader, decoderContext))
+    }
+    reader.readEndArray()
+    list.toList
+  }
+
+  private def readListToDBObject(reader: BsonReader, decoderContext: DecoderContext): DBObject = {
+    reader.readStartArray()
+    val list = new BasicDBList
+    while (reader.readBsonType ne BsonType.END_OF_DOCUMENT) {
+      list.add(readValue(reader, decoderContext).asInstanceOf[Object])
+    }
+    reader.readEndArray()
+    list
+  }
+
+  def encode(writer: BsonWriter, record: T, encoderContext: EncoderContext): Unit = {
+
+    writer.writeStartDocument()
+
+    record.fields().foreach { _ match {
+      case field if (field.optional_? && field.valueBox.isEmpty) => // don't write anything
+      case field: BsonableField[_] =>
+        Option(field.asInstanceOf[BsonableField[Any]]).foreach { bf =>
+          bf.writeToBsonWriter(writer, encoderContext, codecRegistry, bsonTypeCodecMap)
+        }
+      case field: EnumTypedField[_] =>
+        field.asInstanceOf[EnumTypedField[Enumeration]].valueBox
+          .map(_.id)
+          .foreach { id =>
+            writer.writeName(field.name)
+            writer.writeInt32(id)
+          }
+      case field: EnumNameTypedField[_] =>
+        field.asInstanceOf[EnumNameTypedField[Enumeration]].valueBox
+          .map(_.toString)
+          .foreach { s =>
+            writer.writeName(field.name)
+            writer.writeString(s)
+          }
+      case field => field.valueBox match {
+        case Empty if field.optional_? => // don't write anything
+        case Empty =>
+          sys.error(s"Field value is Empty. Field name: ${field.name}.")
+        case Failure(msg, _, _) =>
+          sys.error(s"Error reading value. Field name: ${field.name}. Error message: ${msg}")
+        case Full(v: Array[Byte]) =>
+          writer.writeName(field.name)
+          writer.writeBinaryData(new BsonBinary(v))
+        case Full(v) =>
+          writer.writeName(field.name)
+          writeValue(writer, encoderContext, v)
+      }
+    }}
+
+    writer.writeEndDocument()
+  }
+
+  protected def writeValue[T](writer: BsonWriter, encoderContext: EncoderContext, value: T): Unit = {
+    value match {
+      case isNull if value == null =>
+        writer.writeNull()
+      case map: Map[_, _] =>
+        writeMap(writer, map.asInstanceOf[Map[String, Any]], encoderContext.getChildContext)
+      case list: Iterable[_] =>
+        writeIterable(writer, list, encoderContext.getChildContext)
+      case _ =>
+        val codec = codecRegistry.get(value.getClass).asInstanceOf[Encoder[T]]
+        encoderContext.encodeWithChildContext(codec, writer, value)
+    }
+  }
+
+  protected def writeMap(writer: BsonWriter, map: Map[String, Any], encoderContext: EncoderContext): Unit = {
+    writer.writeStartDocument()
+    map.foreach(kv => {
+      writer.writeName(kv._1)
+      writeValue(writer, encoderContext, kv._2)
+    })
+    writer.writeEndDocument()
+  }
+
+  protected def writeIterable(writer: BsonWriter, list: Iterable[_], encoderContext: EncoderContext): Unit = {
+    writer.writeStartArray()
+    list.foreach(value => writeValue(writer, encoderContext, value))
+    writer.writeEndArray()
+  }
+}
+
+/**
+ * A Codec for Record instances
+ */
+case class RecordCodec[T <: Record[T]](
+  metaRecord: MetaRecord[T],
+  codecRegistry: CodecRegistry = RecordCodec.defaultLegacyRegistry,
+  bsonTypeClassMap: BsonTypeClassMap = RecordCodec.defaultLegacyBsonTypeClassMap,
+  valueTransformer: Transformer = RecordCodec.defaultTransformer
+) extends RecordTypedCodec[T] {
+  def getEncoderClass(): Class[T] = metaRecord.createRecord.getClass.asInstanceOf[Class[T]]
+}

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonRecordField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonRecordField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 WorldWide Conferencing, LLC
+ * Copyright 2011-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,26 +19,64 @@ package mongodb
 package record
 package field
 
-import common._
-import http.js.JsExp
-import http.js.JE.JsNull
-import json._
+import net.liftweb.common._
+import net.liftweb.http.js.JsExp
+import net.liftweb.http.js.JE.JsNull
+import net.liftweb.json._
 import net.liftweb.record._
-import com.mongodb._
-import org.bson.Document
+import net.liftweb.util.Helpers.tryo
 
+import com.mongodb._
+
+import org.bson._
+import org.bson.codecs.{BsonDocumentCodec, BsonTypeCodecMap, Codec, DecoderContext, Encoder, EncoderContext, StringCodec}
+import org.bson.codecs.configuration.CodecRegistry
+
+import scala.collection.mutable
 import scala.reflect.Manifest
-import scala.xml._
+import scala.xml.NodeSeq
 
 /** Field that contains an entire record represented as an inline object value. Inspired by JSONSubRecordField */
 abstract class BsonRecordTypedField[OwnerType <: BsonRecord[OwnerType], SubRecordType <: BsonRecord[SubRecordType]]
-(val owner: OwnerType, valueMeta: BsonMetaRecord[SubRecordType])(implicit subRecordType: Manifest[SubRecordType])
-  extends Field[SubRecordType, OwnerType] {
+(val owner: OwnerType, val valueMeta: BsonMetaRecord[SubRecordType])(implicit subRecordType: Manifest[SubRecordType])
+  extends Field[SubRecordType, OwnerType]
+  with BsonableField[SubRecordType]
+{
 
   def this(owner: OwnerType, valueMeta: BsonMetaRecord[SubRecordType], value: Box[SubRecordType])
     (implicit subRecordType: Manifest[SubRecordType]) = {
     this(owner, valueMeta)
     setBox(value)
+  }
+
+  def setFromBsonReader(reader: BsonReader, context: DecoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Box[MyType] = {
+    reader.getCurrentBsonType match {
+      case BsonType.DOCUMENT =>
+        setBox(tryo(valueMeta.codec.decode(reader, context)))
+      case BsonType.NULL =>
+        reader.readNull()
+        Empty
+      case bsonType =>
+        Failure(s"Invalid BsonType for field ${name}: ${bsonType}")
+    }
+  }
+
+  def writeToBsonWriter(writer: BsonWriter, context: EncoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Unit = {
+    valueBox match {
+      case Empty if optional_? =>
+      case Empty =>
+        writer.writeName(name)
+        val codec = new StringCodec()
+        context.encodeWithChildContext(codec, writer, "Empty")
+      case Full(v) =>
+        writer.writeName(name)
+        val codec = registry.get(v.getClass).asInstanceOf[Encoder[SubRecordType]]
+        context.encodeWithChildContext(codec, writer, v)
+      case Failure(msg, _, _) =>
+        writer.writeName(name)
+        val codec = new StringCodec()
+        context.encodeWithChildContext(codec, writer, s"Failure: ${msg}")
+    }
   }
 
   def asJs = asJValue match {
@@ -83,23 +121,25 @@ class OptionalBsonRecordField[OwnerType <: BsonRecord[OwnerType], SubRecordType 
   extends BsonRecordTypedField(owner, valueMeta) with OptionalTypedField[SubRecordType]
 
 
-/*
+/**
  * List of BsonRecords
  */
 class BsonRecordListField[OwnerType <: BsonRecord[OwnerType], SubRecordType <: BsonRecord[SubRecordType]]
-  (@deprecatedName('rec) owner: OwnerType, valueMeta: BsonMetaRecord[SubRecordType])(implicit mf: Manifest[SubRecordType])
+  (@deprecatedName('rec) owner: OwnerType, val valueMeta: BsonMetaRecord[SubRecordType])(implicit mf: Manifest[SubRecordType])
   extends MongoListField[OwnerType, SubRecordType](owner: OwnerType) {
 
   import scala.collection.JavaConverters._
 
   override def validations = ((elems: ValueType) => elems.flatMap(_.validate)) :: super.validations
 
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   override def asDBObject: DBObject = {
     val dbl = new BasicDBList
     value.foreach { v => dbl.add(v.asDBObject) }
     dbl
   }
 
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   override def setFromDBObject(dbo: DBObject): Box[List[SubRecordType]] = {
     setBox(Full(dbo.keySet.asScala.toList.map { k =>
       valueMeta.fromDBObject(dbo.get(k).asInstanceOf[DBObject])
@@ -116,9 +156,82 @@ class BsonRecordListField[OwnerType <: BsonRecord[OwnerType], SubRecordType <: B
     case other => setBox(FieldHelpers.expectedA("JArray", other))
   }
 
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   override def setFromDocumentList(list: java.util.List[Document]): Box[List[SubRecordType]] = {
     setBox(Full(
       list.asScala.toList.map { valueMeta.fromDocument }
     ))
+  }
+
+  override def setFromBsonReader(reader: BsonReader, context: DecoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Box[List[SubRecordType]] = {
+    reader.getCurrentBsonType match {
+      case BsonType.ARRAY =>
+        setBox(tryo {
+          reader.readStartArray()
+          val list = mutable.ListBuffer[SubRecordType]()
+          while (reader.readBsonType ne BsonType.END_OF_DOCUMENT) {
+            list.append(valueMeta.codec.decode(reader, context))
+          }
+          reader.readEndArray()
+          list.toList
+        })
+      case BsonType.NULL =>
+        reader.readNull()
+        Empty
+      case bsonType =>
+        Failure(s"Invalid BsonType for field ${name}: ${bsonType}")
+    }
+  }
+
+  override def writeToBsonWriter(writer: BsonWriter, context: EncoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Unit = {
+    writer.writeName(name)
+
+    writer.writeStartArray()
+    value.foreach { v =>
+      val codec = registry.get(v.getClass).asInstanceOf[Encoder[SubRecordType]]
+      context.encodeWithChildContext(codec, writer, v)
+    }
+    writer.writeEndArray()
+  }
+}
+
+/**
+ * Map of BsonRecords
+ */
+class BsonRecordMapField[OwnerType <: BsonRecord[OwnerType], SubRecordType <: BsonRecord[SubRecordType]]
+  (owner: OwnerType, val valueMeta: BsonMetaRecord[SubRecordType])(implicit mf: Manifest[SubRecordType])
+  extends MongoMapField[OwnerType, SubRecordType](owner: OwnerType)
+{
+  override def validations = ((elems: ValueType) => elems.values.toList.flatMap(_.validate)) :: super.validations
+
+  override def setFromBsonReader(reader: BsonReader, context: DecoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Box[Map[String, SubRecordType]] = {
+    reader.getCurrentBsonType match {
+      case BsonType.NULL =>
+        reader.readNull()
+        Empty
+      case BsonType.DOCUMENT =>
+        setBox(tryo {
+          val map = mutable.Map[String, SubRecordType]()
+          reader.readStartDocument()
+          while (reader.readBsonType ne BsonType.END_OF_DOCUMENT) {
+            map += (reader.readName -> valueMeta.codec.decode(reader, context))
+          }
+          reader.readEndDocument()
+          map.toMap
+        })
+      case bsonType =>
+        Failure(s"Invalid BsonType for field ${name}: ${bsonType}")
+    }
+  }
+
+  override def writeToBsonWriter(writer: BsonWriter, context: EncoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Unit = {
+    writer.writeName(name)
+    writer.writeStartDocument()
+    value.foreach(kv => {
+      writer.writeName(kv._1)
+      val codec = registry.get(kv._2.getClass).asInstanceOf[Encoder[SubRecordType]]
+      context.encodeWithChildContext(codec, writer, kv._2)
+    })
+    writer.writeEndDocument()
   }
 }

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonableField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/BsonableField.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package field
+
+import scala.collection.mutable
+
+import java.util.UUID
+
+import net.liftweb.common._
+import net.liftweb.http.js.JsExp
+import net.liftweb.http.js.JE.{JsNull, JsRaw}
+import net.liftweb.json._
+import net.liftweb.record.Field
+
+import org.bson._
+import org.bson.codecs._
+import org.bson.codecs.configuration.CodecRegistry
+
+/**
+ * A trait for creating custom Fields. Allows writing your own
+ * functions for encoding to and decoding from Bson.
+ */
+trait BsonableField[T] {
+  this: Field[T, _] =>
+
+  private val uuidClass = classOf[UUID]
+
+  /**
+   * Set this field's value from a BsonReader.
+   */
+  def setFromBsonReader(reader: BsonReader, context: DecoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Box[T]
+
+  /**
+   * Write this field's value to a BsonWriter.
+   */
+  def writeToBsonWriter(writer: BsonWriter, context: EncoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Unit
+
+  /**
+   * Helper function to read a value to a BsonDocument.
+   */
+  protected def readValueToBsonDocument(reader: BsonReader, context: DecoderContext, registry: CodecRegistry): BsonDocument = {
+    val codec = new BsonDocumentCodec(registry)
+    val result = codec.decode(reader, context).asInstanceOf[BsonDocument]
+    result
+  }
+
+  /**
+   * Helper function to read an array to a List of BsonDocuments.
+   */
+  protected def readArrayToBsonDocument(reader: BsonReader, context: DecoderContext, registry: CodecRegistry): List[BsonDocument] = {
+    reader.readStartArray()
+    val list = mutable.ListBuffer[BsonDocument]()
+    while (reader.readBsonType ne BsonType.END_OF_DOCUMENT) {
+      val codec = new BsonDocumentCodec(registry)
+      list.append(codec.decode(reader, context).asInstanceOf[BsonDocument])
+    }
+    reader.readEndArray()
+    list.toList
+  }
+
+  /**
+   * Helper function to write a value to a BsonWriter.
+   */
+  protected def writeValue[T](writer: BsonWriter, encoderContext: EncoderContext, value: T, codecRegistry: CodecRegistry): Unit = {
+    value match {
+      case isNull if value == null =>
+        writer.writeNull()
+      case map: Map[_, _] =>
+        writeMap(writer, map.asInstanceOf[Map[String, Any]], encoderContext.getChildContext, codecRegistry)
+      case list: Iterable[_] =>
+        writeIterable(writer, list, encoderContext.getChildContext, codecRegistry)
+      case _ =>
+        val codec = codecRegistry.get(value.getClass).asInstanceOf[Encoder[T]]
+        encoderContext.encodeWithChildContext(codec, writer, value)
+    }
+  }
+
+  /**
+   * Helper function to write a Map to a BsonWriter.
+   */
+  protected def writeMap(writer: BsonWriter, map: Map[String, Any], encoderContext: EncoderContext, codecRegistry: CodecRegistry): Unit = {
+    writer.writeStartDocument()
+    map.foreach(kv => {
+      writer.writeName(kv._1)
+      writeValue(writer, encoderContext, kv._2, codecRegistry)
+    })
+    writer.writeEndDocument()
+  }
+
+  /**
+   * Helper function to write an Iterable to a BsonWriter.
+   */
+  protected def writeIterable(writer: BsonWriter, list: Iterable[_], encoderContext: EncoderContext, codecRegistry: CodecRegistry): Unit = {
+    writer.writeStartArray()
+    list.foreach(value => writeValue(writer, encoderContext, value, codecRegistry))
+    writer.writeEndArray()
+  }
+
+  /**
+   * Helper function to read a value from a BsonReader.
+   */
+  protected def readValue(reader: BsonReader, decoderContext: DecoderContext, codecRegistry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Any = {
+    reader.getCurrentBsonType match {
+      case BsonType.NULL =>
+        reader.readNull()
+        null
+      case BsonType.ARRAY =>
+        readList(reader, decoderContext, codecRegistry, bsonTypeCodecMap)
+      case BsonType.DOCUMENT =>
+        readMap(reader, decoderContext, codecRegistry, bsonTypeCodecMap)
+      case BsonType.BINARY if BsonBinarySubType.isUuid(reader.peekBinarySubType) && reader.peekBinarySize == 16 =>
+        codecRegistry.get(uuidClass).decode(reader, decoderContext)
+      case bsonType: BsonType =>
+        bsonTypeCodecMap.get(bsonType).decode(reader, decoderContext)
+    }
+  }
+
+  /**
+   * Helper function to read a Map from a BsonReader.
+   */
+  protected def readMap(reader: BsonReader, decoderContext: DecoderContext, codecRegistry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Map[String, _] = {
+    val map = mutable.Map[String, Any]()
+    reader.readStartDocument()
+    while (reader.readBsonType ne BsonType.END_OF_DOCUMENT) {
+      map += (reader.readName -> readValue(reader, decoderContext, codecRegistry, bsonTypeCodecMap))
+    }
+    reader.readEndDocument()
+    map.toMap
+  }
+
+  /**
+   * Helper function to read a List from a BsonReader.
+   */
+  protected def readList(reader: BsonReader, decoderContext: DecoderContext, codecRegistry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): List[_] = {
+    reader.readStartArray()
+    val list = mutable.ListBuffer[Any]()
+    while (reader.readBsonType ne BsonType.END_OF_DOCUMENT) {
+      list.append(readValue(reader, decoderContext, codecRegistry, bsonTypeCodecMap))
+    }
+    reader.readEndArray()
+    list.toList
+  }
+}
+
+/**
+ * A trait for creating custom Fields that are based on JObject and are saved as a document (BsonType.DOCUMENT).
+ */
+trait BsonDocumentJObjectField[T] extends BsonableField[T] {
+  this: Field[T, _] =>
+
+  implicit def formats: Formats = DefaultFormats
+
+  def setFromBsonReader(reader: BsonReader, context: DecoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Box[MyType] = {
+    reader.getCurrentBsonType match {
+      case BsonType.DOCUMENT =>
+        val doc = readValueToBsonDocument(reader, context, registry)
+        setFromJValue(BsonParser.serialize(doc)(formats))
+      case BsonType.NULL =>
+        reader.readNull()
+        Empty
+      case bsonType =>
+        Failure(s"Invalid BsonType for field ${name}: ${bsonType}")
+    }
+  }
+
+  def writeToBsonWriter(writer: BsonWriter, context: EncoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Unit = {
+    asJValue match {
+      case jo: JObject =>
+        writer.writeName(name)
+        val codec = (new BsonDocumentCodec(registry)).asInstanceOf[Codec[Any]]
+        context.encodeWithChildContext(codec, writer, BsonParser.parse(jo)(formats))
+      case JNothing | JNull if optional_? =>
+      case _ =>
+        writer.writeName(name)
+        writer.writeNull()
+    }
+  }
+}

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/CaseClassField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/CaseClassField.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2010-2015 WorldWide Conferencing, LLC
+* Copyright 2010-2020 WorldWide Conferencing, LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,23 +16,26 @@ package mongodb
 package record
 package field
 
+import net.liftweb.common.{Failure, Empty, Full, Box}
+import net.liftweb.http.js.JsExp
+import net.liftweb.http.js.JE.{JsObj, JsRaw, Num, Str, JsNull}
+import net.liftweb.json._
 import net.liftweb.record._
 import net.liftweb.record.RecordHelpers.jvalueToJsExp
 import net.liftweb.record.field._
-import net.liftweb.http.js.JE.{JsObj, Num, Str, JsNull}
-import scala.xml.{Text, NodeSeq}
-import net.liftweb.mongodb.JObjectParser
-import com.mongodb.{BasicDBList, DBObject}
-import net.liftweb.common.{Failure, Empty, Full, Box}
 import net.liftweb.util.Helpers
-import net.liftweb.json._
-import reflect.Manifest
-import net.liftweb.http.js.JsExp
-import org.bson.Document
+
 import scala.collection.JavaConverters._
+import scala.reflect.Manifest
+import scala.xml.{Text, NodeSeq}
+
+import org.bson._
+import org.bson.codecs.{BsonDocumentCodec, BsonTypeCodecMap, Codec, DecoderContext, EncoderContext}
+import org.bson.codecs.configuration.CodecRegistry
+import com.mongodb.{BasicDBList, DBObject}
 
 abstract class CaseClassTypedField[OwnerType <: Record[OwnerType], CaseType](val owner: OwnerType)(implicit mf: Manifest[CaseType])
-  extends Field[CaseType, OwnerType] with MongoFieldFlavor[CaseType] {
+  extends Field[CaseType, OwnerType] with MongoFieldFlavor[CaseType] with BsonableField[CaseType] {
 
   // override this for custom formats
   def formats: Formats = DefaultFormats
@@ -40,7 +43,6 @@ abstract class CaseClassTypedField[OwnerType <: Record[OwnerType], CaseType](val
   implicit lazy val _formats = formats
 
   override type MyType = CaseType
-
 
   def toForm: Box[NodeSeq] = Empty
 
@@ -51,6 +53,42 @@ abstract class CaseClassTypedField[OwnerType <: Record[OwnerType], CaseType](val
     case s => setBox(Helpers.tryo[CaseType] { s.extract[CaseType] })
   }
 
+  def setFromBsonReader(reader: BsonReader, context: DecoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Box[MyType] = {
+    reader.getCurrentBsonType match {
+      case BsonType.DOCUMENT =>
+        val doc = readValueToBsonDocument(reader, context, registry)
+        setFromJValue(BsonParser.serialize(doc))
+      case BsonType.NULL =>
+        reader.readNull()
+        Empty
+      case bsonType =>
+        Failure(s"Invalid BsonType for field ${name}: ${bsonType}")
+    }
+  }
+
+  def writeToBsonWriter(writer: BsonWriter, context: EncoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Unit = {
+    asJValue match {
+      case jo: JObject =>
+        writer.writeName(name)
+        val codec = (new BsonDocumentCodec(registry)).asInstanceOf[Codec[Any]]
+        context.encodeWithChildContext(codec, writer, BsonParser.parse(jo))
+      case JNull if optional_? =>
+      case JNull =>
+        writer.writeName(name)
+        writer.writeNull()
+      case _ =>
+    }
+  }
+
+  /**
+   * Returns the field's value as a valid JavaScript expression
+   */
+  override def asJs = asJValue match {
+    case JNothing => JsNull
+    case jv => JsRaw(compactRender(jv))
+  }
+
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def asDBObject: DBObject = asJValue match {
     case JNothing | JNull => null
     case other => JObjectParser.parse(other.asInstanceOf[JObject])
@@ -61,6 +99,7 @@ abstract class CaseClassTypedField[OwnerType <: Record[OwnerType], CaseType](val
     setFromJValue(jv)
   }
 
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def setFromDBObject(dbo: DBObject): Box[CaseType] = {
     val jvalue = JObjectParser.serialize(dbo)
     setFromJValue(jvalue)
@@ -107,8 +146,11 @@ class OptionalCaseClassField[OwnerType <: Record[OwnerType], CaseType](owner: Ow
 }
 
 class CaseClassListField[OwnerType <: Record[OwnerType], CaseType](val owner: OwnerType)(implicit mf: Manifest[CaseType])
-  extends Field[List[CaseType], OwnerType] with MandatoryTypedField[List[CaseType]] with MongoFieldFlavor[List[CaseType]] {
-
+  extends Field[List[CaseType], OwnerType]
+  with MandatoryTypedField[List[CaseType]]
+  with MongoFieldFlavor[List[CaseType]]
+  with BsonableField[List[CaseType]]
+{
   // override this for custom formats
   def formats: Formats = DefaultFormats
   implicit lazy val _formats = formats
@@ -123,16 +165,54 @@ class CaseClassListField[OwnerType <: Record[OwnerType], CaseType](val owner: Ow
 
   def asJValue: JValue = JArray(value.map(v => Extraction.decompose(v)))
 
+  /**
+   * Returns the field's value as a valid JavaScript expression
+   */
+  override def asJs = asJValue match {
+    case JNothing => JsNull
+    case jv => JsRaw(compactRender(jv))
+  }
+
   def setFromJValue(jvalue: JValue): Box[MyType] = jvalue match {
     case JArray(contents) => setBox(Full(contents.flatMap(s => Helpers.tryo[CaseType]{ s.extract[CaseType] })))
     case _ => setBox(Empty)
   }
 
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def setFromDocumentList(list: java.util.List[Document]): Box[MyType] = {
     val objs = list.asScala.map { JObjectParser.serialize }
     setFromJValue(JArray(objs.toList))
   }
 
+  def setFromBsonReader(reader: BsonReader, context: DecoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Box[MyType] = {
+    reader.getCurrentBsonType match {
+      case BsonType.ARRAY =>
+        setFromJValue(JArray(readArrayToBsonDocument(reader, context, registry).map { BsonParser.serialize _ }))
+      case BsonType.NULL =>
+        reader.readNull()
+        Empty
+      case bsonType =>
+        Failure(s"Invalid BsonType for field ${name}: ${bsonType}")
+    }
+  }
+
+  def writeToBsonWriter(writer: BsonWriter, context: EncoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Unit = {
+    writer.writeName(name)
+    writer.writeStartArray()
+
+    asJValue match {
+      case JArray(list) =>
+        list.foreach { v =>
+          val codec = (new BsonDocumentCodec(registry)).asInstanceOf[Codec[Any]]
+          context.encodeWithChildContext(codec, writer, BsonParser.parse(v.asInstanceOf[JObject]))
+        }
+      case _ =>
+    }
+
+    writer.writeEndArray()
+  }
+
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def asDBObject: DBObject = {
     val dbl = new BasicDBList
 
@@ -145,6 +225,7 @@ class CaseClassListField[OwnerType <: Record[OwnerType], CaseType](val owner: Ow
     dbl
   }
 
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def setFromDBObject(dbo: DBObject): Box[MyType] = {
     val jvalue = JObjectParser.serialize(dbo)
     setFromJValue(jvalue)

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/DBRefField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/DBRefField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.bson.types.ObjectId
 /*
 * Field for storing a DBRef
 */
+@deprecated("DBref is being removed. See 'MongoRef' for an alternative", "3.4.2")
 class DBRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](rec: OwnerType, ref: RefType)
   extends Field[DBRef, OwnerType] with MandatoryTypedField[DBRef] {
 

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JObjectField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/JObjectField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,20 @@ import net.liftweb.common._
 import net.liftweb.json._
 import net.liftweb.record._
 import net.liftweb.util.Helpers.tryo
-import org.bson.Document
+
+import org.bson._
+import org.bson.codecs.{BsonDocumentCodec, BsonTypeCodecMap, Codec, DecoderContext, EncoderContext}
+import org.bson.codecs.configuration.CodecRegistry
 
 import scala.xml.NodeSeq
 
 trait JObjectTypedField[OwnerType <: BsonRecord[OwnerType]] extends TypedField[JObject]
-  with Field[JObject, OwnerType] with MongoFieldFlavor[JObject] {
+  with Field[JObject, OwnerType]
+  with MongoFieldFlavor[JObject]
+  with BsonDocumentJObjectField[JObject]
+{
+
+  override implicit val formats = owner.meta.formats
 
   def setFromJValue(jvalue: JValue): Box[JObject] = jvalue match {
     case JNothing|JNull if optional_? => setBox(Empty)
@@ -59,10 +67,12 @@ trait JObjectTypedField[OwnerType <: BsonRecord[OwnerType]] extends TypedField[J
 
   def toForm: Box[NodeSeq] = Empty
 
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def asDBObject: DBObject = valueBox
     .map { v => JObjectParser.parse(v)(owner.meta.formats) }
     .openOr(new BasicDBObject)
 
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def setFromDBObject(obj: DBObject): Box[JObject] =
     Full(JObjectParser.serialize(obj)(owner.meta.formats).asInstanceOf[JObject])
 

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoFieldFlavor.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoFieldFlavor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,14 +27,17 @@ import com.mongodb.DBObject
 /**
 * Describes common aspects related to Mongo fields
 */
+@deprecated("Please use 'BsonableField' instead.", "3.4.2")
 trait MongoFieldFlavor[MyType] {
 
   /*
   * convert this field's value into a DBObject so it can be stored in Mongo.
   */
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def asDBObject: DBObject
 
   // set this field's value using a DBObject returned from Mongo.
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def setFromDBObject(obj: DBObject): Box[MyType]
 
   /**
@@ -49,4 +52,3 @@ trait MongoFieldFlavor[MyType] {
   def asJValue: JValue
 
 }
-

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoListField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoListField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,29 +19,42 @@ package mongodb
 package record
 package field
 
+import java.util.{List => JavaList, UUID}
+import java.util.regex.Pattern
+
 import com.mongodb._
 import net.liftweb.common.{Box, Empty, Failure, Full}
 import net.liftweb.http.SHtml
 import net.liftweb.json._
 import net.liftweb.record.{Field, FieldHelpers, MandatoryTypedField}
 import net.liftweb.util.Helpers._
-import org.bson.Document
 
+import org.bson._
+import org.bson.codecs.{BsonDocumentCodec, BsonTypeCodecMap, Codec, DecoderContext, Encoder, EncoderContext}
+import org.bson.codecs.configuration.CodecRegistry
+
+import scala.collection.mutable
 import scala.collection.JavaConverters._
 import scala.xml.NodeSeq
+
+object BsonBinary {
+  def apply(subtype: BsonBinarySubType, data: Array[Byte]): BsonBinary = new BsonBinary(subtype, data)
+}
 
 /**
   * List field.
   *
   * Supported types:
-  * primitives - String, Int, Long, Double, Float, Byte, BigInt,
+  * primitives - String, Int, Long, Double, BigDecimal, Byte, BigInt,
   * Boolean (and their Java equivalents)
   * date types - java.util.Date, org.joda.time.DateTime
   * mongo types - ObjectId, Pattern, UUID
   *
   * If you need to support other types, you will need to override the
-  * asDBObject and setFromDBObject functions accordingly. And the
-  * asJValue and setFromJValue functions if you will be using them.
+  * `readValue` function and either override the `writeValue` function
+  * or create a custom codec for it and add it to your registry. You'll
+  * also need to override the `asJValue` and `setFromJValue` functions if you
+  * will be using them.
   *
   * Note: setting optional_? = false will result in incorrect equals behavior when using setFromJValue
   */
@@ -49,6 +62,7 @@ class MongoListField[OwnerType <: BsonRecord[OwnerType], ListType: Manifest](rec
   extends Field[List[ListType], OwnerType]
   with MandatoryTypedField[List[ListType]]
   with MongoFieldFlavor[List[ListType]]
+  with BsonableField[List[ListType]]
 {
   import mongodb.Meta.Reflection._
 
@@ -58,7 +72,7 @@ class MongoListField[OwnerType <: BsonRecord[OwnerType], ListType: Manifest](rec
 
   def owner = rec
 
-  def defaultValue = List[ListType]()
+  def defaultValue = List.empty[ListType]
 
   implicit def formats = owner.meta.formats
 
@@ -68,11 +82,11 @@ class MongoListField[OwnerType <: BsonRecord[OwnerType], ListType: Manifest](rec
       case list@c::xs if mf.runtimeClass.isInstance(c) => setBox(Full(list.asInstanceOf[MyType]))
       case Some(list@c::xs) if mf.runtimeClass.isInstance(c) => setBox(Full(list.asInstanceOf[MyType]))
       case Full(list@c::xs) if mf.runtimeClass.isInstance(c) => setBox(Full(list.asInstanceOf[MyType]))
-      case jlist: java.util.List[_] => {
+      case jlist: JavaList[_] => {
         if(!jlist.isEmpty) {
           val elem = jlist.get(0)
           if(elem.isInstanceOf[Document]) {
-            setFromDocumentList(jlist.asInstanceOf[java.util.List[Document]])
+            setFromDocumentList(jlist.asInstanceOf[JavaList[Document]])
           } else {
             setBox(Full(jlist.asScala.toList.asInstanceOf[MyType]))
           }
@@ -139,6 +153,7 @@ class MongoListField[OwnerType <: BsonRecord[OwnerType], ListType: Manifest](rec
   /*
   * Convert this field's value into a DBObject so it can be stored in Mongo.
   */
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def asDBObject: DBObject = {
     val dbl = new BasicDBList
 
@@ -154,11 +169,29 @@ class MongoListField[OwnerType <: BsonRecord[OwnerType], ListType: Manifest](rec
   }
 
   // set this field's value using a DBObject returned from Mongo.
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
   def setFromDBObject(dbo: DBObject): Box[MyType] =
     setBox(Full(dbo.asInstanceOf[BasicDBList].asScala.toList.asInstanceOf[MyType]))
 
-  def setFromDocumentList(list: java.util.List[Document]): Box[MyType] = {
+  @deprecated("This was replaced with the functions from 'BsonableField'.", "3.4.2")
+  def setFromDocumentList(list: JavaList[Document]): Box[MyType] = {
     throw new RuntimeException("Warning, setting Document as field with no conversion, probably not something you want to do")
   }
 
+  def setFromBsonReader(reader: BsonReader, context: DecoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Box[List[ListType]] = {
+    reader.getCurrentBsonType match {
+      case BsonType.NULL =>
+        reader.readNull()
+        Empty
+      case BsonType.ARRAY =>
+        setBox(tryo(readList(reader, context, registry, bsonTypeCodecMap).asInstanceOf[List[ListType]]))
+      case bsonType =>
+        Failure(s"Invalid BsonType for field ${name}: ${bsonType}")
+    }
+  }
+
+  def writeToBsonWriter(writer: BsonWriter, context: EncoderContext, registry: CodecRegistry, bsonTypeCodecMap: BsonTypeCodecMap): Unit = {
+    writer.writeName(name)
+    writeIterable(writer, value, context.getChildContext, registry)
+  }
 }

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoRefField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/MongoRefField.scala
@@ -45,7 +45,7 @@ trait MongoRefField[RefType <: MongoRecord[RefType], MyType] extends TypedField[
   /**
     * Find the referenced object
     */
-  def find = valueBox.flatMap(v => refMeta.findAny(v))
+  def find: Box[RefType] = valueBox.flatMap(v => refMeta.findAny(v))
 
   /**
     * Get the cacheable referenced object
@@ -102,44 +102,61 @@ trait MongoRefField[RefType <: MongoRecord[RefType], MyType] extends TypedField[
 
 class ObjectIdRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](
   @deprecatedName('rec) owner: OwnerType, val refMeta: MongoMetaRecord[RefType]
-) extends ObjectIdField[OwnerType](owner) with MongoRefField[RefType, ObjectId]
+) extends ObjectIdField[OwnerType](owner) with MongoRefField[RefType, ObjectId] {
+  override def find: Box[RefType] = valueBox.flatMap(v => refMeta.find(v))
+}
 
 class OptionalObjectIdRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](
   owner: OwnerType, val refMeta: MongoMetaRecord[RefType]
-) extends OptionalObjectIdField[OwnerType](owner) with MongoRefField[RefType, ObjectId]
+) extends OptionalObjectIdField[OwnerType](owner) with MongoRefField[RefType, ObjectId] {
+  override def find: Box[RefType] = valueBox.flatMap(v => refMeta.find(v))
+}
 
 
 class UUIDRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](
   @deprecatedName('rec) owner: OwnerType, val refMeta: MongoMetaRecord[RefType]
-) extends UUIDField[OwnerType](owner) with MongoRefField[RefType, UUID]
+) extends UUIDField[OwnerType](owner) with MongoRefField[RefType, UUID] {
+  override def find: Box[RefType] = valueBox.flatMap(v => refMeta.find(v))
+}
 
 class OptionalUUIDRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](
   owner: OwnerType, val refMeta: MongoMetaRecord[RefType]
-) extends OptionalUUIDField[OwnerType](owner) with MongoRefField[RefType, UUID]
-
+) extends OptionalUUIDField[OwnerType](owner) with MongoRefField[RefType, UUID] {
+  override def find: Box[RefType] = valueBox.flatMap(v => refMeta.find(v))
+}
 
 class StringRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](
   @deprecatedName('rec) owner: OwnerType, val refMeta: MongoMetaRecord[RefType], maxLen: Int
-) extends StringField[OwnerType](owner, maxLen) with MongoRefField[RefType, String]
+) extends StringField[OwnerType](owner, maxLen) with MongoRefField[RefType, String] {
+  override def find: Box[RefType] = valueBox.flatMap(v => refMeta.find(v))
+}
 
 class OptionalStringRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](
   owner: OwnerType, val refMeta: MongoMetaRecord[RefType], maxLen: Int
-) extends OptionalStringField[OwnerType](owner, maxLen) with MongoRefField[RefType, String]
-
+) extends OptionalStringField[OwnerType](owner, maxLen) with MongoRefField[RefType, String] {
+  override def find: Box[RefType] = valueBox.flatMap(v => refMeta.find(v))
+}
 
 class IntRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](
   @deprecatedName('rec) owner: OwnerType, val refMeta: MongoMetaRecord[RefType]
-) extends IntField[OwnerType](owner) with MongoRefField[RefType, Int]
+) extends IntField[OwnerType](owner) with MongoRefField[RefType, Int] {
+  override def find: Box[RefType] = valueBox.flatMap(v => refMeta.find(v))
+}
 
 class OptionalIntRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](
   owner: OwnerType, val refMeta: MongoMetaRecord[RefType]
-) extends OptionalIntField[OwnerType](owner) with MongoRefField[RefType, Int]
-
+) extends OptionalIntField[OwnerType](owner) with MongoRefField[RefType, Int] {
+  override def find: Box[RefType] = valueBox.flatMap(v => refMeta.find(v))
+}
 
 class LongRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](
   @deprecatedName('rec) owner: OwnerType, val refMeta: MongoMetaRecord[RefType]
-) extends LongField[OwnerType](owner) with MongoRefField[RefType, Long]
+) extends LongField[OwnerType](owner) with MongoRefField[RefType, Long] {
+  override def find: Box[RefType] = valueBox.flatMap(v => refMeta.find(v))
+}
 
 class OptionalLongRefField[OwnerType <: BsonRecord[OwnerType], RefType <: MongoRecord[RefType]](
   owner: OwnerType, val refMeta: MongoMetaRecord[RefType]
-) extends OptionalLongField[OwnerType](owner) with MongoRefField[RefType, Long]
+) extends OptionalLongField[OwnerType](owner) with MongoRefField[RefType, Long] {
+  override def find: Box[RefType] = valueBox.flatMap(v => refMeta.find(v))
+}

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/PatternField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/PatternField.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2010-2019 WorldWide Conferencing, LLC
+* Copyright 2010-2020 WorldWide Conferencing, LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@ import java.util.regex.Pattern
 import net.liftweb.common.{Box, Empty, Failure, Full}
 import net.liftweb.http.js.JE.{JsNull, Str}
 import net.liftweb.json._
-import net.liftweb.record.{Field, FieldHelpers, MandatoryTypedField, OptionalTypedField}
+import net.liftweb.record.{Field, FieldHelpers, MandatoryTypedField, OptionalTypedField, Record}
 import net.liftweb.util.Helpers.tryo
 
 import scala.xml.NodeSeq
 
-abstract class PatternTypedField[OwnerType <: BsonRecord[OwnerType]](val owner: OwnerType) extends Field[Pattern, OwnerType] {
+abstract class PatternTypedField[OwnerType <: Record[OwnerType]](val owner: OwnerType) extends Field[Pattern, OwnerType] {
   def setFromAny(in: Any): Box[Pattern] = in match {
     case p: Pattern => setBox(Full(p))
     case Some(p: Pattern) => setBox(Full(p))
@@ -37,7 +37,9 @@ abstract class PatternTypedField[OwnerType <: BsonRecord[OwnerType]](val owner: 
     case Full(s: String) => setFromString(s)
     case null|None|Empty => setBox(defaultValueBox)
     case f: Failure => setBox(f)
-    case o => setFromString(o.toString)
+    case o => {
+      setFromString(o.toString)
+    }
   }
 
   def setFromJValue(jvalue: JValue): Box[Pattern] = jvalue match {
@@ -77,7 +79,7 @@ abstract class PatternTypedField[OwnerType <: BsonRecord[OwnerType]](val owner: 
   }
 }
 
-class PatternField[OwnerType <: BsonRecord[OwnerType]](@deprecatedName('rec) owner: OwnerType) extends PatternTypedField[OwnerType](owner) with MandatoryTypedField[Pattern] {
+class PatternField[OwnerType <: Record[OwnerType]](@deprecatedName('rec) owner: OwnerType) extends PatternTypedField[OwnerType](owner) with MandatoryTypedField[Pattern] {
   def this(owner: OwnerType, value: Pattern) = {
     this(owner)
     setBox(Full(value))
@@ -86,7 +88,7 @@ class PatternField[OwnerType <: BsonRecord[OwnerType]](@deprecatedName('rec) own
   def defaultValue = Pattern.compile("")
 }
 
-class OptionalPatternField[OwnerType <: BsonRecord[OwnerType]](owner: OwnerType) extends PatternTypedField[OwnerType](owner) with OptionalTypedField[Pattern] {
+class OptionalPatternField[OwnerType <: Record[OwnerType]](owner: OwnerType) extends PatternTypedField[OwnerType](owner) with OptionalTypedField[Pattern] {
   def this(owner: OwnerType, value: Box[Pattern]) = {
     this(owner)
     setBox(value)

--- a/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/UUIDField.scala
+++ b/persistence/mongodb-record/src/main/scala/net/liftweb/mongodb/record/field/UUIDField.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2010-2017 WorldWide Conferencing, LLC
+* Copyright 2010-2020 WorldWide Conferencing, LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import net.liftweb.util.Helpers._
 
 import scala.xml.NodeSeq
 
-trait UUIDTypedField[OwnerType <: BsonRecord[OwnerType]] extends TypedField[UUID] with Field[UUID, OwnerType] {
+trait UUIDTypedField[OwnerType <: Record[OwnerType]] extends TypedField[UUID] with Field[UUID, OwnerType] {
   def setFromAny(in: Any): Box[UUID] = in match {
     case uid: UUID => setBox(Full(uid))
     case Some(uid: UUID) => setBox(Full(uid))
@@ -74,7 +74,7 @@ trait UUIDTypedField[OwnerType <: BsonRecord[OwnerType]] extends TypedField[UUID
   def asJValue: JValue = valueBox.map(v => JsonUUID(v)) openOr (JNothing: JValue)
 }
 
-class UUIDField[OwnerType <: BsonRecord[OwnerType]](@deprecatedName('rec) val owner: OwnerType)
+class UUIDField[OwnerType <: Record[OwnerType]](@deprecatedName('rec) val owner: OwnerType)
   extends UUIDTypedField[OwnerType] with MandatoryTypedField[UUID] {
 
   def this(owner: OwnerType, value: UUID) = {
@@ -86,7 +86,7 @@ class UUIDField[OwnerType <: BsonRecord[OwnerType]](@deprecatedName('rec) val ow
 
 }
 
-class OptionalUUIDField[OwnerType <: BsonRecord[OwnerType]](val owner: OwnerType)
+class OptionalUUIDField[OwnerType <: Record[OwnerType]](val owner: OwnerType)
   extends UUIDTypedField[OwnerType] with OptionalTypedField[UUID] {
 
   def this(owner: OwnerType, value: Box[UUID]) = {

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/BsonRecordSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/BsonRecordSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2013 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@ import org.specs2.mutable.Specification
 
 class BsonRecordSpec extends Specification with MongoTestKit {
   "BsonRecordSpec Specification".title
+
   import fixtures._
+  import testmodels._
 
   override def before = {
     super.before

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/CustomSerializersSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/CustomSerializersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,7 +174,7 @@ class CustomSerializersSpec extends Specification  with MongoTestKit {
       val mother = Person.createRecord
       mother.children(List(jack, jill))
       mother.firstBorn(jack)
-      mother.save()
+      mother.save
 
       // retrieve it and compare
       val mother2 = Person.find(mother.id.get)

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/Fixtures.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/Fixtures.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,18 +32,13 @@ import java.util.{Date, UUID}
 import java.util.regex.Pattern
 import scala.xml.Text
 
+import net.liftweb.mongodb.record.testmodels._
 import net.liftweb.record._
 import net.liftweb.record.field._
 import net.liftweb.record.field.joda._
 
 import org.bson.types.ObjectId
 import org.joda.time.DateTime
-
-object MyTestEnum extends Enumeration {
-  val ONE = Value("ONE")
-  val TWO = Value("TWO")
-  val THREE = Value("THREE")
-}
 
 trait HarnessedLifecycleCallbacks extends LifecycleCallbacks {
   this: BaseField =>
@@ -264,56 +259,6 @@ class PasswordTestRecord private () extends MongoRecord[PasswordTestRecord] with
 }
 object PasswordTestRecord extends PasswordTestRecord with MongoMetaRecord[PasswordTestRecord]
 
-case class CaseClassTestObject(intField: Int, stringField: String, enum: MyTestEnum.Value)
-
-class ListTestRecord private () extends MongoRecord[ListTestRecord] with UUIDPk[ListTestRecord] {
-  def meta = ListTestRecord
-
-  object mandatoryStringListField extends MongoListField[ListTestRecord, String](this)
-  object mandatoryMongoRefListField extends ObjectIdRefListField(this, FieldTypeTestRecord)
-  object mandatoryIntListField extends MongoListField[ListTestRecord, Int](this)
-  object mandatoryJsonObjectListField extends JsonObjectListField(this, TypeTestJsonObject)
-  object caseClassListField extends CaseClassListField[ListTestRecord, CaseClassTestObject](this) {
-    override def formats = owner.meta.formats
-  }
-}
-object ListTestRecord extends ListTestRecord with MongoMetaRecord[ListTestRecord] {
-  override def formats = allFormats + new EnumSerializer(MyTestEnum)
-}
-
-class MongoListTestRecord private () extends MongoRecord[MongoListTestRecord] with UUIDPk[MongoListTestRecord] {
-  def meta = MongoListTestRecord
-
-  object objectIdRefListField extends ObjectIdRefListField(this, FieldTypeTestRecord)
-  object patternListField extends MongoListField[MongoListTestRecord, Pattern](this)
-  object dateListField extends MongoListField[MongoListTestRecord, Date](this)
-  object uuidListField extends MongoListField[MongoListTestRecord, UUID](this)
-}
-object MongoListTestRecord extends MongoListTestRecord with MongoMetaRecord[MongoListTestRecord] {
-  override def formats = DefaultFormats.lossless + new ObjectIdSerializer + new PatternSerializer + new DateSerializer
-}
-
-class MongoJodaListTestRecord private () extends MongoRecord[MongoJodaListTestRecord] with UUIDPk[MongoJodaListTestRecord] {
-  def meta = MongoJodaListTestRecord
-
-  object dateTimeListField extends MongoListField[MongoJodaListTestRecord, DateTime](this)
-}
-object MongoJodaListTestRecord extends MongoJodaListTestRecord with MongoMetaRecord[MongoJodaListTestRecord] {
-  override def formats = DefaultFormats.lossless + new DateTimeSerializer
-}
-
-class MapTestRecord private () extends MongoRecord[MapTestRecord] with StringPk[MapTestRecord] {
-  def meta = MapTestRecord
-
-  object mandatoryStringMapField extends MongoMapField[MapTestRecord, String](this)
-  object mandatoryIntMapField extends MongoMapField[MapTestRecord, Int](this)
-
-  // TODO: More Map types, including JsonObject (will require a new Field type)
-}
-object MapTestRecord extends MapTestRecord with MongoMetaRecord[MapTestRecord] {
-  override def formats = allFormats
-}
-
 class LifecycleTestRecord private ()
   extends MongoRecord[LifecycleTestRecord]
   with ObjectIdPk[LifecycleTestRecord]
@@ -327,53 +272,6 @@ class LifecycleTestRecord private ()
 }
 
 object LifecycleTestRecord extends LifecycleTestRecord with MongoMetaRecord[LifecycleTestRecord]
-
-/*
- * SubRecord fields
- */
-class SubRecord private () extends BsonRecord[SubRecord] {
-  def meta = SubRecord
-
-  object name extends StringField(this, 12)
-  object subsub extends BsonRecordField(this, SubSubRecord)
-  object subsublist extends BsonRecordListField(this, SubSubRecord)
-  object when extends DateField(this)
-  object slist extends MongoListField[SubRecord, String](this)
-  object smap extends MongoMapField[SubRecord, String](this)
-  object oid extends ObjectIdField(this)
-  object pattern extends PatternField(this)
-  object uuid extends UUIDField(this)
-}
-object SubRecord extends SubRecord with BsonMetaRecord[SubRecord] {
-  override def formats = allFormats
-}
-
-class SubSubRecord private () extends BsonRecord[SubSubRecord] {
-  def meta = SubSubRecord
-
-  object name extends StringField(this, 12)
-}
-object SubSubRecord extends SubSubRecord with BsonMetaRecord[SubSubRecord] {
-  override def formats = allFormats
-}
-
-class SubRecordTestRecord private () extends MongoRecord[SubRecordTestRecord] with ObjectIdPk[SubRecordTestRecord] {
-  def meta = SubRecordTestRecord
-
-  object mandatoryBsonRecordField extends BsonRecordField(this, SubRecord)
-  object optioalBsonRecordField extends OptionalBsonRecordField(this, SubRecord)
-  object legacyOptionalBsonRecordField extends BsonRecordField(this, SubRecord) {
-    override def optional_? = true
-  }
-
-  object mandatoryBsonRecordListField extends BsonRecordListField(this, SubRecord)
-  object legacyOptionalBsonRecordListField extends BsonRecordListField(this, SubRecord) {
-    override def optional_? = true
-  }
-}
-object SubRecordTestRecord extends SubRecordTestRecord with MongoMetaRecord[SubRecordTestRecord] {
-  override def formats = allFormats
-}
 
 case class JsonObj(id: String, name: String) extends JsonObject[JsonObj] {
   def meta = JsonObj
@@ -435,17 +333,6 @@ class RefFieldTestRecord private () extends MongoRecord[RefFieldTestRecord] with
 }
 
 object RefFieldTestRecord extends RefFieldTestRecord with MongoMetaRecord[RefFieldTestRecord] {
-  override def formats = allFormats
-}
-
-
-class JObjectFieldTestRecord private () extends MongoRecord[JObjectFieldTestRecord]  with ObjectIdPk[JObjectFieldTestRecord] {
-  def meta = JObjectFieldTestRecord
-
-  object mandatoryJObjectField extends JObjectField(this)
-}
-
-object JObjectFieldTestRecord extends JObjectFieldTestRecord with MongoMetaRecord[JObjectFieldTestRecord] {
   override def formats = allFormats
 }
 

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/LegacyMongoClientSaveSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/LegacyMongoClientSaveSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 WorldWide Conferencing, LLC
+ * Copyright 2014-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.specs2.mutable.Specification
 import com.mongodb._
 
 
-package mongoclientsaverecords {
+package legacymongoclientsaverecords {
 
   import field._
 
@@ -44,12 +44,12 @@ package mongoclientsaverecords {
 
 
 /**
-  * Systems under specification for MongoClientSave.
+  * Systems under specification for LegacyMongoClientSave.
   */
-class MongoClientSaveSpec extends Specification with MongoTestKit {
-  "MongoClientSave Specification".title
+class LegacyMongoClientSaveSpec extends Specification with MongoTestKit {
+  "LegacyMongoClientSave Specification".title
 
-  import mongoclientsaverecords._
+  import legacymongoclientsaverecords._
 
   "MongoMetaRecord with Mongo save" in {
 

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/LegacyMongoRecordExamplesSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/LegacyMongoRecordExamplesSpec.scala
@@ -1,0 +1,522 @@
+/*
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+
+import java.util.{Calendar, Date, UUID}
+import java.util.regex.Pattern
+
+import net.liftweb.common.{Box, Empty, Failure, Full}
+import net.liftweb.json.DefaultFormats
+import net.liftweb.json.JsonDSL._
+import net.liftweb.record.field._
+import net.liftweb.util.TimeHelpers._
+import net.liftweb.mongodb.record.field._
+
+import org.specs2.mutable.Specification
+
+import com.mongodb._
+import org.bson.types.ObjectId
+import http.{S, LiftSession}
+
+
+package legacymongotestrecords {
+
+  import field._
+
+  class TstRecord private () extends MongoRecord[TstRecord] with UUIDPk[TstRecord] {
+
+    def meta = TstRecord
+
+    object booleanfield	extends BooleanField(this)
+    object datetimefield extends DateTimeField(this)
+    object doublefield extends DoubleField(this)
+    object emailfield extends EmailField(this, 220)
+    object intfield extends IntField(this)
+    object localefield extends LocaleField(this)
+    object longfield extends LongField(this)
+    object passwordfield extends MongoPasswordField(this)
+    object stringfield extends StringField(this, 32)
+    object timezonefield extends TimeZoneField(this)
+    object patternfield extends PatternField(this)
+    object datefield extends DateField(this)
+
+    // JsonObjectField (requires a definition for defaultValue)
+    object person extends JsonObjectField[TstRecord, Person](this, Person) {
+      def defaultValue = Person("", 0, Address("", ""), Nil)
+    }
+  }
+
+  object TstRecord extends TstRecord with MongoMetaRecord[TstRecord]
+
+  case class Address(street: String, city: String)
+  case class Child(name: String, age: Int, birthdate: Option[Date])
+
+  case class Person(name: String, age: Int, address: Address, children: List[Child])
+    extends JsonObject[Person] {
+    def meta = Person
+  }
+
+  object Person extends JsonObjectMeta[Person]
+
+  class MainDoc private () extends MongoRecord[MainDoc] with ObjectIdPk[MainDoc] {
+    def meta = MainDoc
+
+    object name extends StringField(this, 12)
+    object cnt extends IntField(this)
+    object refdocId extends ObjectIdRefField(this, RefDoc)
+    object refuuid extends UUIDRefField(this, RefUuidDoc)
+  }
+  object MainDoc extends MainDoc with MongoMetaRecord[MainDoc]
+
+  class RefDoc private () extends MongoRecord[RefDoc] with ObjectIdPk[RefDoc] {
+    def meta = RefDoc
+  }
+  object RefDoc extends RefDoc with MongoMetaRecord[RefDoc]
+
+  // uuid as id
+  class RefUuidDoc private () extends MongoRecord[RefUuidDoc] with UUIDPk[RefUuidDoc] {
+    def meta = RefUuidDoc
+  }
+  object RefUuidDoc extends RefUuidDoc with MongoMetaRecord[RefUuidDoc]
+
+  class ListDoc private () extends MongoRecord[ListDoc] with ObjectIdPk[ListDoc] {
+    def meta = ListDoc
+
+    import scala.collection.JavaConverters._
+
+    // standard list types
+    object name extends StringField(this, 10)
+    object stringlist extends MongoListField[ListDoc, String](this)
+    object intlist extends MongoListField[ListDoc, Int](this)
+    object doublelist extends MongoListField[ListDoc, Double](this)
+    object boollist extends MongoListField[ListDoc, Boolean](this)
+    object objidlist extends MongoListField[ListDoc, ObjectId](this)
+    object dtlist extends MongoListField[ListDoc, Date](this)
+    object patternlist extends MongoListField[ListDoc, Pattern](this)
+    object binarylist extends MongoListField[ListDoc, Array[Byte]](this)
+
+    // specialized list types
+    object jsonobjlist extends JsonObjectListField(this, JsonDoc)
+
+    // these require custom setFromDBObject methods
+    object maplist extends MongoListField[ListDoc, Map[String, String]](this) {
+      override def asDBObject: DBObject = {
+        val dbl = new BasicDBList
+
+        value.foreach {
+          m => {
+            val dbo = new BasicDBObject
+
+            m.keys.foreach(k => {
+              dbo.put(k.toString, m.getOrElse(k, ""))
+            })
+
+            dbl.add(dbo)
+          }
+        }
+
+        dbl
+      }
+
+      override def setFromDBObject(dbo: DBObject): Box[List[Map[String, String]]] = {
+        val lst: List[Map[String, String]] =
+          dbo.keySet.asScala.toList.map(dbo.get).collect {
+            case bdbo: BasicDBObject if bdbo.containsField("name") && bdbo.containsField("type") =>
+              Map("name"-> bdbo.getString("name"), "type" -> bdbo.getString("type"))
+          }
+        Full(set(lst))
+      }
+    }
+
+  }
+  object ListDoc extends ListDoc with MongoMetaRecord[ListDoc]
+
+  case class JsonDoc(id: String, name: String) extends JsonObject[JsonDoc] {
+    def meta = JsonDoc
+  }
+  object JsonDoc extends JsonObjectMeta[JsonDoc]
+
+  class MapDoc private () extends MongoRecord[MapDoc] with ObjectIdPk[MapDoc] {
+    def meta = MapDoc
+
+    object stringmap extends MongoMapField[MapDoc, String](this)
+  }
+  object MapDoc extends MapDoc with MongoMetaRecord[MapDoc] {
+    override def formats = DefaultFormats.lossless // adds .000
+  }
+
+  class OptionalDoc private () extends MongoRecord[OptionalDoc] with ObjectIdPk[OptionalDoc] {
+    def meta = OptionalDoc
+    // optional fields
+    object stringbox extends StringField(this, 32) {
+      override def optional_? = true
+      override def defaultValue = "nothin"
+    }
+  }
+  object OptionalDoc extends OptionalDoc with MongoMetaRecord[OptionalDoc]
+
+  class StrictDoc private () extends MongoRecord[StrictDoc] with ObjectIdPk[StrictDoc] {
+    def meta = StrictDoc
+    object name extends StringField(this, 32)
+  }
+  object StrictDoc extends StrictDoc with MongoMetaRecord[StrictDoc] {
+
+    import net.liftweb.json.JsonDSL._
+
+    createIndex(("name" -> 1), true) // unique name
+  }
+}
+
+
+/**
+ * Systems under specification for LegacyMongoRecordExamples.
+ */
+class LegacyMongoRecordExamplesSpec extends Specification with MongoTestKit {
+  "LegacyMongoRecordExamples Specification".title
+
+  import legacymongotestrecords._
+  import net.liftweb.util.TimeHelpers._
+
+  val session = new LiftSession("hello", "", Empty)
+  "TstRecord example" in {
+
+    checkMongoIsRunning
+
+    S.initIfUninitted(session) {
+
+      val pwd = "test"
+      val cal = Calendar.getInstance
+      cal.set(2009, 10, 2)
+
+      val tr = TstRecord.createRecord
+      tr.stringfield("test record string field")
+      tr.emailfield("test")
+      tr.validate.size must_== 2
+      tr.passwordfield.setPassword(pwd)
+      tr.emailfield("test@example.com")
+      tr.datetimefield(cal)
+      tr.patternfield(Pattern.compile("^Mo", Pattern.CASE_INSENSITIVE))
+      tr.validate.size must_== 0
+
+      // JsonObjectField
+      val dob1 = Calendar.getInstance.setYear(2005).setMonth(7).setDay(4)
+      val per = Person("joe", 27, Address("Bulevard", "Helsinki"), List(Child("Mary", 5, Some(dob1.getTime)), Child("Mazy", 3, None)))
+      tr.person(per)
+
+      // save the record in the db
+      tr.save()
+
+      // retrieve from db
+      def fromDb = TstRecord.find("_id", tr.id.value)
+
+      fromDb.isDefined must_== true
+
+      for (t <- fromDb) {
+        t.id.value must_== tr.id.value
+        t.booleanfield.value must_== tr.booleanfield.value
+        TstRecord.formats.dateFormat.format(t.datetimefield.value.getTime) must_==
+        TstRecord.formats.dateFormat.format(tr.datetimefield.value.getTime)
+        t.doublefield.value must_== tr.doublefield.value
+        t.intfield.value must_== tr.intfield.value
+        t.localefield.value must_== tr.localefield.value
+        t.longfield.value must_== tr.longfield.value
+        t.passwordfield.isMatch(pwd) must_== true
+        t.stringfield.value must_== tr.stringfield.value
+        t.timezonefield.value must_== tr.timezonefield.value
+        t.datetimefield.value must_== tr.datetimefield.value
+        t.patternfield.value.pattern must_== tr.patternfield.value.pattern
+        t.patternfield.value.flags must_== tr.patternfield.value.flags
+        t.datefield.value must_== tr.datefield.value
+        t.person.value.name must_== tr.person.value.name
+        t.person.value.age must_== tr.person.value.age
+        t.person.value.address.street must_== tr.person.value.address.street
+        t.person.value.address.city must_== tr.person.value.address.city
+        t.person.value.children.size must_== tr.person.value.children.size
+        for (i <- List.range(0, t.person.value.children.size-1)) {
+          t.person.value.children(i).name must_== tr.person.value.children(i).name
+          t.person.value.children(i).age must_== tr.person.value.children(i).age
+          t.person.value.children(i).birthdate must_== tr.person.value.children(i).birthdate
+        }
+      }
+
+      if (!debug) TstRecord.drop
+    }
+
+    success
+  }
+
+  "Ref example" in {
+
+    checkMongoIsRunning
+
+    val ref1 = RefDoc.createRecord
+    val ref2 = RefDoc.createRecord
+
+    ref1.save() must_== ref1
+    ref2.save() must_== ref2
+
+    val refUuid1 = RefUuidDoc.createRecord
+    val refUuid2 = RefUuidDoc.createRecord
+
+    refUuid1.save() must_== refUuid1
+    refUuid2.save() must_== refUuid2
+
+    val md1 = MainDoc.createRecord
+    val md2 = MainDoc.createRecord
+    val md3 = MainDoc.createRecord
+    val md4 = MainDoc.createRecord
+
+    md1.name.set("md1")
+    md2.name.set("md2")
+    md3.name.set("md3")
+    md4.name.set("md4")
+
+    md1.refdocId.set(ref1.id.get)
+    md2.refdocId.set(ref1.id.get)
+    md3.refdocId.set(ref2.id.get)
+    md4.refdocId.set(ref2.id.get)
+
+    md1.refuuid.set(refUuid1.id.get)
+    md2.refuuid.set(refUuid1.id.get)
+    md3.refuuid.set(refUuid2.id.get)
+    md4.refuuid.set(refUuid2.id.get)
+
+    md1.save() must_== md1
+    md2.save() must_== md2
+    md3.save() must_== md3
+    md4.save() must_== md4
+
+    MainDoc.count must_== 4
+    RefDoc.count must_== 2
+
+    // get the docs back from the db
+    MainDoc.find(md1.id.get).foreach(m => {
+      m.name.value must_== md1.name.value
+      m.cnt.value must_== md1.cnt.value
+      m.refdocId.value must_== md1.refdocId.value
+      m.refuuid.value must_== md1.refuuid.value
+    })
+
+    // fetch a refdoc
+    val refFromFetch = md1.refdocId.obj
+    refFromFetch.isDefined must_== true
+    refFromFetch.openOrThrowException("we know this is Full").id.get must_== ref1.id.get
+
+    // query for a single doc with a JObject query
+    val md1a = MainDoc.find(("name") -> "md1")
+    md1a.isDefined must_== true
+    md1a.foreach(o => o.id.get must_== md1.id.get)
+
+    // query for a single doc with a k, v query
+    val md1b = MainDoc.find("_id", md1.id.get)
+    md1b.isDefined must_== true
+    md1b.foreach(o => o.id.get must_== md1.id.get)
+
+    // query for a single doc with a Map query
+    val md1c = MainDoc.find(("name" -> "md1"))
+    md1c.isDefined must_== true
+    md1c.foreach(o => o.id.get must_== md1.id.get)
+
+    // find all documents
+    MainDoc.findAll.size must_== 4
+    RefDoc.findAll.size must_== 2
+
+    // find all documents with JObject query
+    val mdq1 = MainDoc.findAll(("name" -> "md1"))
+    mdq1.size must_== 1
+
+    // find all documents with $in query, sorted
+    val qry = ("name" -> ("$in" -> List("md1", "md2")))
+    val mdq2 = MainDoc.findAll(qry, ("name" -> -1))
+    mdq2.size must_== 2
+    mdq2.head.id.get must_== md2.id.get
+
+    // Find all documents using a k, v query
+    val mdq3 = MainDoc.findAll("_id", md1.id.get)
+    mdq3.size must_== 1
+
+    // find all documents with field selection
+    val mdq4 = MainDoc.findAll(("name" -> "md1"), ("name" -> 1), Empty)
+    mdq4.size must_== 1
+
+    // Upsert - this should add a new row
+    val md5 = MainDoc.createRecord
+    md5.name.set("md5")
+    md5.refdocId.set(ref1.id.get)
+    MainDoc.update(("name" -> "nothing"), md5, Upsert)
+    MainDoc.findAll.size must_== 5
+
+    // modifier operations $inc, $set, $push...
+    val o2 = (("$inc" -> ("cnt" -> 1)) ~ ("$set" -> ("name" -> "md1a")))
+    MainDoc.update(("name" -> "md1"), o2)
+    // get the doc back from the db and compare
+    val mdq5 = MainDoc.find("_id", md1.id.get)
+    mdq5.isDefined must_== true
+    mdq5.map ( m => {
+      m.name.value must_== "md1a"
+      m.cnt.value must_== 1
+    })
+
+    if (!debug) {
+      // delete them
+      md1.delete_!
+      md2.delete_!
+      md3.delete_!
+      md4.delete_!
+      md5.delete_!
+      ref1.delete_!
+      ref2.delete_!
+
+      MainDoc.findAll.size must_== 0
+
+      MainDoc.drop
+      RefDoc.drop
+    }
+
+    success
+  }
+
+  "List example" in {
+    checkMongoIsRunning
+
+    val ref1 = RefDoc.createRecord
+    val ref2 = RefDoc.createRecord
+
+    ref1.save() must_== ref1
+    ref2.save() must_== ref2
+
+    val name = "ld1"
+    val strlist = List("string1", "string2", "string3", "string1")
+    val jd1 = JsonDoc("1", "jsondoc1")
+
+    val ld1 = ListDoc.createRecord
+    ld1.name.set(name)
+    ld1.stringlist.set(strlist)
+    ld1.intlist.set(List(99988,88, 88))
+    ld1.doublelist.set(List(997655.998,88.8))
+    ld1.boollist.set(List(true,true,false))
+    ld1.objidlist.set(List(ObjectId.get, ObjectId.get))
+    ld1.dtlist.set(List(now, now))
+    ld1.jsonobjlist.set(List(jd1, JsonDoc("2", "jsondoc2"), jd1))
+    ld1.patternlist.set(List(Pattern.compile("^Mongo"), Pattern.compile("^Mongo2")))
+    ld1.maplist.set(List(Map("name" -> "map1", "type" -> "map"), Map("name" -> "map2", "type" -> "map")))
+    ld1.binarylist.set(List[Array[Byte]]("foo".getBytes(), "bar".getBytes()))
+
+    ld1.save() must_== ld1
+
+    val qld1 = ListDoc.find(ld1.id.get)
+
+    qld1.isDefined must_== true
+
+    qld1.foreach { l =>
+      l.name.value must_== ld1.name.value
+      l.stringlist.value must_== ld1.stringlist.value
+      l.intlist.value must_== ld1.intlist.value
+      l.doublelist.value must_== ld1.doublelist.value
+      l.boollist.value must_== ld1.boollist.value
+      l.objidlist.value must_== ld1.objidlist.value
+      l.dtlist.value must_== ld1.dtlist.value
+      l.jsonobjlist.value must_== ld1.jsonobjlist.value
+      for (i <- List.range(0, l.patternlist.value.size-1)) {
+        l.patternlist.value(i).pattern must_== ld1.patternlist.value(i).pattern
+      }
+      l.maplist.value must_== ld1.maplist.value
+      for (i <- List.range(0, l.jsonobjlist.value.size-1)) {
+        l.jsonobjlist.value(i).id must_== ld1.jsonobjlist.value(i).id
+        l.jsonobjlist.value(i).name must_== ld1.jsonobjlist.value(i).name
+      }
+      for {
+        orig <- ld1.binarylist.value.headOption
+        queried <- l.binarylist.value.headOption
+      } new String(orig) must_== new String(queried)
+    }
+
+    if (!debug) {
+      ListDoc.drop
+      RefDoc.drop
+    }
+
+    success
+  }
+
+  "Map Example" in {
+
+    checkMongoIsRunning
+
+    val md1 = MapDoc.createRecord
+    md1.stringmap.set(Map("h" -> "hola"))
+
+    md1.save() must_== md1
+
+    md1.delete_!
+
+    if (!debug) MapDoc.drop
+
+    success
+  }
+
+  "Optional Example" in {
+
+    checkMongoIsRunning
+
+    val od1 = OptionalDoc.createRecord
+    od1.stringbox.valueBox must_== Empty
+    od1.save() must_== od1
+
+    OptionalDoc.find(od1.id.get).foreach {
+      od1FromDB =>
+        od1FromDB.stringbox.valueBox must_== od1.stringbox.valueBox
+    }
+
+
+    val od2 = OptionalDoc.createRecord
+    od1.stringbox.valueBox must_== Empty
+    od2.stringbox.set("aloha")
+    od2.save() must_== od2
+
+    OptionalDoc.find(od2.id.get).foreach {
+      od2FromDB =>
+        od2FromDB.stringbox.valueBox must_== od2.stringbox.valueBox
+    }
+
+    if (!debug) OptionalDoc.drop
+
+    success
+  }
+
+  "Strict Example" in {
+
+    checkMongoIsRunning
+
+    val sd1 = StrictDoc.createRecord.name("sd1")
+    val sd2 = StrictDoc.createRecord.name("sd1")
+
+    sd1.save(true) must_== sd1
+    sd2.save(true) must throwA[MongoException]
+
+    sd1.save()
+
+    sd2.name("sd2")
+    sd2.save(true) must_== sd2
+
+    if (!debug) StrictDoc.drop
+
+    success
+  }
+}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoFieldSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 WorldWide Conferencing, LLC
+ * Copyright 2006-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ class MongoFieldSpec extends Specification with MongoTestKit with AroundEach {
   sequential
 
   import fixtures._
+  import testmodels._
 
   lazy val session = new LiftSession("", randomString(20), Empty)
 

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoRecordAsyncSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoRecordAsyncSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 WorldWide Conferencing, LLC
+ * Copyright 2017-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoTestKit.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/MongoTestKit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ object TestMongo {
   lazy val isMongoRunning: Boolean =
     try {
       // this will throw an exception if it can't connect to the db
-      mongo.getConnectPoint
+      mongo.listDatabases
       true
     } catch {
       case _: MongoTimeoutException =>
@@ -75,7 +75,7 @@ trait MongoTestKit extends Specification with BeforeAfterEach {
     if (!debug && TestMongo.isMongoRunning) {
       // drop the databases
       dbs.foreach { case (id, _) =>
-        MongoDB.use(id) { db => db.dropDatabase }
+        MongoDB.useDatabase(id) { db => db.drop() }
       }
     }
 

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/PlainRecordSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/PlainRecordSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+
+import org.specs2.mutable.Specification
+
+import org.bson._
+import org.bson.codecs.{DecoderContext, EncoderContext}
+
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.model.Filters.{eq => eqs}
+
+import net.liftweb.mongodb.record.testmodels._
+import net.liftweb.record._
+
+class PlainRecordSpec extends Specification with MongoTestKit {
+  "PlainRecordSpec Specification".title
+
+  /**
+   * Encodes then decodes a Record instance to/from Bson and asserts they are equal.
+   */
+  private def testEncodeDecode(record: RecordTest) = {
+    val bson = new BsonDocument()
+    val writer = new BsonDocumentWriter(bson)
+
+    RecordTestStore.codec.encode(writer, record, EncoderContext.builder.build)
+
+    val reader = new BsonDocumentReader(bson)
+    val result: RecordTest = RecordTestStore.codec.decode(reader, DecoderContext.builder.build)
+
+    result must_== record
+  }
+
+  override def before = {
+    super.before
+    checkMongoIsRunning
+  }
+
+  "Record" should {
+    "encode and decode properly" in {
+      val rec0 = RecordTest.createRecord
+      val rec1 = RecordTest.createRecord.stringfield("hello")
+
+      testEncodeDecode(rec0)
+      testEncodeDecode(rec1)
+    }
+
+    "save and find properly" in {
+      val rec0 = RecordTest.createRecord
+      val rec1 = RecordTest.createRecord.stringfield("hello")
+
+      RecordTestStore.collection.insertOne(rec0)
+      RecordTestStore.collection.insertOne(rec1)
+
+      val rec0fromDb = RecordTestStore.collection.find(eqs("_id", rec0.id.get)).first()
+      val rec1fromDb = RecordTestStore.collection.find(eqs("_id", rec1.id.get)).first()
+
+      rec0fromDb must_== rec0
+      rec1fromDb must_== rec1
+
+      MongoConfig.main.drop()
+
+      success
+    }
+  }
+}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/codecs/RecordCodecSpec.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/codecs/RecordCodecSpec.scala
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package codecs
+
+import java.util.{Calendar, Date, UUID}
+import java.util.regex.Pattern
+
+import org.bson.types.ObjectId
+import org.specs2.mutable.Specification
+
+import net.liftweb.common._
+import net.liftweb.json._
+import net.liftweb.json.JsonDSL._
+import net.liftweb.mongodb.record.fixtures._
+import net.liftweb.mongodb.record.testmodels._
+import net.liftweb.record.{MetaRecord, Record}
+import net.liftweb.util.Helpers._
+
+import com.mongodb._
+import org.bson._
+import org.bson.codecs.{BsonTypeClassMap, DecoderContext, EncoderContext}
+
+import org.joda.time.DateTime
+
+/**
+ * Systems under specification for RecordCodec.
+ */
+object RecordCodecSpec extends Specification {
+  "RecordCodec Specification".title
+
+  /**
+   * Encodes then decodes a BsonRecord instance to/from Bson and asserts they are equal.
+   */
+  private def testEncodeDecode[T <: BsonRecord[T]](metaRecord: BsonMetaRecord[T], record: T) = {
+    val bson = new BsonDocument()
+    val writer = new BsonDocumentWriter(bson)
+
+    metaRecord.codec.encode(writer, record, EncoderContext.builder.build)
+
+    val reader = new BsonDocumentReader(bson)
+    val result: T = metaRecord.codec.decode(reader, DecoderContext.builder.build)
+
+    result must_== record
+  }
+
+  "RecordCodec" should {
+
+    "support Binary fields" in {
+      val binData: Array[Byte] = Array(18, 19, 20)
+      val rec0 = BinaryTest.createRecord
+      val rec1 = BinaryTest.createRecord.binaryfield(binData)
+
+      testEncodeDecode(BinaryTest, rec0)
+      testEncodeDecode(BinaryTest, rec1)
+    }
+
+    "support Boolean fields" in {
+      val rec0 = BooleanTest.createRecord
+      val rec1 = BooleanTest.createRecord.booleanfield(true)
+      val rec2 = BooleanTest.createRecord.booleanfield(false)
+
+      testEncodeDecode(BooleanTest, rec0)
+      testEncodeDecode(BooleanTest, rec1)
+      testEncodeDecode(BooleanTest, rec2)
+    }
+
+    "support Calendar fields (DateTimeField)" in {
+      val rec0 = CalendarTest.createRecord
+      val rec1 = CalendarTest.createRecord.calendarfield(Calendar.getInstance)
+
+      testEncodeDecode(CalendarTest, rec0)
+      testEncodeDecode(CalendarTest, rec1)
+    }
+
+    "support Case Class fields" in {
+      val rec0 = CaseClassTest.createRecord
+      val tcc = TestCaseClass("hi", 9)
+      val rec1 = CaseClassTest.createRecord.caseclassfield(tcc)
+
+      testEncodeDecode(CaseClassTest, rec0)
+      testEncodeDecode(CaseClassTest, rec1)
+    }
+
+    "support Date fields" in {
+      val rec0 = DateTest.createRecord
+      val rec1 = DateTest.createRecord.datefield(new Date)
+
+      testEncodeDecode(DateTest, rec0)
+      testEncodeDecode(DateTest, rec1)
+    }
+
+    "support Decimal fields (legacy)" in {
+      val rec0 = LegacyDecimalTest.createRecord
+      val rec1 = LegacyDecimalTest.createRecord.decimalfield(BigDecimal("1234.25"))
+
+      testEncodeDecode(LegacyDecimalTest, rec0)
+      testEncodeDecode(LegacyDecimalTest, rec1)
+    }
+
+    "support Decimal fields" in {
+      val rec0 = DecimalTest.createRecord
+      val rec1 = DecimalTest.createRecord.decimalfield(BigDecimal("1234.25"))
+
+      testEncodeDecode(DecimalTest, rec0)
+      testEncodeDecode(DecimalTest, rec1)
+    }
+
+    "support Double fields" in {
+      val rec0 = DoubleTest.createRecord
+      val rec1 = DoubleTest.createRecord.doublefield(1234)
+
+      testEncodeDecode(DoubleTest, rec0)
+      testEncodeDecode(DoubleTest, rec1)
+    }
+
+    "support Enum fields" in {
+      val rec0 = EnumTest.createRecord
+      val rec1 = EnumTest.createRecord.enumfield(TestEnum.Three)
+
+      testEncodeDecode(EnumTest, rec0)
+      testEncodeDecode(EnumTest, rec1)
+    }
+
+    "support Int fields" in {
+      val rec0 = IntTest.createRecord
+      val rec1 = IntTest.createRecord.intfield(1234)
+
+      testEncodeDecode(IntTest, rec0)
+      testEncodeDecode(IntTest, rec1)
+    }
+
+    "support Long fields" in {
+      val rec0 = LongTest.createRecord
+      val rec1 = LongTest.createRecord.longfield(1234L)
+
+      testEncodeDecode(LongTest, rec0)
+      testEncodeDecode(LongTest, rec1)
+    }
+
+    "support String fields" in {
+      val rec0 = StringTest.createRecord
+      val rec1 = StringTest.createRecord.stringfield("abc")
+      val rec2 = StringTest.createRecord.optstringfield("def")
+      val rec3 = StringTest.createRecord.stringfield("abc").optstringfield("def")
+      val rec4 = StringTest.createRecord.stringfieldopt("abc")
+
+      testEncodeDecode(StringTest, rec0)
+      testEncodeDecode(StringTest, rec1)
+      testEncodeDecode(StringTest, rec2)
+      testEncodeDecode(StringTest, rec3)
+      testEncodeDecode(StringTest, rec4)
+    }
+
+    // joda
+    "support Joda DateTime fields (JodaTimeField)" in {
+      val rec0 = JodaTimeTest.createRecord
+      val rec1 = JodaTimeTest.createRecord.jodatimefield(DateTime.now)
+
+      testEncodeDecode(JodaTimeTest, rec0)
+      testEncodeDecode(JodaTimeTest, rec1)
+    }
+
+    // mongodb.record.field
+    "support BsonRecord fields" in {
+      val sub = TestSubRecord.createRecord.name("mrx")
+
+      val rec0 = BsonRecordTest.createRecord
+      val rec1 = BsonRecordTest.createRecord.bsonrecordfield(sub)
+      val rec2 = BsonRecordTest.createRecord.bsonrecordlistfield(List(sub))
+      val rec3 = BsonRecordTest.createRecord.bsonrecordmapfield(Map("a" -> sub))
+
+      testEncodeDecode(BsonRecordTest, rec0)
+      testEncodeDecode(BsonRecordTest, rec1)
+      testEncodeDecode(BsonRecordTest, rec2)
+      testEncodeDecode(BsonRecordTest, rec3)
+
+      val mrec0 = BsonRecordMapTest.createRecord
+      val mrec1 = BsonRecordMapTest.createRecord.bsonrecordmapfield(Map("a" -> sub))
+
+      testEncodeDecode(BsonRecordMapTest, mrec0)
+      testEncodeDecode(BsonRecordMapTest, mrec1)
+
+      val lrec0 = BsonRecordListTest.createRecord
+      val lrec1 = BsonRecordListTest.createRecord.bsonrecordlistfield(List(sub))
+
+      testEncodeDecode(BsonRecordListTest, lrec0)
+      testEncodeDecode(BsonRecordListTest, lrec1)
+    }
+
+    "support List fields" in {
+      val binData: Array[Byte] = Array(11, 19, 20)
+
+      val sub0 = FieldTypeTestRecord.createRecord
+      val sub1 = FieldTypeTestRecord.createRecord.mandatoryStringField("mrx")
+
+      val rec0 = ListTestRecord.createRecord
+      val rec1 = ListTestRecord.createRecord.mandatoryStringListField(List("a", "b"))
+      val rec2 = ListTestRecord.createRecord.mandatoryIntListField(List(1,12))
+      val rec3 = ListTestRecord.createRecord.mandatoryMongoRefListField(List(sub1.id.get))
+      val rec4 = ListTestRecord.createRecord.mandatoryMongoRefListField(List(sub0.id.get, sub1.id.get))
+      val rec5 = ListTestRecord.createRecord.mandatoryJsonObjectListField(List(TypeTestJsonObject(1, "jsonobj1", Map("x" -> "1")), TypeTestJsonObject(2, "jsonobj2", Map("x" -> "2"))))
+      val rec6 = ListTestRecord.createRecord.caseClassListField(List(CaseClassTestObject(12, "twelve", MyTestEnum.THREE)))
+
+      testEncodeDecode(ListTestRecord, rec0)
+      testEncodeDecode(ListTestRecord, rec1)
+      testEncodeDecode(ListTestRecord, rec2)
+      testEncodeDecode(ListTestRecord, rec3)
+      testEncodeDecode(ListTestRecord, rec4)
+      testEncodeDecode(ListTestRecord, rec5)
+      testEncodeDecode(ListTestRecord, rec6)
+
+      val mrec0 = MongoListTestRecord.createRecord
+      val mrec1 = MongoListTestRecord.createRecord.patternListField(List(Pattern.compile("^Mongo")))
+      val mrec2 = MongoListTestRecord.createRecord.dateListField(List(new Date))
+      val mrec3 = MongoListTestRecord.createRecord.uuidListField(List(UUID.randomUUID))
+
+      testEncodeDecode(MongoListTestRecord, mrec0)
+      testEncodeDecode(MongoListTestRecord, mrec1)
+      testEncodeDecode(MongoListTestRecord, mrec2)
+      testEncodeDecode(MongoListTestRecord, mrec3)
+
+      val brec0 = BasicListTestRecord.createRecord
+      val brec1 = BasicListTestRecord.createRecord.binaryListField(List(binData))
+      val brec2 = BasicListTestRecord.createRecord.booleanListField(List(false))
+      val brec3 = BasicListTestRecord.createRecord.decimalListField(List(BigDecimal(27.33)))
+      val brec4 = BasicListTestRecord.createRecord.doubleListField(List(12.34))
+      val brec5 = BasicListTestRecord.createRecord.longListField(List(876000L))
+      val brec6 = BasicListTestRecord.createRecord.stringListListField(List(List("abc")))
+      val brec7 = BasicListTestRecord.createRecord.stringMapListField(List(Map("key" -> "abc")))
+      val brec8 = BasicListTestRecord.createRecord.bigIntListField(List(BigInt(2000L)))
+
+      testEncodeDecode(BasicListTestRecord, brec0)
+      testEncodeDecode(BasicListTestRecord, brec1)
+      testEncodeDecode(BasicListTestRecord, brec2)
+      testEncodeDecode(BasicListTestRecord, brec3)
+      testEncodeDecode(BasicListTestRecord, brec4)
+      testEncodeDecode(BasicListTestRecord, brec5)
+      testEncodeDecode(BasicListTestRecord, brec6)
+      testEncodeDecode(BasicListTestRecord, brec7)
+      testEncodeDecode(BasicListTestRecord, brec8)
+
+      val jrec0 = MongoJodaListTestRecord.createRecord
+      val jrec1 = MongoJodaListTestRecord.createRecord.dateTimeListField(List(DateTime.now))
+
+      testEncodeDecode(MongoJodaListTestRecord, jrec0)
+      testEncodeDecode(MongoJodaListTestRecord, jrec1)
+    }
+
+    "support Map fields" in {
+      val binData: Array[Byte] = Array(12, 19, 20)
+
+      val sub0 = FieldTypeTestRecord.createRecord
+      val sub1 = FieldTypeTestRecord.createRecord.mandatoryStringField("mrx")
+
+      val rec0 = MapTest.createRecord
+      val rec1 = MapTest.createRecord.mandatoryStringMapField(Map("a" -> "b"))
+      val rec2 = MapTest.createRecord.mandatoryIntMapField(Map("one" -> 1, "twelve" -> 12))
+      val rec3 = MapTest.createRecord.binaryMapField(Map("bin" -> binData))
+      val rec4 = MapTest.createRecord.booleanMapField(Map("bool" -> false))
+      val rec5 = MapTest.createRecord.dateMapField(Map("when" -> new Date))
+      val rec6 = MapTest.createRecord.decimalMapField(Map("bigd" -> BigDecimal(1.23)))
+      val rec7 = MapTest.createRecord.doubleMapField(Map("double" -> 1234.0))
+      val rec8 = MapTest.createRecord.longMapField(Map("long" -> 1234L))
+      val rec9 = MapTest.createRecord.patternMapField(Map("regex" -> Pattern.compile("^Mongo")))
+      val rec10 = MapTest.createRecord.stringListMapField(Map("list" -> List("hello")))
+      val rec11 = MapTest.createRecord.stringMapMapField(Map("map" -> Map("a" -> "hello")))
+      val rec12 = MapTest.createRecord.uuidMapField(Map("id" -> UUID.randomUUID))
+
+      testEncodeDecode(MapTest, rec0)
+      testEncodeDecode(MapTest, rec1)
+      testEncodeDecode(MapTest, rec2)
+      testEncodeDecode(MapTest, rec3)
+      testEncodeDecode(MapTest, rec4)
+      testEncodeDecode(MapTest, rec5)
+      testEncodeDecode(MapTest, rec6)
+      testEncodeDecode(MapTest, rec7)
+      testEncodeDecode(MapTest, rec8)
+      testEncodeDecode(MapTest, rec9)
+      testEncodeDecode(MapTest, rec10)
+      testEncodeDecode(MapTest, rec11)
+      testEncodeDecode(MapTest, rec12)
+
+      val jrec0 = JodaTimeMapTest.createRecord
+      val jrec1 = JodaTimeMapTest.createRecord.jodatimeMapField(Map("dt" -> DateTime.now))
+
+      testEncodeDecode(JodaTimeMapTest, jrec0)
+      testEncodeDecode(JodaTimeMapTest, jrec1)
+    }
+
+    "support Pattern fields" in {
+      val rec0 = PatternTest.createRecord
+      val rec1 = PatternTest.createRecord.patternfield(Pattern.compile("^Mo", Pattern.CASE_INSENSITIVE))
+
+      testEncodeDecode(PatternTest, rec0)
+      testEncodeDecode(PatternTest, rec1)
+    }
+
+    "support UUID fields" in {
+      val rec0 = UUIDTest.createRecord
+      val rec1 = UUIDTest.createRecord.uuidfield(UUID.randomUUID)
+
+      testEncodeDecode(UUIDTest, rec0)
+      testEncodeDecode(UUIDTest, rec1)
+    }
+
+    "support JObject fields" in {
+      val joftrFieldJObject: JObject = ("minutes" -> 59)
+
+      val rec0 = JObjectFieldTestRecord.createRecord
+      val rec1 = JObjectFieldTestRecord.createRecord.mandatoryJObjectField(joftrFieldJObject)
+
+      testEncodeDecode(JObjectFieldTestRecord, rec0)
+      testEncodeDecode(JObjectFieldTestRecord, rec1)
+    }
+  }
+}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/BinaryTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/BinaryTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.field.BinaryField
+
+import com.mongodb._
+
+class BinaryTest private () extends MongoRecord[BinaryTest] with ObjectIdPk[BinaryTest] {
+
+  def meta = BinaryTest
+
+  object binaryfield extends BinaryField(this) {}
+}
+
+object BinaryTest extends BinaryTest with MongoMetaRecord[BinaryTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/BooleanTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/BooleanTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.field.BooleanField
+
+import com.mongodb._
+
+class BooleanTest private () extends MongoRecord[BooleanTest] with ObjectIdPk[BooleanTest] {
+
+  def meta = BooleanTest
+
+  object booleanfield extends BooleanField(this)
+}
+
+object BooleanTest extends BooleanTest with MongoMetaRecord[BooleanTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/BsonRecordTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/BsonRecordTest.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.field.StringField
+
+import com.mongodb._
+
+import org.bson.codecs.Codec
+import org.bson.codecs.configuration.CodecRegistries
+
+class TestSubRecord private () extends BsonRecord[TestSubRecord] {
+  def meta = TestSubRecord
+
+  object name extends StringField(this, 12)
+}
+object TestSubRecord extends TestSubRecord with BsonMetaRecord[TestSubRecord] {
+  override def formats = allFormats
+}
+
+
+class BsonRecordTest private () extends MongoRecord[BsonRecordTest] with ObjectIdPk[BsonRecordTest] {
+
+  def meta = BsonRecordTest
+
+  object bsonrecordfield extends BsonRecordField(this, TestSubRecord)
+  object bsonrecordlistfield extends BsonRecordListField(this, TestSubRecord)
+  object bsonrecordmapfield extends BsonRecordMapField(this, TestSubRecord)
+}
+
+object BsonRecordTest extends BsonRecordTest with MongoMetaRecord[BsonRecordTest]
+
+/*
+ * SubRecord fields
+ */
+class SubRecord private () extends BsonRecord[SubRecord] {
+  def meta = SubRecord
+
+  object name extends StringField(this, 12)
+  object subsub extends BsonRecordField(this, SubSubRecord)
+  object subsublist extends BsonRecordListField(this, SubSubRecord)
+  object when extends DateField(this)
+  object slist extends MongoListField[SubRecord, String](this)
+  object smap extends MongoMapField[SubRecord, String](this)
+  object oid extends ObjectIdField(this)
+  object pattern extends PatternField(this)
+  object uuid extends UUIDField(this)
+}
+object SubRecord extends SubRecord with BsonMetaRecord[SubRecord] {
+  override def formats = allFormats
+}
+
+class SubSubRecord private () extends BsonRecord[SubSubRecord] {
+  def meta = SubSubRecord
+
+  object name extends StringField(this, 12)
+}
+object SubSubRecord extends SubSubRecord with BsonMetaRecord[SubSubRecord] {
+  override def formats = allFormats
+}
+
+class SubRecordTestRecord private () extends MongoRecord[SubRecordTestRecord] with ObjectIdPk[SubRecordTestRecord] {
+  def meta = SubRecordTestRecord
+
+  object mandatoryBsonRecordField extends BsonRecordField(this, SubRecord)
+  object optioalBsonRecordField extends OptionalBsonRecordField(this, SubRecord)
+  object legacyOptionalBsonRecordField extends BsonRecordField(this, SubRecord) {
+    override def optional_? = true
+  }
+
+  object mandatoryBsonRecordListField extends BsonRecordListField(this, SubRecord)
+  object legacyOptionalBsonRecordListField extends BsonRecordListField(this, SubRecord) {
+    override def optional_? = true
+  }
+}
+object SubRecordTestRecord extends SubRecordTestRecord with MongoMetaRecord[SubRecordTestRecord] {
+  override def formats = allFormats
+}
+
+class BsonRecordMapTest private () extends MongoRecord[BsonRecordMapTest] with ObjectIdPk[BsonRecordMapTest] {
+
+  def meta = BsonRecordMapTest
+
+  object bsonrecordmapfield extends BsonRecordMapField(this, TestSubRecord)
+}
+
+object BsonRecordMapTest extends BsonRecordMapTest with MongoMetaRecord[BsonRecordMapTest]
+
+class BsonRecordListTest private () extends MongoRecord[BsonRecordListTest] with ObjectIdPk[BsonRecordListTest] {
+
+  def meta = BsonRecordListTest
+
+  object bsonrecordlistfield extends BsonRecordListField(this, TestSubRecord)
+}
+
+object BsonRecordListTest extends BsonRecordListTest with MongoMetaRecord[BsonRecordListTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/CalendarTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/CalendarTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import java.util.{Date, GregorianCalendar}
+
+import net.liftweb.common._
+import net.liftweb.mongodb.codecs.{BsonTypeClassMap, CalendarCodec}
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.field.DateTimeField
+
+import org.bson.BsonType
+import org.bson.codecs.configuration.CodecRegistries
+
+import com.mongodb._
+
+class CalendarTest private () extends MongoRecord[CalendarTest] with ObjectIdPk[CalendarTest] {
+
+  def meta = CalendarTest
+
+  object calendarfield extends DateTimeField(this)
+}
+
+object CalendarTest extends CalendarTest with MongoMetaRecord[CalendarTest] {
+
+  override def codecRegistry = CodecRegistries.fromRegistries(
+    CodecRegistries.fromCodecs(CalendarCodec()),
+    super.codecRegistry
+  )
+
+  override def bsonTypeClassMap = BsonTypeClassMap((BsonType.DATE_TIME -> classOf[GregorianCalendar]))
+}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/CaseClassTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/CaseClassTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+
+import com.mongodb._
+
+case class TestCaseClass(a: String, b: Int)
+
+class CaseClassTest private () extends MongoRecord[CaseClassTest] with ObjectIdPk[CaseClassTest] {
+
+  def meta = CaseClassTest
+
+  object caseclassfield extends CaseClassField[CaseClassTest, TestCaseClass](this)
+}
+
+object CaseClassTest extends CaseClassTest with MongoMetaRecord[CaseClassTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/DateTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/DateTest.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.mongodb.record.field._
+
+class DateTest private () extends MongoRecord[DateTest] with ObjectIdPk[DateTest] {
+
+  def meta = DateTest
+
+  object datefield extends DateField(this)
+}
+
+object DateTest extends DateTest with MongoMetaRecord[DateTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/DecimalTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/DecimalTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import java.math.MathContext
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.mongodb.record.codecs.RecordCodec
+import net.liftweb.record.field.DecimalField
+
+import com.mongodb._
+
+class DecimalTest private () extends MongoRecord[DecimalTest] with ObjectIdPk[DecimalTest] {
+
+  def meta = DecimalTest
+
+  object decimalfield extends DecimalField(this, MathContext.UNLIMITED, 2)
+}
+
+object DecimalTest extends DecimalTest with MongoMetaRecord[DecimalTest] {
+  override def codecRegistry = RecordCodec.defaultRegistry
+  override def bsonTypeClassMap = RecordCodec.defaultBsonTypeClassMap
+}
+
+class LegacyDecimalTest private () extends MongoRecord[LegacyDecimalTest] with ObjectIdPk[LegacyDecimalTest] {
+
+  def meta = LegacyDecimalTest
+
+  object decimalfield extends DecimalField(this, MathContext.UNLIMITED, 2)
+}
+
+object LegacyDecimalTest extends LegacyDecimalTest with MongoMetaRecord[LegacyDecimalTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/DoubleTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/DoubleTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.field.DoubleField
+
+import com.mongodb._
+
+class DoubleTest private () extends MongoRecord[DoubleTest] with ObjectIdPk[DoubleTest] {
+
+  def meta = DoubleTest
+
+  object doublefield extends DoubleField(this)
+}
+
+object DoubleTest extends DoubleTest with MongoMetaRecord[DoubleTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/EnumTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/EnumTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.Field
+import net.liftweb.record.field._
+
+import com.mongodb._
+
+import org.bson._
+import org.bson.codecs._
+import org.bson.codecs.configuration.{CodecProvider, CodecRegistries, CodecRegistry}
+
+object TestEnum extends Enumeration {
+  val One = Value("One")
+  val Two = Value("Two")
+  val Three = Value("Three")
+}
+
+class EnumTest private () extends MongoRecord[EnumTest] with ObjectIdPk[EnumTest] {
+
+  def meta = EnumTest
+
+  object enumfield extends EnumField(this, TestEnum)
+  object enumnamefield extends EnumNameField(this, TestEnum)
+}
+
+object EnumTest extends EnumTest with MongoMetaRecord[EnumTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/IntTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/IntTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.field.IntField
+
+import com.mongodb._
+
+class IntTest private () extends MongoRecord[IntTest] with ObjectIdPk[IntTest] {
+
+  def meta = IntTest
+
+  object intfield extends IntField(this)
+}
+
+object IntTest extends IntTest with MongoMetaRecord[IntTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/JObjectTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/JObjectTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+
+import com.mongodb._
+
+class JObjectFieldTestRecord private () extends MongoRecord[JObjectFieldTestRecord]  with ObjectIdPk[JObjectFieldTestRecord] {
+  def meta = JObjectFieldTestRecord
+
+  object mandatoryJObjectField extends JObjectField(this)
+}
+
+object JObjectFieldTestRecord extends JObjectFieldTestRecord with MongoMetaRecord[JObjectFieldTestRecord] {
+  override def formats = allFormats
+}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/JodaTimeTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/JodaTimeTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.codecs.{BsonTypeClassMap, JodaDateTimeCodec}
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.field.joda.JodaTimeField
+
+import com.mongodb._
+
+import org.bson.BsonType
+import org.bson.codecs.configuration.CodecRegistries
+
+import org.joda.time.DateTime
+
+class JodaTimeTest private () extends MongoRecord[JodaTimeTest] with ObjectIdPk[JodaTimeTest] {
+
+  def meta = JodaTimeTest
+
+  object jodatimefield extends JodaTimeField(this)
+}
+
+object JodaTimeTest extends JodaTimeTest with MongoMetaRecord[JodaTimeTest] {}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/ListTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/ListTest.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import fixtures._
+
+import java.util.{Date, UUID}
+import java.util.regex.Pattern
+
+import net.liftweb.common._
+import net.liftweb.json._
+import net.liftweb.json.ext.EnumSerializer
+import net.liftweb.mongodb.codecs.{BigIntLongCodec, BsonTypeClassMap, JodaDateTimeCodec}
+import net.liftweb.mongodb.record.codecs.{RecordCodec}
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.field.IntField
+
+import org.bson.BsonType
+import org.bson.codecs.configuration.CodecRegistries
+import org.bson.types.ObjectId
+import org.joda.time.DateTime
+
+import com.mongodb._
+
+class BasicListTestRecord private () extends MongoRecord[BasicListTestRecord] with UUIDPk[BasicListTestRecord] {
+  def meta = BasicListTestRecord
+
+  object bigIntListField extends MongoListField[BasicListTestRecord, BigInt](this)
+  object binaryListField extends MongoListField[BasicListTestRecord, Array[Byte]](this)
+  object booleanListField extends MongoListField[BasicListTestRecord, Boolean](this)
+  object decimalListField extends MongoListField[BasicListTestRecord, BigDecimal](this)
+  object doubleListField extends MongoListField[BasicListTestRecord, Double](this)
+  object longListField extends MongoListField[BasicListTestRecord, Long](this)
+  object stringListListField extends MongoListField[BasicListTestRecord, List[String]](this)
+  object stringMapListField extends MongoListField[BasicListTestRecord, Map[String, String]](this)
+}
+
+object BasicListTestRecord extends BasicListTestRecord with MongoMetaRecord[BasicListTestRecord] {
+  override def formats = allFormats
+
+  override def codecRegistry = CodecRegistries.fromRegistries(
+    CodecRegistries.fromCodecs(BigIntLongCodec()),
+    RecordCodec.defaultRegistry
+  )
+  override def bsonTypeClassMap = RecordCodec.defaultBsonTypeClassMap
+}
+
+class ListTestRecord private () extends MongoRecord[ListTestRecord] with UUIDPk[ListTestRecord] {
+  def meta = ListTestRecord
+
+  object mandatoryStringListField extends MongoListField[ListTestRecord, String](this)
+  object mandatoryMongoRefListField extends ObjectIdRefListField(this, FieldTypeTestRecord)
+  object mandatoryIntListField extends MongoListField[ListTestRecord, Int](this)
+  object mandatoryJsonObjectListField extends JsonObjectListField(this, TypeTestJsonObject)
+  object caseClassListField extends CaseClassListField[ListTestRecord, CaseClassTestObject](this) {
+    override def formats = owner.meta.formats
+  }
+}
+
+object ListTestRecord extends ListTestRecord with MongoMetaRecord[ListTestRecord] {
+  override def formats = allFormats + new EnumSerializer(MyTestEnum)
+}
+
+
+class MongoListTestRecord private () extends MongoRecord[MongoListTestRecord] with UUIDPk[MongoListTestRecord] {
+  def meta = MongoListTestRecord
+
+  object objectIdRefListField extends ObjectIdRefListField(this, FieldTypeTestRecord)
+
+  object patternListField extends MongoListField[MongoListTestRecord, Pattern](this) {
+    override def equals(other: Any): Boolean = {
+      other match {
+        case that: MongoListField[MongoListTestRecord, Pattern] =>
+          that.value.corresponds(this.value) { (a,b) =>
+            a.pattern == b.pattern && a.flags == b.flags
+          }
+        case _ =>
+          false
+      }
+    }
+  }
+
+  object dateListField extends MongoListField[MongoListTestRecord, Date](this)
+  object uuidListField extends MongoListField[MongoListTestRecord, UUID](this)
+}
+
+object MongoListTestRecord extends MongoListTestRecord with MongoMetaRecord[MongoListTestRecord] {
+  override def formats = DefaultFormats.lossless + new ObjectIdSerializer + new PatternSerializer + new DateSerializer
+}
+
+
+class MongoJodaListTestRecord private () extends MongoRecord[MongoJodaListTestRecord] with UUIDPk[MongoJodaListTestRecord] {
+  def meta = MongoJodaListTestRecord
+
+  object dateTimeListField extends MongoListField[MongoJodaListTestRecord, DateTime](this)
+}
+
+object MongoJodaListTestRecord extends MongoJodaListTestRecord with MongoMetaRecord[MongoJodaListTestRecord] {
+  override def formats = DefaultFormats.lossless + new DateTimeSerializer
+  override def bsonTypeClassMap: BsonTypeClassMap = BsonTypeClassMap((BsonType.DATE_TIME -> classOf[DateTime]))
+}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/LongTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/LongTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.field.LongField
+
+import com.mongodb._
+
+class LongTest private () extends MongoRecord[LongTest] with ObjectIdPk[LongTest] {
+
+  def meta = LongTest
+
+  object longfield extends LongField(this)
+}
+
+object LongTest extends LongTest with MongoMetaRecord[LongTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/MapTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/MapTest.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import fixtures._
+
+import java.util.{Date, UUID}
+import java.util.regex.Pattern
+
+import net.liftweb.common._
+import net.liftweb.json._
+import net.liftweb.json.ext.EnumSerializer
+import net.liftweb.mongodb.codecs.{BsonTypeClassMap, JodaDateTimeCodec}
+import net.liftweb.mongodb.record.codecs.RecordCodec
+import net.liftweb.mongodb.record.field._
+
+import org.bson.{BsonDocument, BsonType}
+import org.bson.codecs.configuration.CodecRegistries
+import org.bson.types.ObjectId
+import org.joda.time.DateTime
+
+import com.mongodb._
+
+class MapTest private () extends MongoRecord[MapTest] with StringPk[MapTest] {
+  def meta = MapTest
+
+  object mandatoryStringMapField extends MongoMapField[MapTest, String](this)
+  object mandatoryIntMapField extends MongoMapField[MapTest, Int](this)
+
+  object binaryMapField extends MongoMapField[MapTest, Array[Byte]](this)
+  object booleanMapField extends MongoMapField[MapTest, Boolean](this)
+  object dateMapField extends MongoMapField[MapTest, Date](this)
+  object decimalMapField extends MongoMapField[MapTest, BigDecimal](this)
+  object doubleMapField extends MongoMapField[MapTest, Double](this)
+  object longMapField extends MongoMapField[MapTest, Long](this)
+
+  object patternMapField extends MongoMapField[MapTest, Pattern](this) {
+    override def equals(other: Any): Boolean = {
+      other match {
+        case that: MongoMapField[MapTest, Pattern] =>
+          that.value.toSeq.corresponds(this.value.toSeq) { (a,b) =>
+            a._1 == b._1 && // keys
+            a._2.pattern == b._2.pattern && a._2.flags == b._2.flags
+          }
+        case _ =>
+          false
+      }
+    }
+  }
+
+  object stringListMapField extends MongoMapField[MapTest, List[String]](this)
+  object stringMapMapField extends MongoMapField[MapTest, Map[String, String]](this)
+  object uuidMapField extends MongoMapField[MapTest, UUID](this)
+}
+
+object MapTest extends MapTest with MongoMetaRecord[MapTest] {
+  override def formats = allFormats
+
+  override def codecRegistry = RecordCodec.defaultRegistry
+  override def bsonTypeClassMap = BsonTypeClassMap(
+    (BsonType.REGULAR_EXPRESSION -> classOf[Pattern]),
+    (BsonType.BINARY -> classOf[Array[Byte]]),
+    (BsonType.DECIMAL128 -> classOf[BigDecimal]),
+    (BsonType.DOCUMENT, classOf[BsonDocument])
+  )
+}
+
+class MapTestRecord private () extends MongoRecord[MapTestRecord] with StringPk[MapTestRecord] {
+  def meta = MapTestRecord
+
+  object mandatoryStringMapField extends MongoMapField[MapTestRecord, String](this)
+  object mandatoryIntMapField extends MongoMapField[MapTestRecord, Int](this)
+}
+
+object MapTestRecord extends MapTestRecord with MongoMetaRecord[MapTestRecord] {
+  override def formats = allFormats
+}
+
+class JodaTimeMapTest private () extends MongoRecord[JodaTimeMapTest] with ObjectIdPk[JodaTimeMapTest] {
+
+  def meta = JodaTimeMapTest
+
+  object jodatimeMapField extends MongoMapField[JodaTimeMapTest, DateTime](this)
+}
+
+object JodaTimeMapTest extends JodaTimeMapTest with MongoMetaRecord[JodaTimeMapTest] {
+  override def bsonTypeClassMap: BsonTypeClassMap = BsonTypeClassMap((BsonType.DATE_TIME -> classOf[DateTime]))
+}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/PatternTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/PatternTest.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+
+import com.mongodb._
+
+class PatternTest private () extends MongoRecord[PatternTest] with ObjectIdPk[PatternTest] {
+
+  def meta = PatternTest
+
+  object patternfield extends PatternField(this)
+}
+
+object PatternTest extends PatternTest with MongoMetaRecord[PatternTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/RecordTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/RecordTest.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import scala.util.Random
+
+import net.liftweb.common._
+import net.liftweb.record._
+import net.liftweb.record.field._
+
+import org.bson._
+import org.bson.codecs.{DecoderContext, EncoderContext}
+import org.bson.codecs.configuration.{CodecRegistry, CodecRegistries}
+
+import com.mongodb._
+import com.mongodb.client.{MongoClients, MongoCollection}
+import com.mongodb.client.model.Filters.{eq => eqs}
+
+import net.liftweb.mongodb.codecs.{BigDecimalCodec, BsonTypeClassMap}
+import net.liftweb.mongodb.record.codecs.CollectibleRecordCodec
+import net.liftweb.mongodb.record.testmodels._
+import net.liftweb.record._
+
+class RecordTest private () extends Record[RecordTest] {
+
+  def meta = RecordTest
+
+  object id extends IntField(this) {
+    override def name = "_id"
+    override def defaultValue = Random.nextInt
+  }
+
+  object stringfield extends StringField(this, 100)
+}
+
+object RecordTest extends RecordTest with MetaRecord[RecordTest]
+
+object MongoConfig {
+  val defaultBsonTypeClassMap: BsonTypeClassMap =
+    BsonTypeClassMap(
+      (BsonType.BINARY -> classOf[Array[Byte]]),
+      (BsonType.DECIMAL128 -> classOf[BigDecimal]),
+      (BsonType.DOCUMENT, classOf[BsonDocument])
+    )
+
+  val defaultRegistry: CodecRegistry = CodecRegistries.fromRegistries(
+    MongoClientSettings.getDefaultCodecRegistry(),
+    CodecRegistries.fromCodecs(BigDecimalCodec())
+  )
+
+  private val mongoClient = MongoClients.create()
+
+  val main = mongoClient.getDatabase("record_test_db")
+}
+
+object RecordTestStore {
+  val codec = CollectibleRecordCodec(RecordTest, MongoConfig.defaultRegistry, MongoConfig.defaultBsonTypeClassMap)
+
+  private val registry = CodecRegistries.fromRegistries(
+    CodecRegistries.fromCodecs(codec),
+    MongoConfig.defaultRegistry
+  )
+
+  val collection: MongoCollection[RecordTest] = MongoConfig.main.getCollection("record_test", classOf[RecordTest]).withCodecRegistry(registry)
+}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/StringTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/StringTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record.field.{OptionalStringField, StringField}
+
+import com.mongodb._
+
+class StringTest private () extends MongoRecord[StringTest] with ObjectIdPk[StringTest] {
+
+  def meta = StringTest
+
+  object stringfield extends StringField(this, 100)
+  object optstringfield extends OptionalStringField(this, 100)
+  object stringfieldopt extends StringField(this, 100) {
+    override def optional_? = true
+  }
+}
+
+object StringTest extends StringTest with MongoMetaRecord[StringTest]

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/TestModels.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/TestModels.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+case class CaseClassTestObject(intField: Int, stringField: String, enum: MyTestEnum.Value)
+
+object MyTestEnum extends Enumeration {
+  val ONE = Value("ONE")
+  val TWO = Value("TWO")
+  val THREE = Value("THREE")
+}

--- a/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/UUIDTest.scala
+++ b/persistence/mongodb-record/src/test/scala/net/liftweb/mongodb/record/testmodels/UUIDTest.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package record
+package testmodels
+
+import net.liftweb.common._
+import net.liftweb.mongodb.record.field._
+
+import com.mongodb._
+
+class UUIDTest private () extends MongoRecord[UUIDTest] with ObjectIdPk[UUIDTest] {
+
+  def meta = UUIDTest
+
+  object uuidfield extends UUIDField(this)
+}
+
+object UUIDTest extends UUIDTest with MongoMetaRecord[UUIDTest]

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/BsonParser.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/BsonParser.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+
+import scala.collection.JavaConverters._
+
+import java.util.{Date, UUID}
+import java.util.regex.Pattern
+
+import net.liftweb.json._
+import net.liftweb.common.Box
+import net.liftweb.util.SimpleInjector
+
+import com.mongodb.{BasicDBObject, BasicDBList, DBObject}
+import org.bson.types.ObjectId
+import org.bson._
+
+object BsonParser extends SimpleInjector {
+  /**
+    * Set this to override BsonParser turning strings that are valid
+    * ObjectIds into actual ObjectIds. For example, place the following in Boot.boot:
+    *
+    * <code>BsonParser.stringProcessor.default.set((s: String) => BsonString(s))</code>
+    */
+  val stringProcessor = new Inject(() => defaultStringProcessor _) {}
+
+  def defaultStringProcessor(s: String): BsonValue = {
+    if (ObjectId.isValid(s)) new BsonObjectId(new ObjectId(s))
+    else new BsonString(s)
+  }
+
+  /**
+   * Parse a JObject into a BsonDocument
+   */
+  def parse(jo: JObject)(implicit formats: Formats): BsonDocument =
+    Parser.parse(jo, formats)
+
+  /*
+  * Serialize a BsonDocument into a JObject
+  */
+  def serialize(a: Any)(implicit formats: Formats): JValue = {
+    import mongodb.Meta.Reflection._
+    a.asInstanceOf[AnyRef] match {
+      case null => JNull
+      case x if primitive_?(x.getClass) => primitive2jvalue(x)
+      case x if datetype_?(x.getClass) => datetype2jvalue(x)(formats)
+      case x if mongotype_?(x.getClass) => mongotype2jvalue(x)(formats)
+      case x if bsontype_?(x.getClass) => bsontype2jvalue(x)(formats)
+      case x: BasicDBList => JArray(x.asScala.toList.map(x => serialize(x)(formats)))
+      case x: BasicDBObject => JObject(
+        x.keySet.asScala.toList.map { f =>
+          JField(f.toString, serialize(x.get(f.toString))(formats))
+        }
+      )
+      case x: BsonDocument => JObject(
+        x.keySet.asScala.toList.map { f =>
+          JField(f.toString, serialize(x.get(f.toString))(formats))
+        }
+      )
+      case x: BsonArray =>
+        JArray(x.getValues.asScala.toList.map(x => serialize(x)(formats)))
+      case x =>
+        JNothing
+    }
+  }
+
+  object Parser {
+
+    def parse(jo: JObject, formats: Formats): BsonDocument = {
+      parseObject(jo.obj)(formats)
+    }
+
+    private def parseArray(arr: List[JValue])(implicit formats: Formats): BsonArray = {
+      val dbl = new BsonArray
+      trimArr(arr).map { a =>
+        a match {
+          case JsonObjectId(objectId) => dbl.add(new BsonObjectId(objectId))
+          case JsonRegex(pattern) => dbl.add(new BsonRegularExpression(pattern.pattern, PatternHelper.flagsToString(pattern.flags)))
+          case JsonUUID(uuid) => dbl.add(new BsonBinary(uuid, UuidRepresentation.JAVA_LEGACY))
+          case JsonDate(date) => dbl.add(new BsonDateTime(date.getTime))
+          case JArray(arr) => dbl.add(parseArray(arr))
+          case JObject(jo) => dbl.add(parseObject(jo))
+          case jv: JValue => dbl.add(renderValue(jv))
+        }
+      }
+      dbl
+    }
+
+    private def parseObject(obj: List[JField])(implicit formats: Formats): BsonDocument = {
+      val dbo = new BsonDocument
+      trimObj(obj).foreach { jf =>
+        jf.value match {
+          case JsonObjectId(objectId) => dbo.put(jf.name, new BsonObjectId(objectId))
+          case JsonRegex(pattern) => dbo.put(jf.name, new BsonRegularExpression(pattern.pattern, PatternHelper.flagsToString(pattern.flags)))
+          case JsonUUID(uuid) => dbo.put(jf.name, new BsonBinary(uuid, UuidRepresentation.JAVA_LEGACY))
+          case JsonDate(date) => dbo.put(jf.name, new BsonDateTime(date.getTime))
+          case JArray(arr) => dbo.put(jf.name, parseArray(arr))
+          case JObject(jo) => dbo.put(jf.name, parseObject(jo))
+          case jv: JValue => dbo.put(jf.name, renderValue(jv))
+        }
+      }
+      dbo
+    }
+
+    private def renderValue(jv: JValue)(implicit formats: Formats): BsonValue = jv match {
+      case JBool(b) => new BsonBoolean(java.lang.Boolean.valueOf(b))
+      case JInt(n) => renderInteger(n)
+      case JDouble(n) => new BsonDouble(new java.lang.Double(n))
+      case JNull => new BsonNull()
+      case JNothing => sys.error("can't render 'nothing'")
+      case JString(null) => new BsonString("null")
+      case JString(s) => stringProcessor.vend(s)
+      case x =>  new BsonString(x.toString)
+    }
+
+    private def renderInteger(i: BigInt): BsonValue = {
+      if (i.isValidInt) {
+        new BsonInt32(new java.lang.Integer(i.intValue))
+      } else if (i.isValidLong) {
+        new BsonInt64(new java.lang.Long(i.longValue))
+      }
+      else {
+        new BsonString(i.toString)
+      }
+    }
+
+    private def trimArr(xs: List[JValue]) = xs.filter(_ != JNothing)
+    private def trimObj(xs: List[JField]) = xs.filter(_.value != JNothing)
+  }
+}

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JObjectParser.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JObjectParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import com.mongodb.{BasicDBObject, BasicDBList, DBObject}
 import org.bson.types.ObjectId
 import org.bson.Document
 
+@deprecated("Please use BsonParser instead.", "3.4.2")
 object JObjectParser extends SimpleInjector {
   /**
     * Set this to override JObjectParser turning strings that are valid
@@ -37,6 +38,7 @@ object JObjectParser extends SimpleInjector {
     *
     * <code>JObjectParser.stringProcessor.default.set((s: String) => s)</code>
     */
+  @deprecated("Please use BsonParser instead.", "3.4.2")
   val stringProcessor = new Inject(() => defaultStringProcessor _) {}
 
   def defaultStringProcessor(s: String): Object = {
@@ -47,14 +49,16 @@ object JObjectParser extends SimpleInjector {
   /*
   * Parse a JObject into a DBObject
   */
+  @deprecated("Please use BsonParser instead.", "3.4.2")
   def parse(jo: JObject)(implicit formats: Formats): DBObject =
     Parser.parse(jo, formats)
 
   /*
   * Serialize a DBObject into a JObject
   */
+  @deprecated("Please use BsonParser instead.", "3.4.2")
   def serialize(a: Any)(implicit formats: Formats): JValue = {
-    import Meta.Reflection._
+    import mongodb.Meta.Reflection._
     a.asInstanceOf[AnyRef] match {
       case null => JNull
       case x if primitive_?(x.getClass) => primitive2jvalue(x)
@@ -77,8 +81,10 @@ object JObjectParser extends SimpleInjector {
     }
   }
 
+  @deprecated("Please use BsonParser instead.", "3.4.2")
   object Parser {
 
+    @deprecated("Please use BsonParser instead.", "3.4.2")
     def parse(jo: JObject, formats: Formats): DBObject = {
       parseObject(jo.obj)(formats)
     }

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JsonExtractors.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JsonExtractors.scala
@@ -1,5 +1,5 @@
 /**
-  * Copyright 2014 WorldWide Conferencing, LLC
+  * Copyright 2014-2020 WorldWide Conferencing, LLC
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.
@@ -91,6 +91,7 @@ object JsonDate {
   }
 
   def apply(dt: Date)(implicit formats: Formats): JValue = ("$dt" -> formats.dateFormat.format(dt))
+  def apply(dt: Long)(implicit formats: Formats): JValue = ("$dt" -> formats.dateFormat.format(new Date(dt)))
 }
 
 object JsonDateTime {

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JsonObject.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/JsonObject.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2010-2011 WorldWide Conferencing, LLC
+* Copyright 2010-2020 WorldWide Conferencing, LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -11,8 +11,8 @@
 * limitations under the License.
 */
 
-package net.liftweb 
-package mongodb 
+package net.liftweb
+package mongodb
 
 import json.Formats
 import json.JsonAST.JObject
@@ -22,9 +22,9 @@ import scala.reflect.Manifest
 import org.bson.types.ObjectId
 
 /*
-* These traits provide lift-json related conveniece methods for case classes
+* These traits provide lift-json related convenience methods for case classes
 * and their companion objects. Used by MongoDocument, JsonObjectField, and
-* MongoJsonObjectListField
+* JsonObjectListField
 */
 trait JsonObject[BaseDocument] {
   self: BaseDocument =>

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Mongo.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/Mongo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,19 @@
 package net.liftweb
 package mongodb
 
-import util.{ConnectionIdentifier, DefaultConnectionIdentifier}
+import net.liftweb.json.{Formats, JObject}
+import net.liftweb.util.{ConnectionIdentifier, DefaultConnectionIdentifier}
 
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.immutable.HashSet
 
+import org.bson.Document
+import org.bson.conversions.Bson
 import com.mongodb.{DB, DBCollection, Mongo, MongoClient, MongoException, MongoOptions, ServerAddress}
-import com.mongodb.client.MongoDatabase
+import com.mongodb.client.{MongoCollection, MongoDatabase}
+import com.mongodb.client.model.{IndexModel, IndexOptions}
+
 
 /**
   * Main Mongo object
@@ -44,8 +49,16 @@ object MongoDB {
   }
 
   /**
+    * Get a MongoClient reference
+    */
+  private[this] def getClient(name: ConnectionIdentifier): Option[MongoClient] = {
+    Option(dbs.get(name)).map { case (mngo, db) => mngo }
+  }
+
+  /**
     * Get a DB reference
     */
+  @deprecated("Use useDatabase instead", "3.4.2")
   def getDb(name: ConnectionIdentifier): Option[DB] = dbs.get(name) match {
     case null => None
     case (mngo, db) => Some(mngo.getDB(db))
@@ -58,17 +71,45 @@ object MongoDB {
     Option(dbs.get(name)).map { case (mngo, db) => mngo.getDatabase(db) }
   }
 
+  // for legacy purposes
+  @deprecated("Use getCollection instead", "3.4.2")
+  private[this] def getColl(name: ConnectionIdentifier, collectionName: String): Option[DBCollection] =
+    getDb(name) match {
+      case Some(mongo) if mongo != null =>
+        Some(mongo.getCollection(collectionName))
+      case _ =>
+        None
+    }
+
   /**
     * Get a Mongo collection. Gets a Mongo db first.
     */
-  private[this] def getCollection(name: ConnectionIdentifier, collectionName: String): Option[DBCollection] = getDb(name) match {
-    case Some(mongo) if mongo != null => Some(mongo.getCollection(collectionName))
-    case _ => None
+  private[this] def getCollection[TDocument](name: ConnectionIdentifier, collectionName: String, documentClass: Class[TDocument]): Option[MongoCollection[TDocument]] =
+    getDatabase(name) match {
+      case Some(mongo) if mongo != null =>
+        Some(mongo.getCollection(collectionName, documentClass))
+      case _ =>
+        None
+    }
+
+  /**
+    * Executes function {@code f} with the MongoClient.
+    */
+  def useClient[T](name: ConnectionIdentifier)(f: (MongoClient) => T): T = {
+    val client = getClient(name) match {
+      case Some(mongo) =>
+        mongo
+      case _ =>
+        throw new MongoException("Mongo not found: "+name.toString)
+    }
+
+    f(client)
   }
 
   /**
     * Executes function {@code f} with the mongo db named {@code name}.
     */
+  @deprecated("Use useDatabase instead", "3.4.2")
   def use[T](name: ConnectionIdentifier)(f: (DB) => T): T = {
 
     val db = getDb(name) match {
@@ -80,9 +121,25 @@ object MongoDB {
   }
 
   /**
+    * Executes function {@code f} with the mongo db named {@code name}.
+    */
+  def useDatabase[T](name: ConnectionIdentifier)(f: (MongoDatabase) => T): T = {
+
+    val db = getDatabase(name) match {
+      case Some(mongo) =>
+        mongo
+      case _ =>
+        throw new MongoException("Mongo not found: "+name.toString)
+    }
+
+    f(db)
+  }
+
+  /**
     * Executes function {@code f} with the mongo named {@code name}.
     * Uses the default ConnectionIdentifier
     */
+  @deprecated("Use useDefaultDatabase instead", "3.4.2")
   def use[T](f: (DB) => T): T = {
 
     val db = getDb(DefaultConnectionIdentifier) match {
@@ -93,12 +150,27 @@ object MongoDB {
     f(db)
   }
 
+   /**
+    * Executes function {@code f} with the DefaultConnectionIdentifier
+    */
+  def useDefaultDatabase[T](f: (MongoDatabase) => T): T = {
+    val db = getDatabase(DefaultConnectionIdentifier) match {
+      case Some(mongo) =>
+        mongo
+      case _ =>
+        throw new MongoException("Mongo not found: "+DefaultConnectionIdentifier.toString)
+    }
+
+    f(db)
+  }
+
   /**
     * Executes function {@code f} with the mongo named {@code name} and
     * collection names {@code collectionName}. Gets a collection for you.
     */
+  @deprecated("Use useMongoCollection instead", "3.4.2")
   def useCollection[T](name: ConnectionIdentifier, collectionName: String)(f: (DBCollection) => T): T = {
-    val coll = getCollection(name, collectionName) match {
+    val coll = getColl(name, collectionName) match {
       case Some(collection) => collection
       case _ => throw new MongoException("Mongo not found: "+collectionName+". ConnectionIdentifier: "+name.toString)
     }
@@ -107,12 +179,53 @@ object MongoDB {
   }
 
   /**
+    * Executes function {@code f} with the mongo named {@code name} and
+    * collection names {@code collectionName}. Gets a collection for you.
+    */
+  def useMongoCollection[TDocument, T](name: ConnectionIdentifier, collectionName: String, documentClass: Class[TDocument])(f: (MongoCollection[TDocument]) => T): T = {
+    val coll = getCollection[TDocument](name, collectionName, documentClass) match {
+      case Some(collection) =>
+        collection
+      case _ =>
+        throw new MongoException("Mongo not found: "+collectionName+". ConnectionIdentifier: "+name.toString)
+    }
+
+    f(coll)
+  }
+
+  /**
     * Same as above except uses DefaultConnectionIdentifier
     */
+  @deprecated("Use useMongoCollection instead", "3.4.2")
   def useCollection[T](collectionName: String)(f: (DBCollection) => T): T = {
-    val coll = getCollection(DefaultConnectionIdentifier, collectionName) match {
+    val coll = getColl(DefaultConnectionIdentifier, collectionName) match {
       case Some(collection) => collection
       case _ => throw new MongoException("Mongo not found: "+collectionName+". ConnectionIdentifier: "+DefaultConnectionIdentifier.toString)
+    }
+
+    f(coll)
+  }
+
+  /**
+   * Same as above except uses DefaultConnectionIdentifier
+   */
+  def useMongoCollection[TDocument, T](collectionName: String, documentClass: Class[TDocument])(f: (MongoCollection[TDocument]) => T): T = {
+    val coll = getCollection[TDocument](DefaultConnectionIdentifier, collectionName, documentClass) match {
+      case Some(collection) =>
+        collection
+      case _ =>
+        throw new MongoException("Mongo not found: "+collectionName+". ConnectionIdentifier: "+DefaultConnectionIdentifier.toString)
+    }
+
+    f(coll)
+  }
+
+  def useMongoCollection[T](collectionName: String)(f: (MongoCollection[Document]) => T): T = {
+    val coll = getCollection[Document](DefaultConnectionIdentifier, collectionName, classOf[Document]) match {
+      case Some(collection) =>
+        collection
+      case _ =>
+        throw new MongoException("Mongo not found: "+collectionName+". ConnectionIdentifier: "+DefaultConnectionIdentifier.toString)
     }
 
     f(coll)

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoAsync.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoAsync.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 WorldWide Conferencing, LLC
+ * Copyright 2017-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@ package net.liftweb.mongodb
 import java.util.concurrent.ConcurrentHashMap
 
 import com.mongodb.MongoException
-import com.mongodb.async.client.{MongoClient, MongoCollection, MongoDatabase}
+import com.mongodb.async.client.{MongoCollection, MongoDatabase}
 import com.mongodb.async.SingleResultCallback
 import net.liftweb.util.ConnectionIdentifier
 import org.bson.Document
 
 import scala.concurrent.Promise
 
+@deprecated("No longer supported. This will be removed in Lift 4.", "3.4.2")
 private[mongodb] class SingleBooleanVoidCallback(f: () => Unit) extends SingleResultCallback[Void] {
   private[this] val p = Promise[Boolean]()
 
@@ -50,6 +51,7 @@ private[mongodb] class SingleBooleanVoidCallback(f: () => Unit) extends SingleRe
   * Example:
   *
   * {{{
+  * import com.mongodb.MongoClientSettings
   * import com.mongodb.async.client.MongoClients
   * import net.liftweb.util.{ConnectionIdentifier, DefaultConnectionIdentifier}
   * import org.bson.codecs.configuration.CodecRegistries
@@ -65,7 +67,7 @@ private[mongodb] class SingleBooleanVoidCallback(f: () => Unit) extends SingleRe
   * }
   *
   * val codecRegistry = CodecRegistries.fromRegistries(
-  *   com.mongodb.MongoClient.getDefaultCodecRegistry(),
+  *   MongoClientSettings.getDefaultCodecRegistry(),
   *   CodecRegistries.fromCodecs(new LongPrimitiveCodec, new IntegerPrimitiveCodec)
   * )
 
@@ -74,6 +76,7 @@ private[mongodb] class SingleBooleanVoidCallback(f: () => Unit) extends SingleRe
   *
   * }}}
   */
+@deprecated("No longer supported. This will be removed in Lift 4.", "3.4.2")
 object MongoAsync {
 
   /**
@@ -84,6 +87,7 @@ object MongoAsync {
   /**
     * Define a Mongo db using a MongoDatabase instance.
     */
+  @deprecated("No longer supported. This will be removed in Lift 4.", "3.4.2")
   def defineDb(id: ConnectionIdentifier, db: MongoDatabase): Unit = {
     dbs.put(id, db)
   }
@@ -98,6 +102,7 @@ object MongoAsync {
   /**
     * Executes function {@code f} with the mongo database identified by {@code name}.
     */
+  @deprecated("No longer supported. This will be removed in Lift 4.", "3.4.2")
   def use[T](name: ConnectionIdentifier)(f: (MongoDatabase) => T): T = {
     val db = getDatabase(name) match {
       case Some(mongo) => mongo
@@ -110,6 +115,7 @@ object MongoAsync {
     * Executes function {@code f} with the collection named {@code collectionName} from
     * the mongo database identified by {@code name}.
     */
+  @deprecated("No longer supported. This will be removed in Lift 4.", "3.4.2")
   def useCollection[T](name: ConnectionIdentifier, collectionName: String)(f: (MongoCollection[Document]) => T): T = {
     val coll = getCollection(name, collectionName) match {
       case Some(collection) => collection
@@ -126,6 +132,7 @@ object MongoAsync {
   /**
     * Clear the HashMap.
     */
+  @deprecated("No longer supported. This will be removed in Lift 4.", "3.4.2")
   def clear(): Unit = {
     dbs.clear()
   }
@@ -133,6 +140,7 @@ object MongoAsync {
   /**
     * Remove a specific ConnectionIdentifier from the HashMap.
     */
+  @deprecated("No longer supported. This will be removed in Lift 4.", "3.4.2")
   def remove(id: ConnectionIdentifier): Option[MongoDatabase] = {
     Option(dbs.remove(id))
   }

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoMeta.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/MongoMeta.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2010-2011 WorldWide Conferencing, LLC
+* Copyright 2010-2020 WorldWide Conferencing, LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,13 +14,24 @@
 package net.liftweb
 package mongodb
 
+import net.liftweb.common.Box
+import net.liftweb.json.{DefaultFormats, Formats}
+import net.liftweb.json.JsonAST.JObject
+import net.liftweb.util.ConnectionIdentifier
+import net.liftweb.util.Helpers.tryo
+
+import scala.collection.JavaConverters._
+
+import com.mongodb.{BasicDBObject, DB, DBCollection, DBObject, MongoClientSettings, WriteConcern}
+import com.mongodb.client.{FindIterable, MongoCollection, MongoDatabase}
+import com.mongodb.client.model.{DeleteOptions, IndexOptions, UpdateOptions}
+import com.mongodb.client.result.{DeleteResult, UpdateResult}
+
+import org.bson.{BsonDocument, Document, UuidRepresentation}
+import org.bson.codecs.configuration.CodecRegistry
+
+import org.bson.conversions.Bson
 import org.bson.types.ObjectId
-
-import json.{DefaultFormats, Formats}
-import json.JsonAST.JObject
-import util.ConnectionIdentifier
-
-import com.mongodb.{BasicDBObject, DB, DBCollection, DBObject}
 
 trait JsonFormats {
   // override this for custom Formats
@@ -31,25 +42,29 @@ trait JsonFormats {
   lazy val allFormats = DefaultFormats.lossless + new ObjectIdSerializer + new DateSerializer + new DateTimeSerializer + new PatternSerializer + new UUIDSerializer
 }
 
-/*
-* This is used by both MongoDocumentMeta and MongoMetaRecord
-*/
-trait MongoMeta[BaseDocument] extends JsonFormats {
+trait MongoCodecs {
+  def codecRegistry: CodecRegistry
+}
+
+/**
+ * This is used by both MongoDocumentMeta and MongoMetaRecord
+ */
+trait MongoMeta[BaseDocument, TDocument] extends JsonFormats with MongoCodecs {
 
   def connectionIdentifier: ConnectionIdentifier
 
   // class name has a $ at the end.
   private lazy val _collectionName = getClass.getName.replaceAllLiterally("$", "")
 
-  /*
-  * Collection names should begin with letters or an underscore and may include
-  * numbers; $ is reserved. Collections can be organized in namespaces; these
-  * are named groups of collections defined using a dot notation. For example,
-  * you could define collections blog.posts and blog.authors, both reside under
-  * "blog". Note that this is simply an organizational mechanism for the user
-  * -- the collection namespace is flat from the database's perspective.
-  * From: http://www.mongodb.org/display/DOCS/Collections
-  */
+  /**
+   * Collection names should begin with letters or an underscore and may include
+   * numbers; $ is reserved. Collections can be organized in namespaces; these
+   * are named groups of collections defined using a dot notation. For example,
+   * you could define collections blog.posts and blog.authors, both reside under
+   * "blog". Note that this is simply an organizational mechanism for the user
+   * -- the collection namespace is flat from the database's perspective.
+   * From: http://www.mongodb.org/display/DOCS/Collections
+   */
   def fixCollectionName = {
     val colName = MongoRules.collectionName.vend.apply(connectionIdentifier, _collectionName)
 
@@ -58,50 +73,156 @@ trait MongoMeta[BaseDocument] extends JsonFormats {
   }
 
   /**
-  * The name of the database collection.  Override this method if you
-  * want to change the collection to something other than the name of
-  * the class with an 's' appended to the end.
-  */
+   * The name of the database collection.  Override this method if you
+   * want to change the collection to something other than the name of
+   * the class with an 's' appended to the end.
+   */
   def collectionName: String = fixCollectionName
 
-  /*
+  /**
+   * This will be used if set to Some, otherwise the WriteConcern set
+   * in MongoClientOptions will be used. Used by useCollection and useDatabase.
+   */
+  def writeConcern: WriteConcern = MongoRules.defaultWriteConcern.vend
+
+  /**
    * Use the collection associated with this Meta.
    */
+  def useCollection[T](f: MongoCollection[TDocument] => T): T
+
+  @deprecated("Use useCollection instead", "3.4.2")
   def useColl[T](f: DBCollection => T): T
 
-  /*
+  /**
    * Use the db associated with this Meta.
    */
+  def useDatabase[T](f: MongoDatabase => T): T
+
+  @deprecated("Use useDatabase instead", "3.4.2")
   def useDb[T](f: DB => T): T
 
-  /*
-  * Count all documents
-  */
-  def count: Long = useColl { coll => coll.getCount }
+  /**
+   * Count all documents
+   */
+  def count: Box[Long] = tryo { useCollection { coll => coll.countDocuments } }
 
-  /*
-  * Count documents by DBObject query
-  */
-  def count(qry: DBObject):Long = useColl { coll => coll.getCount(qry) }
+  /**
+   * Count documents by Bson query
+   */
+  def count(qry: Bson): Box[Long] = tryo { useCollection { coll => coll.countDocuments(qry) } }
 
-  /*
-  * Count documents by JObject query
-  */
-  def count(qry: JObject):Long = count(JObjectParser.parse(qry))
+  /**
+   * Count documents by JObject query
+   */
+  def count(qry: JObject): Box[Long] = count(BsonParser.parse(qry))
 
-  /*
-  * Count distinct records on a given field
-  */
-  def countDistinct(key: String, query: DBObject): Long =
-    useColl { coll => coll.distinct(key, query).size }
+  /**
+   * Count distinct records on a given field.
+   *
+   * **Warning:** This retrieves all matching documents and puts them in memory.
+   */
+  def countDistinct(key: String, query: Bson): Box[Long] = tryo {
+    useCollection { coll => coll.distinct(key, query, classOf[Document]).iterator.asScala.toList.length }
+  }
 
-  /*
-  * Delete documents by a DBObject query
-  */
+  def createIndex(keys: Bson, opts: IndexOptions): Box[String] = tryo {
+    useCollection(_.createIndex(keys, opts))
+  }
+
+  def createIndex(keys: Bson): Box[String] = {
+    val options = new IndexOptions
+    createIndex(keys, options)
+  }
+
+  def createIndex(keys: Bson, uniq: Boolean): Box[String] = {
+    val options = (new IndexOptions).unique(uniq)
+    createIndex(keys, options)
+  }
+
+  def createIndex(keys: JObject, opts: IndexOptions): Box[String] = tryo {
+    useCollection(_.createIndex(BsonParser.parse(keys), opts))
+  }
+
+  def createIndex(keys: JObject): Box[String] = tryo {
+    useCollection(_.createIndex(BsonParser.parse(keys)))
+  }
+
+  def createIndex(keys: JObject, uniq: Boolean = false): Box[String] = {
+    val options = (new IndexOptions).unique(uniq)
+    createIndex(BsonParser.parse(keys), options)
+  }
+
+  /**
+   * Delete a single document by a Bson query
+   */
+  def deleteOne(qry: Bson): Box[DeleteResult] = tryo {
+    useCollection(_.deleteOne(qry))
+  }
+
+  /**
+   * Delete a single document by a Bson query with the given DeleteOptions
+   */
+  def deleteOne(qry: Bson, opts: DeleteOptions): Box[DeleteResult] = tryo {
+    useCollection(_.deleteOne(qry, opts))
+  }
+
+  /**
+   * Delete a single document by a JObject query
+   */
+  def deleteOne(qry: JObject): Box[DeleteResult] =
+    deleteOne(BsonParser.parse(qry))
+
+  /**
+   * Delete a single document by a JObject query with the given DeleteOptions
+   */
+  def deleteOne(qry: JObject, opts: DeleteOptions): Box[DeleteResult] =
+    deleteOne(BsonParser.parse(qry), opts)
+
+  /**
+   * Delete a single document by a key-value pair query
+   */
+  def deleteOne(k: String, v: Any, opts: DeleteOptions = new DeleteOptions): Box[DeleteResult] = {
+    deleteOne(new Document(k, v match {
+      case s: String if (ObjectId.isValid(s)) => new ObjectId(s)
+      case _ => v
+    }), opts)
+  }
+
+  /**
+   * Delete many documents by a Bson query
+   */
+  def deleteMany(qry: Bson): Box[DeleteResult] = tryo {
+    useCollection(_.deleteMany(qry))
+  }
+
+  /**
+   * Delete many documents by a Bson query with the given DeleteOptions
+   */
+  def deleteMany(qry: Bson, opts: DeleteOptions): Box[DeleteResult] = tryo {
+    useCollection(_.deleteMany(qry, opts))
+  }
+
+  /**
+   * Delete many documents by a JObject query
+   */
+  def deleteMany(qry: JObject): Box[DeleteResult] =
+    deleteMany(BsonParser.parse(qry))
+
+  /**
+   * Delete many documents by a JObject query with the given DeleteOptions
+   */
+  def deleteMany(qry: JObject, opts: DeleteOptions): Box[DeleteResult] =
+    deleteMany(BsonParser.parse(qry), opts)
+
+  /**
+   * Delete documents by a DBObject query
+   */
+  @deprecated("Use deleteOne or deleteMany instead", "3.4.2")
   def delete(qry: DBObject): Unit =
     useColl { coll => coll.remove(qry) }
 
   // delete a document
+  @deprecated("Use deleteOne or deleteMany instead", "3.4.2")
   def delete(k: String, v: Any) {
     delete(new BasicDBObject(k, v match {
       case s: String if (ObjectId.isValid(s)) => new ObjectId(s)
@@ -109,32 +230,75 @@ trait MongoMeta[BaseDocument] extends JsonFormats {
     }))
   }
 
-  /*
-  * Delete documents by a JObject query
-  */
+  /**
+   * Delete documents by a JObject query
+   */
+  @deprecated("Use deleteOne or deleteMany instead", "3.4.2")
   def delete(qry: JObject): Unit = delete(JObjectParser.parse(qry))
 
   /* drop this document collection */
-  def drop: Unit =  useColl { coll => coll.drop }
+  def drop: Box[Unit] =  tryo { useCollection { coll => coll.drop() } }
 
-  def createIndex(keys: JObject, unique: Boolean = false): Unit = {
-    val options = new BasicDBObject
-    if (unique) {
-      options.put("unique", true: java.lang.Boolean)
-    }
-    useColl { coll =>
-      coll.createIndex(JObjectParser.parse(keys), options)
-    }
-  }
-
+  @deprecated("Use createIndex that takes IndexOptions as argument instead", "3.4.2")
   def createIndex(keys: JObject, opts: JObject): Unit =
     useColl { coll =>
       coll.createIndex(JObjectParser.parse(keys), JObjectParser.parse(opts))
     }
 
-  /*
-  * Update document with a DBObject query using the given Mongo instance.
-  */
+  /**
+   * Update many documents with a Bson query
+   */
+  def updateMany(qry: Bson, update: Bson): Box[UpdateResult] = tryo {
+    useCollection(_.updateMany(qry, update))
+  }
+
+  /**
+   * Update many documents with a Bson query with the given UpdateOptions
+   */
+  def updateMany(qry: Bson, update: Bson, opts: UpdateOptions): Box[UpdateResult] = tryo {
+    useCollection(_.updateMany(qry, update, opts))
+  }
+
+  /**
+   * Update many documents with a JObject query
+   */
+  def updateMany(qry: JObject, update: JObject): Box[UpdateResult] =
+    updateMany(BsonParser.parse(qry), BsonParser.parse(update))
+
+  /**
+   * Update many documents with a JObject query with the given UpdateOptions
+   */
+  def updateMany(qry: JObject, update: JObject, opts: UpdateOptions): Box[UpdateResult] =
+    updateMany(BsonParser.parse(qry), BsonParser.parse(update))
+
+  /**
+   * Update a single document with a Bson query
+   */
+  def updateOne(qry: Bson, update: Bson): Box[UpdateResult] = tryo {
+    useCollection(_.updateOne(qry, update))
+  }
+
+  /**
+   * Update a single document with a Bson query with the given UpdateOptions
+   */
+  def updateOne(qry: Bson, update: Bson, opts: UpdateOptions): Box[UpdateResult] = tryo {
+    useCollection(_.updateOne(qry, update, opts))
+  }
+
+  /**
+   * Update a single document with a JObject query
+   */
+  def updateOne(qry: JObject, update: JObject): Box[UpdateResult] = {
+    updateOne(BsonParser.parse(qry), BsonParser.parse(update))
+  }
+
+  /**
+   * Update a single document with a JObject query with the given UpdateOptions
+   */
+  def updateOne(qry: JObject, update: JObject, opts: UpdateOptions): Box[UpdateResult] =
+    updateOne(BsonParser.parse(qry), BsonParser.parse(update))
+
+  @deprecated("Use updateOne or updateMany instead", "3.4.2")
   def update(qry: DBObject, newobj: DBObject, db: DB, opts: UpdateOption*) {
     val dboOpts = opts.toList
     db.getCollection(collectionName).update(
@@ -145,9 +309,7 @@ trait MongoMeta[BaseDocument] extends JsonFormats {
     )
   }
 
-  /*
-  * Update document with a JObject query using the given Mongo instance.
-  */
+  @deprecated("Use updateOne or updateMany instead", "3.4.2")
   def update(qry: JObject, newobj: JObject, db: DB, opts: UpdateOption*) {
     update(
       JObjectParser.parse(qry),
@@ -157,17 +319,15 @@ trait MongoMeta[BaseDocument] extends JsonFormats {
     )
   }
 
-  /*
-  * Update document with a JObject query.
-  */
+  @deprecated("Use updateOne or updateMany instead", "3.4.2")
   def update(qry: JObject, newobj: JObject, opts: UpdateOption*) {
     useDb { db => update(qry, newobj, db, opts :_*) }
   }
 }
 
-/*
-* For passing in options to the find function
-*/
+/**
+ * For passing in options to the find function
+ */
 abstract sealed class FindOption {
   def value: Int
 }
@@ -177,7 +337,10 @@ case class Skip(value: Int) extends FindOption
 /*
 * For passing in options to the update function
 */
+@deprecated("Use com.mongodb.client.model.UpdateOptions instead", "3.4.2")
 abstract sealed class UpdateOption
+@deprecated("Use com.mongodb.client.model.UpdateOptions instead", "3.4.2")
 case object Upsert extends UpdateOption
+@deprecated("Use com.mongodb.client.model.UpdateOptions instead", "3.4.2")
 case object Multi extends UpdateOption
 

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/PatternHelper.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/PatternHelper.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb.mongodb
+
+import java.util.regex.Pattern
+
+// only i,x,m,s options are supported: https://docs.mongodb.com/manual/reference/operator/query/regex/
+object PatternHelper {
+  // values
+  // 128 -> Pattern.CANON_EQ
+  // 2 -> Pattern.CASE_INSENSITIVE
+  // 4 -> Pattern.COMMENTS
+  // 32 -> Pattern.DOTALL
+  // 16 -> Pattern.LITERAL
+  // 8 -> Pattern.MULTILINE
+  // 64 -> Pattern.UNICODE_CASE
+  // 1 -> Pattern.UNIX_LINES
+
+  private val flagMap = Map(
+    Pattern.CANON_EQ -> "c",
+    Pattern.CASE_INSENSITIVE -> "i",
+    Pattern.COMMENTS -> "x",
+    Pattern.DOTALL -> "s",
+    Pattern.LITERAL -> "t",
+    Pattern.MULTILINE -> "m",
+    Pattern.UNICODE_CASE -> "u",
+    Pattern.UNIX_LINES -> "d"
+  )
+
+  def flagsToString(flags: Int): String = {
+    (for {
+      (mask, char) <- flagMap
+      if (flags & mask) != 0
+    } yield char).mkString
+  }
+
+  def optionsToFlags(opts: String): Int = {
+    opts.foldLeft(0) { (result, char) => char match {
+      case 'i' => result | Pattern.CASE_INSENSITIVE
+      case 'x' => result | Pattern.COMMENTS
+      case 'm' => result | Pattern.MULTILINE
+      case 's' => result | Pattern.DOTALL
+      case _ => result
+    } }
+  }
+}

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/BigDecimalCodec.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/BigDecimalCodec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb.mongodb
+package codecs
+
+import scala.math.BigDecimal
+
+import org.bson.{BsonReader, BsonWriter}
+import org.bson.codecs._
+import org.bson.types.Decimal128
+
+/**
+ * A Codec for BigDecimal instances.
+ */
+case class BigDecimalCodec() extends Codec[BigDecimal] {
+  override def encode(writer: BsonWriter, value: BigDecimal, encoderContext: EncoderContext): Unit = {
+    writer.writeDecimal128(new Decimal128(value.bigDecimal))
+  }
+
+  override def decode(reader: BsonReader, decoderContext: DecoderContext): BigDecimal = {
+    BigDecimal(reader.readDecimal128().bigDecimalValue())
+  }
+
+  override def getEncoderClass(): Class[BigDecimal] = classOf[BigDecimal]
+}

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/BigDecimalStringCodec.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/BigDecimalStringCodec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb.mongodb
+package codecs
+
+import scala.math.BigDecimal
+
+import org.bson.{BsonReader, BsonWriter}
+import org.bson.codecs._
+import org.bson.types.Decimal128
+
+/**
+ * A Codec for BigDecimal instances that saves the value as a String.
+ */
+case class BigDecimalStringCodec() extends Codec[BigDecimal] {
+  override def encode(writer: BsonWriter, value: BigDecimal, encoderContext: EncoderContext): Unit = {
+    writer.writeString(value.toString)
+  }
+
+  override def decode(reader: BsonReader, decoderContext: DecoderContext): BigDecimal = {
+    BigDecimal(reader.readString)
+  }
+
+  override def getEncoderClass(): Class[BigDecimal] = classOf[BigDecimal]
+}

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/BigIntCodec.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/BigIntCodec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb.mongodb
+package codecs
+
+import scala.math.BigInt
+
+import org.bson.{BsonReader, BsonWriter}
+import org.bson.codecs._
+
+/**
+ * A Codec for BigInt instances. Values are stored as INT64.
+ */
+case class BigIntLongCodec() extends Codec[BigInt] {
+  override def encode(writer: BsonWriter, value: BigInt, encoderContext: EncoderContext): Unit = {
+    writer.writeInt64(value.longValue)
+  }
+
+  override def decode(reader: BsonReader, decoderContext: DecoderContext): BigInt = {
+    BigInt(reader.readInt64())
+  }
+
+  override def getEncoderClass(): Class[BigInt] = classOf[BigInt]
+}

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/BsonTypeClassMap.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/BsonTypeClassMap.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb.mongodb
+package codecs
+
+import org.bson.BsonType
+
+/**
+ * A companion object for BsonTypeClassMap.
+ */
+object BsonTypeClassMap {
+  def apply(replacements: (BsonType, Class[_])*): BsonTypeClassMap = {
+    val jreplacements = new java.util.HashMap[BsonType, Class[_]]()
+    replacements.foreach(kv => jreplacements.put(kv._1, kv._2))
+    new BsonTypeClassMap(jreplacements)
+  }
+}

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/CalendarCodec.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/CalendarCodec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+package codecs
+
+import java.util.{Calendar, GregorianCalendar}
+
+import org.bson.codecs._
+import org.bson.{BsonReader, BsonWriter}
+
+/**
+ * A Codec for Calendar instances.
+ */
+case class CalendarCodec() extends Codec[GregorianCalendar] {
+  override def decode(reader: BsonReader, decoderContext: DecoderContext): GregorianCalendar = {
+    val cal = new GregorianCalendar()
+    cal.setTimeInMillis(reader.readDateTime())
+    cal
+  }
+
+  override def encode(writer: BsonWriter, value: GregorianCalendar, encoderContext: EncoderContext): Unit = {
+    writer.writeDateTime(value.getTimeInMillis())
+  }
+
+  override def getEncoderClass(): Class[GregorianCalendar] = classOf[GregorianCalendar]
+}

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/JodaDateTimeCodec.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/JodaDateTimeCodec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb.mongodb
+package codecs
+
+import org.joda.time.DateTime
+
+import org.bson.codecs._
+import org.bson.{BsonReader, BsonWriter}
+
+/**
+ * A Codec for joda DateTime instances.
+ */
+case class JodaDateTimeCodec() extends Codec[DateTime] {
+  override def decode(reader: BsonReader, decoderContext: DecoderContext): DateTime = {
+    new DateTime(reader.readDateTime())
+  }
+
+  override def encode(writer: BsonWriter, value: DateTime, encoderContext: EncoderContext): Unit = {
+    writer.writeDateTime(value.getMillis())
+  }
+
+  override def getEncoderClass(): Class[DateTime] = classOf[DateTime]
+}

--- a/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/package.scala
+++ b/persistence/mongodb/src/main/scala/net/liftweb/mongodb/codecs/package.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package net.liftweb.mongodb
+
+package object codecs {
+  type BsonTypeClassMap = org.bson.codecs.BsonTypeClassMap
+}

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/BsonDSLSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/BsonDSLSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 WorldWide Conferencing, LLC
+ * Copyright 2011-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ package mongodb
 import BsonDSL._
 import json._
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.util.matching.Regex
 
 import java.util.{Date, UUID}
@@ -48,7 +48,13 @@ class BsonDSLSpec extends Specification  {
       val oidList = ObjectId.get :: ObjectId.get :: ObjectId.get :: Nil
       val qry: JObject = ("ids" -> oidList)
       val dbo: DBObject = JObjectParser.parse(qry)(DefaultFormats)
-      val oidList2: List[ObjectId] = dbo.get("ids").asInstanceOf[BasicDBList].toList.map(_.asInstanceOf[ObjectId])
+      val oidList2: List[ObjectId] =
+        dbo
+          .get("ids")
+          .asInstanceOf[BasicDBList]
+          .asScala
+          .toList
+          .map(_.asInstanceOf[ObjectId])
 
       oidList2 must_== oidList
     }
@@ -70,7 +76,13 @@ class BsonDSLSpec extends Specification  {
         Pattern.compile("^Mongo3") :: Nil
       val qry: JObject = ("ptrns" -> ptrnList)
       val dbo: DBObject = JObjectParser.parse(qry)(DefaultFormats)
-      val ptrnList2: List[Pattern] = dbo.get("ptrns").asInstanceOf[BasicDBList].toList.map(_.asInstanceOf[Pattern])
+      val ptrnList2: List[Pattern] =
+        dbo
+          .get("ptrns")
+          .asInstanceOf[BasicDBList]
+          .asScala
+          .toList
+          .map(_.asInstanceOf[Pattern])
 
       for (i <- 0 to 2) yield {
         ptrnList(i).pattern must_== ptrnList2(i).pattern
@@ -102,7 +114,13 @@ class BsonDSLSpec extends Specification  {
       val uuidList = UUID.randomUUID :: UUID.randomUUID :: UUID.randomUUID :: Nil
       val qry: JObject = ("ids" -> uuidList)
       val dbo: DBObject = JObjectParser.parse(qry)(DefaultFormats)
-      val uuidList2: List[UUID] = dbo.get("ids").asInstanceOf[BasicDBList].toList.map(_.asInstanceOf[UUID])
+      val uuidList2: List[UUID] =
+        dbo
+          .get("ids")
+          .asInstanceOf[BasicDBList]
+          .asScala
+          .toList
+          .map(_.asInstanceOf[UUID])
 
       uuidList2 must_== uuidList
     }
@@ -121,7 +139,13 @@ class BsonDSLSpec extends Specification  {
       val dateList = new Date :: new Date :: new Date :: Nil
       val qry: JObject = ("dts" -> dateList)
       val dbo: DBObject = JObjectParser.parse(qry)
-      val dateList2: List[Date] = dbo.get("dts").asInstanceOf[BasicDBList].toList.map(_.asInstanceOf[Date])
+      val dateList2: List[Date] =
+        dbo
+          .get("dts")
+          .asInstanceOf[BasicDBList]
+          .asScala
+          .toList
+          .map(_.asInstanceOf[Date])
 
       dateList2 must_== dateList
     }
@@ -140,7 +164,13 @@ class BsonDSLSpec extends Specification  {
       val dateList = new DateTime :: new DateTime :: new DateTime :: Nil
       val qry: JObject = ("dts" -> dateList)
       val dbo: DBObject = JObjectParser.parse(qry)
-      val dateList2: List[DateTime] = dbo.get("dts").asInstanceOf[BasicDBList].toList.map(_.asInstanceOf[Date]).map(d => new DateTime(d))
+      val dateList2: List[DateTime] =
+        dbo
+          .get("dts")
+          .asInstanceOf[BasicDBList]
+          .asScala
+          .toList
+          .map(_.asInstanceOf[Date]).map(d => new DateTime(d))
 
       dateList2 must_== dateList
     }

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/BsonParserSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/BsonParserSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+
+import json._
+import JsonDSL._
+import util.Helpers._
+
+import org.bson.types.ObjectId
+import org.specs2.mutable.Specification
+
+import org.bson._
+
+class BsonParserSpec extends Specification  {
+  "BsonParser Specification".title
+
+  def buildTestData: (ObjectId, BsonDocument) = {
+    val oid = ObjectId.get
+    val dbo = BsonParser.parse(("x" -> oid.toString))(DefaultFormats)
+    (oid, dbo)
+  }
+
+  "BsonParser" should {
+    "convert strings to ObjectId by default" in {
+      val (oid, dbo) = buildTestData
+      val xval = tryo(dbo.getObjectId("x"))
+
+      xval.toList map { x =>
+        x.getValue must_== oid
+      }
+
+      xval.isDefined must_== true
+    }
+    "not convert strings to ObjectId when configured not to" in {
+      BsonParser.stringProcessor.doWith((s: String) => new BsonString(s)) {
+        val (oid, dbo) = buildTestData
+        val xval = tryo(dbo.getString("x"))
+
+        xval.toList map { x =>
+          x.getValue must_== oid.toString
+        }
+
+        xval.isDefined must_== true
+      }
+    }
+  }
+}

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/LegacyJObjectParserSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/LegacyJObjectParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 WorldWide Conferencing, LLC
+ * Copyright 2012-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import org.specs2.mutable.Specification
 
 import com.mongodb.DBObject
 
-class JObjectParserSpec extends Specification  {
-  "JObjectParser Specification".title
+class LegacyJObjectParserSpec extends Specification  {
+  "LegacyJObjectParser Specification".title
 
   def buildTestData: (ObjectId, DBObject) = {
     val oid = ObjectId.get

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/LegacyMongoDirectMongoClientSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/LegacyMongoDirectMongoClientSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 WorldWide Conferencing, LLC
+ * Copyright 2014-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import org.specs2.mutable.Specification
 /**
  * System under specification for MongoDirectMonoClient.
  */
-class MongoDirectMongoClientSpec extends Specification with MongoTestKit {
-  "MongoDirectMongoClient Specification".title
+class LegacyMongoDirectMongoClientSpec extends Specification with MongoTestKit {
+  "LegacyMongoDirectMongoClient Specification".title
 
   "MongoClient example" in {
 
@@ -65,4 +65,3 @@ class MongoDirectMongoClientSpec extends Specification with MongoTestKit {
     success
   }
 }
-

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/LegacyMongoDirectSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/LegacyMongoDirectSpec.scala
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+
+import net.liftweb.util.{Helpers, DefaultConnectionIdentifier}
+
+import java.util.UUID
+import java.util.regex.Pattern
+
+import com.mongodb.{WriteConcern, BasicDBObject, BasicDBObjectBuilder, MongoException}
+
+import org.specs2.mutable.Specification
+
+import json.DefaultFormats
+import net.liftweb.common.Failure
+
+
+/**
+ * System under specification for MongoDirect.
+ */
+class LegacyMongoDirectSpec extends Specification with MongoTestKit {
+  "LegacyMongoDirect Specification".title
+
+  def date(s: String) = DefaultFormats.dateFormat.parse(s).get
+
+  "Mongo tutorial example" in {
+
+    checkMongoIsRunning
+
+    // build the DBObject
+    val doc = new BasicDBObject
+
+    doc.put("name", "MongoDB")
+    doc.put("type", "database")
+    doc.put("count", 1: java.lang.Integer)
+
+    val info = new BasicDBObject
+
+    info.put("x", 203: java.lang.Integer)
+    info.put("y", 102: java.lang.Integer)
+
+    doc.put("info", info)
+
+    // use the Mongo instance directly
+    MongoDB.use(DefaultConnectionIdentifier) ( db => {
+      val coll = db.getCollection("testCollection")
+
+      // save the doc to the db
+      coll.save(doc)
+
+      // get the doc back from the db and compare them
+      coll.findOne must_== doc
+
+      // upsert
+      doc.put("type", "document")
+      doc.put("count", 2: java.lang.Integer)
+      val q = new BasicDBObject("name", "MongoDB") // the query to select the document(s) to update
+      val o = doc // the new object to update with, replaces the entire document, except possibly _id
+      val upsert = false // if the database should create the element if it does not exist
+      val apply = false // if an _id field should be added to the new object
+      coll.update(q, o, upsert, apply)
+
+      // get the doc back from the db and compare
+      coll.findOne.get("type") must_== "document"
+      coll.findOne.get("count") must_== 2
+
+      // modifier operations $inc, $set, $push...
+      val o2 = new BasicDBObject
+      o2.put("$inc", new BasicDBObject("count", 1)) // increment count by 1
+      o2.put("$set", new BasicDBObject("type", "docdb")) // set type
+      coll.update(q, o2, false, false)
+
+      // get the doc back from the db and compare
+      coll.findOne.get("type") must_== "docdb"
+      coll.findOne.get("count") must_== 3
+
+      if (!debug) {
+        // delete it
+        coll.remove(new BasicDBObject("_id", doc.get("_id")))
+        coll.find.count must_== 0
+        coll.drop
+      }
+
+      // server-side eval
+      val six = db.eval(" function() { return 3+3; } ")
+      six must_== 6
+    })
+  }
+
+  "Mongo tutorial 2 example" in {
+
+    checkMongoIsRunning
+
+    // use a DBCollection directly
+    MongoDB.useCollection("iDoc") ( coll => {
+      // insert multiple documents
+      for (i <- List.range(1, 101)) {
+        coll.insert(new BasicDBObject().append("i", i))
+      }
+
+      // create an index
+      coll.createIndex(new BasicDBObject("i", 1))  // create index on "i", ascending
+
+      // count the docs
+      coll.getCount must_== 100
+
+      // get the count using a query
+      coll.getCount(new BasicDBObject("i", new BasicDBObject("$gt", 50))) must_== 50
+
+      // use a cursor to get all docs
+      val cur = coll.find
+
+      cur.count must_== 100
+
+      // get a single document with a query ( i = 71 )
+      val query = new BasicDBObject("i", 71)
+      val cur2 = coll.find(query)
+
+      cur2.count must_== 1
+      cur2.next.get("i") must_== 71
+
+      // get a set of documents with a query
+      // e.g. find all where i > 50
+      val cur3 = coll.find(new BasicDBObject("i", new BasicDBObject("$gt", 50)))
+
+      cur3.count must_== 50
+
+      // range - 20 < i <= 30
+      val cur4 = coll.find(new BasicDBObject("i", new BasicDBObject("$gt", 20).append("$lte", 30)))
+
+      cur4.count must_== 10
+
+      // limiting result set
+      val cur5 = coll.find(new BasicDBObject("i", new BasicDBObject("$gt", 50))).limit(3)
+
+      var cntr5 = 0
+      while(cur5.hasNext) {
+        cur5.next
+        cntr5 += 1
+      }
+      cntr5 must_== 3
+
+      // skip
+      val cur6 = coll.find(new BasicDBObject("i", new BasicDBObject("$gt", 50))).skip(10)
+
+      var cntr6 = 0
+      while(cur6.hasNext) {
+        cntr6 += 1
+        cur6.next.get("i") must_== 60+cntr6
+      }
+      cntr6 must_== 40
+
+      /* skip and limit */
+      val cur7 = coll.find.skip(10).limit(20)
+
+      var cntr7 = 0
+      while(cur7.hasNext) {
+        cntr7 += 1
+        cur7.next.get("i") must_== 10+cntr7
+      }
+      cntr7 must_== 20
+
+      // sorting
+      val cur8 = coll.find.sort(new BasicDBObject("i", -1)) // descending
+
+      var cntr8 = 100
+      while(cur8.hasNext) {
+        cur8.next.get("i") must_== cntr8
+        cntr8 -= 1
+      }
+
+      // remove some docs by a query
+      coll.remove(new BasicDBObject("i", new BasicDBObject("$gt", 50)))
+
+      coll.find.count must_== 50
+
+      if (!debug) {
+        // delete the rest of the rows
+        coll.remove(new BasicDBObject("i", new BasicDBObject("$lte", 50)))
+        coll.find.count must_== 0
+        coll.drop
+      }
+    })
+    success
+  }
+
+  "Mongo more examples" in {
+
+    checkMongoIsRunning
+
+    // use a Mongo instance directly
+    MongoDB.use ( db => {
+      val coll = db.getCollection("testCollection")
+
+      // create a unique index on name
+      coll.createIndex(new BasicDBObject("name", 1), new BasicDBObject("unique", true))
+
+      // build the DBObjects
+      val doc = new BasicDBObject
+      val doc2 = new BasicDBObject
+      val doc3 = new BasicDBObject
+
+      doc.put("name", "MongoSession")
+      doc.put("type", "db")
+      doc.put("count", 1: java.lang.Integer)
+
+      doc2.put("name", "MongoSession")
+      doc2.put("type", "db")
+      doc2.put("count", 1: java.lang.Integer)
+
+      doc3.put("name", "MongoDB")
+      doc3.put("type", "db")
+      doc3.put("count", 1: java.lang.Integer)
+
+      // save the docs to the db
+      Helpers.tryo(coll.save(doc, WriteConcern.SAFE)).toOption must beSome
+      coll.save(doc2, WriteConcern.SAFE) must throwA[MongoException]
+      Helpers.tryo(coll.save(doc2, WriteConcern.SAFE)) must beLike {
+        case Failure(msg, _, _) =>
+          msg must contain("E11000")
+      }
+      Helpers.tryo(coll.save(doc3, WriteConcern.SAFE)).toOption must beSome
+
+      // query for the docs by type
+      val qry = new BasicDBObject("type", "db")
+      coll.find(qry).count must_== 2
+
+      // modifier operations $inc, $set, $push...
+      val o2 = new BasicDBObject
+      o2.put("$inc", new BasicDBObject("count", 1)) // increment count by 1
+      coll.update(qry, o2, false, false).getN must_== 1
+      coll.update(qry, o2, false, false).isUpdateOfExisting must_== true
+
+      // this update query won't find any docs to update
+      coll.update(new BasicDBObject("name", "None"), o2, false, false).getN must_== 0
+
+      // regex query example
+      val key = "name"
+      val regex = "^Mongo"
+      val cur = coll.find(
+          BasicDBObjectBuilder.start.add(key, Pattern.compile(regex)).get)
+      cur.count must_== 2
+
+      // use regex and another dbobject
+      val cur2 = coll.find(
+          BasicDBObjectBuilder.start.add(key, Pattern.compile(regex)).add("count", 1).get)
+      cur2.count must_== 1
+
+      if (!debug) {
+        // delete them
+        coll.remove(new BasicDBObject("type", "db")).getN must_== 2
+        coll.find.count must_== 0
+        coll.drop
+      }
+    })
+    success
+  }
+
+  "UUID Example" in {
+
+    checkMongoIsRunning
+
+    MongoDB.useCollection("examples.uuid") { coll =>
+      val uuid = UUID.randomUUID
+      val dbo = new BasicDBObject("_id", uuid).append("name", "dbo")
+      coll.save(dbo)
+
+      val qry = new BasicDBObject("_id", uuid)
+      val dbo2 = coll.findOne(qry)
+
+      dbo2.get("_id") must_== dbo.get("_id")
+      dbo2.get("name") must_== dbo.get("name")
+    }
+  }
+}

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/LegacyMongoDocumentExamplesSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/LegacyMongoDocumentExamplesSpec.scala
@@ -1,0 +1,668 @@
+/*
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.liftweb
+package mongodb
+
+import BsonDSL._
+import net.liftweb.util.{Helpers, ConnectionIdentifier, DefaultConnectionIdentifier}
+
+import java.util.{Calendar, Date, UUID}
+import java.util.regex.Pattern
+
+import org.bson.types.ObjectId
+import com.mongodb._
+
+import org.specs2.mutable.Specification
+
+import json.DefaultFormats
+import net.liftweb.common.Failure
+
+
+package legacymongotestdocs {
+  /*
+  * ConnectionIdentifiers
+  */
+  object TstDBa extends ConnectionIdentifier {
+    val jndiName = "test_a"
+  }
+  object TstDBb extends ConnectionIdentifier {
+    val jndiName = "test_b"
+  }
+
+  /*
+  * _id as a ObjectId
+  */
+  case class SimplePerson(_id: ObjectId, name: String, age: Int) extends MongoDocument[SimplePerson] {
+    def meta = SimplePerson
+  }
+  object SimplePerson extends MongoDocumentMeta[SimplePerson] {
+    override val collectionName = "simplepersons"
+    override def connectionIdentifier = DefaultConnectionIdentifier
+    override def formats = super.formats + new ObjectIdSerializer
+    // index name
+    createIndex(("name" -> 1))
+  }
+
+  case class Address(street: String, city: String)
+  case class Child(name: String, age: Int, birthdate: Option[Date])
+
+  /*
+  * _id as UUID
+  */
+  case class Person(_id: UUID, name: String, age: Int, address: Address, children: List[Child], dob: Date)
+    extends MongoDocument[Person] {
+
+    def meta = Person
+  }
+
+  object Person extends MongoDocumentMeta[Person] {
+    override def connectionIdentifier = TstDBa
+    override def collectionName = "mypersons"
+    override def formats = super.formats + new UUIDSerializer
+  }
+
+  /*
+  * _id as ObjectId.toString
+  */
+  case class TCInfo(x: Int, y: Int, uuid: UUID)
+  case class TstCollection(_id: String, name: String, dbtype: String, count: Int, info: TCInfo)
+    extends MongoDocument[TstCollection] {
+
+    def meta = TstCollection
+  }
+
+  object TstCollection extends MongoDocumentMeta[TstCollection] {
+    override def formats = super.formats + new UUIDSerializer
+    // create a unique index on name
+    createIndex(("name" -> 1), true)
+    // create a non-unique index on dbtype passing unique = false.
+    createIndex(("dbtype" -> 1), false)
+  }
+
+  case class IDoc(_id: ObjectId, i: Int) extends MongoDocument[IDoc] {
+
+    def meta = IDoc
+  }
+
+  object IDoc extends MongoDocumentMeta[IDoc] {
+    override def formats = super.formats + new ObjectIdSerializer
+    // create an index on "i", descending with custom name
+    createIndex(("i" -> -1), ("name" -> "i_ix1"))
+  }
+
+  case class SessCollection(_id: ObjectId, name: String, dbtype: String, count: Int)
+    extends MongoDocument[SessCollection] {
+
+    def meta = SessCollection
+  }
+
+  object SessCollection extends MongoDocumentMeta[SessCollection] {
+    override def formats = super.formats + new ObjectIdSerializer
+    // create a unique index on name
+    createIndex(("name" -> 1), true)
+  }
+
+  /*
+  * mongo-java-driver is not compatible with numbers that have an e in them
+  */
+  case class Primitive(
+    _id: ObjectId,
+    intfield: Int,
+    longfield: Long,
+    doublefield: Double,
+    floatfield: Float,
+    bigintfield: BigInt,
+    bytefield: Byte,
+    booleanfield: Boolean,
+    shortfield: Short,
+    datefield: Date
+  ) extends MongoDocument[Primitive] {
+
+    def meta = Primitive
+  }
+
+  object Primitive extends MongoDocumentMeta[Primitive] {
+    override def formats = super.formats + new ObjectIdSerializer
+  }
+
+  case class MainJDoc(_id: ObjectId, name: String, refdoc: Option[MongoRef], refId: Option[ObjectId]) extends MongoDocument[MainJDoc] {
+    def meta = MainJDoc
+  }
+
+  object MainJDoc extends MongoDocumentMeta[MainJDoc] {
+    override def formats = super.formats + new ObjectIdSerializer
+  }
+
+  case class RefJDoc(_id: ObjectId) extends MongoDocument[RefJDoc] {
+    def meta = RefJDoc
+  }
+
+  object RefJDoc extends MongoDocumentMeta[RefJDoc] {
+    override def formats = super.formats + new ObjectIdSerializer
+  }
+
+  case class PatternDoc(_id: ObjectId, regx: Pattern) extends MongoDocument[PatternDoc] {
+    def meta = PatternDoc
+  }
+  object PatternDoc extends MongoDocumentMeta[PatternDoc] {
+    override def formats = super.formats + new ObjectIdSerializer + new PatternSerializer
+  }
+
+  case class StringDateDoc(_id: ObjectId, dt: Date) extends MongoDocument[StringDateDoc] {
+    def meta = StringDateDoc
+  }
+  object StringDateDoc extends MongoDocumentMeta[StringDateDoc] {
+    override def formats = new DefaultFormats {
+      override def dateFormatter = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'")
+    } + new DateSerializer + new ObjectIdSerializer
+  }
+
+}
+
+
+/**
+ * Systems under specification for MongoDocumentExamples.
+ */
+class LegacyMongoDocumentExamplesSpec extends Specification with MongoTestKit {
+  "LegacyMongoDocumentExamples Specification".title
+
+  import legacymongotestdocs._
+
+  override def dbName = "lift_legacymongodocumentexamples"
+
+  override def dbs = (TstDBa, "lift_legacymongodocumentexamples_a") :: super.dbs
+
+  "Simple Person example" in {
+
+    checkMongoIsRunning
+
+    // create a new SimplePerson
+    val pid = ObjectId.get
+    val p = SimplePerson(pid, "Tim", 38)
+
+    // save it
+    p.save
+
+    // retrieve it
+    def pFromDb = SimplePerson.find(pid)
+
+    pFromDb.isDefined must_== true
+    p mustEqual pFromDb.get
+
+    // retrieve it using a Json query
+    def pFromDbViaJson = SimplePerson.find(("_id" -> pid))
+
+    pFromDbViaJson.isDefined must_== true
+
+    p mustEqual pFromDbViaJson.get
+
+    // modify and save the person
+    val p2 = p.copy(name="Timm", age=27)
+    p2.save
+    pFromDb.isDefined must_== true
+    p2 must_== pFromDb.get
+    p2.name must_== pFromDb.get.name
+
+    // find all documents
+    val all = SimplePerson.findAll
+
+    all.isEmpty must_== false
+
+    all.size must_== 1
+    all.head must_== p2
+
+    // delete it
+    p2.delete
+
+    pFromDb.isEmpty must_== true
+    pFromDbViaJson.isEmpty must_== true
+
+    if (!debug) {
+      SimplePerson.drop
+    }
+
+    success
+  }
+
+  "Multiple Simple Person example" in {
+
+    checkMongoIsRunning
+
+    // create new SimplePersons
+    val p = SimplePerson(ObjectId.get, "Jill", 27)
+    val p2 = SimplePerson(ObjectId.get, "Bob", 25)
+    val p3 = SimplePerson(ObjectId.get, "Bob", 29)
+
+    // save them
+    p.save
+    p2.save
+    p3.save
+
+    // retrieve them
+    def pFromDb = SimplePerson.find(p._id)
+    def p2FromDb = SimplePerson.find(p2._id)
+    def p3FromDb = SimplePerson.find(("_id" -> ("$oid" -> p3._id.toString)))
+
+    pFromDb.isDefined must_== true
+    p2FromDb.isDefined must_== true
+    p3FromDb.isDefined must_== true
+
+    p mustEqual pFromDb.get
+    p2 mustEqual p2FromDb.get
+    p3 mustEqual p3FromDb.get
+
+    // find all persons named 'Bob'
+    val allBobs = SimplePerson.findAll(("name" -> "Bob"))
+    val allBobs2 = SimplePerson.findAll("name", "Bob")
+
+    allBobs.isEmpty must_== false
+    allBobs2.isEmpty must_== false
+
+    if (!debug) {
+      allBobs.size must_== 2
+      allBobs2.size must_== 2
+
+      // delete them
+      p.delete
+      p2.delete
+      p3.delete
+
+      pFromDb.isEmpty must_== true
+      p2FromDb.isEmpty must_== true
+      p3FromDb.isEmpty must_== true
+
+      SimplePerson.drop
+    }
+
+    success
+  }
+
+  "Person example" in {
+
+    checkMongoIsRunning
+
+    def date(s: String) = Person.formats.dateFormat.parse(s).get
+
+    val cal = Calendar.getInstance
+    cal.set(2009, 10, 2)
+
+    // create a new Person UUID.randomUUID.toString
+    val p = Person(UUID.randomUUID, "joe", 27, Address("Bulevard", "Helsinki"), List(Child("Mary", 5, Some(cal.getTime)), Child("Mazy", 3, None)), date("2004-09-04T18:06:22.000Z"))
+
+    // save it
+    p.save
+
+    // retrieve it
+    def pFromDb = Person.find(p._id)
+
+    // compare to original
+    val p2 = pFromDb
+    p2.isDefined must_== true
+    p must_== p2.get
+
+    Person.count must_== 1
+
+    if (!debug) {
+      // delete it
+      p.delete
+
+      pFromDb.isEmpty must_== true
+
+      Person.drop
+    }
+
+    success
+  }
+
+  "Mongo tutorial example" in {
+
+    import scala.collection.JavaConverters._
+
+    checkMongoIsRunning
+
+    // get the indexes
+    val ixs = MongoDB.useCollection(TstCollection.collectionName)( coll => {
+      coll.getIndexInfo.asScala
+    })
+
+    // unique index on name
+    val ixName = ixs.find(dbo => dbo.get("name") == "name_1")
+    ixName.isDefined must_== true
+    ixName foreach { ix =>
+      ix.containsField("unique") must beTrue
+      ix.get("unique").asInstanceOf[Boolean] must beTrue
+    }
+
+    // non-unique index on dbtype
+    val ixDbtype = ixs.find(dbo => dbo.get("name") == "dbtype_1")
+    ixDbtype.isDefined must_== true
+    ixDbtype foreach { ix =>
+      ix.containsField("unique") must beFalse
+    }
+
+    // build a TstCollection
+    val info = TCInfo(203, 102, UUID.randomUUID)
+    val tc = TstCollection(ObjectId.get.toString, "MongoDB", "database", 1, info)
+    val tc2 = TstCollection(ObjectId.get.toString, "OtherDB", "database", 1, info)
+
+    // save to db
+    tc.save
+    tc2.save
+
+    // Query
+    def tcFromDb = TstCollection.find(tc._id)
+    def tc2FromDb = TstCollection.find(tc2._id)
+
+    tcFromDb.isDefined must_== true
+    tcFromDb.get must_== tc
+    tc2FromDb.isDefined must_== true
+    tc2FromDb.get must_== tc2
+
+    // update
+    val tc3 = TstCollection(tc._id, "MongoDB", "document", 2, info) // the new object to update with, replaces the entire document, except possibly _id
+    val q = ("name" -> "MongoDB") // the query to select the document(s) to update
+    TstCollection.update(q, tc3)
+    tcFromDb.isDefined must_== true
+    tcFromDb.get must_== tc3
+
+    // Upsert - this should add a new row
+    val tc4 = TstCollection(ObjectId.get.toString, "nothing", "document", 1, info)
+    TstCollection.update(("name" -> "nothing"), tc4, Upsert)
+    TstCollection.findAll.length must_== 3
+
+    // modifier operations $inc, $set, $push...
+    val o2 = (("$inc" -> ("count" -> 1)) ~ ("$set" -> ("dbtype" -> "docdb")))
+    TstCollection.update(q, o2)
+    tcFromDb.isDefined must_== true
+    tcFromDb.get must_== TstCollection(tc._id, tc.name, "docdb", 3, info)
+
+    // this one shouldn't update anything
+    val o3 = (("$inc" -> ("count" -> 1)) ~ ("$set" -> ("dbtype" -> "docdb")))
+    // when using $ modifiers, apply has to be false
+    TstCollection.update(("name" -> "nothing"), o3)
+    TstCollection.findAll.length must_== 3
+
+    if (!debug) {
+      // delete them
+      tc.delete
+      tc2.delete
+      tc4.delete
+
+      TstCollection.findAll.size must_== 0
+    }
+
+    // insert multiple documents
+    for (i <- List.range(1, 101)) {
+      IDoc(ObjectId.get, i).save
+    }
+
+    // count the docs
+    IDoc.count must_== 100
+
+    // get the count using a query
+    IDoc.count(("i" -> ("$gt" -> 50))) must_== 50
+
+    // get a List of all documents
+    val all = IDoc.findAll
+    all.length must_== 100
+
+    // get a single document with a query ( i = 71 )
+    val doc = IDoc.find(("i" -> 71))
+
+    doc.isDefined must_== true
+    doc.get.i must_== 71
+
+    // get a set of documents with a query
+    // e.g. find all where i > 50
+    val list1 = IDoc.findAll(("i" -> ("$gt" -> 50)))
+
+    list1.length must_== 50
+
+    // range - 20 < i <= 30
+    val list2 = IDoc.findAll(("i" -> ("$gt" -> 20) ~ ("$lte" -> 30)))
+
+    list2.length must_== 10
+
+    // limiting result set
+    val list3 = IDoc.findAll(("i" -> ("$gt" -> 50)), Limit(3))
+
+    list3.length must_== 3
+
+    // skip
+    val list4 = IDoc.findAll(("i" -> ("$gt" -> 50)), ("i" -> 1), Skip(10))
+    list4.size must_== 40
+    var cntr4 = 0
+    for (idoc <- list4) {
+      cntr4 += 1
+      idoc.i must_== 60+cntr4
+    }
+
+    // skip and limit (get first 10, skipping the first 5, where i > 50)
+    val list5 = IDoc.findAll(("i" -> ("$gt" -> 50)), ("i" -> 1), Limit(10), Skip(5))
+    var cntr5 = 0
+    for (idoc <- list5) {
+      cntr5 += 1
+      idoc.i must_== 55+cntr5
+    }
+    list5.length must_== 10
+
+    // sorting (it's also easy to sort the List after it's returned)
+    val list6 = IDoc.findAll(("i" -> ("$gt" -> 0)), ("i" -> -1)) // descending
+    var cntr6 = 100
+    for (idoc <- list6) {
+      idoc.i must_== cntr6
+      cntr6 -= 1
+    }
+    list6.length must_== 100
+
+    // remove some docs by a query
+    IDoc.delete(("i" -> ("$gt" -> 50)))
+    IDoc.findAll.length must_== 50
+
+    IDoc.drop
+
+    success
+  }
+
+  "Mongo examples" in {
+
+    checkMongoIsRunning
+
+    val tc = SessCollection(ObjectId.get, "MongoSession", "db", 1)
+    val tc2 = SessCollection(ObjectId.get, "MongoSession", "db", 1)
+    val tc3 = SessCollection(ObjectId.get, "MongoDB", "db", 1)
+
+    // use a Mongo instance directly
+    MongoDB.use( db => {
+
+      // save to db
+      Helpers.tryo(SessCollection.save(tc, db)).toOption must beSome
+      SessCollection.save(tc2, db) must throwA[MongoException]
+      Helpers.tryo(SessCollection.save(tc2, db)) must beLike {
+        case Failure(msg, _, _) =>
+          msg must contain("E11000")
+      }
+
+      Helpers.tryo(SessCollection.save(tc3, db)).toOption must beSome
+
+      // query for the docs by type
+      val qry = ("dbtype" -> "db")
+      SessCollection.findAll(qry).size must_== 2
+
+      // modifier operations $inc, $set, $push...
+      val o2 = ("$inc" -> ("count" -> 1)) // increment count by 1
+      SessCollection.update(qry, o2, db)
+      SessCollection.update(qry, o2, db, Multi)
+
+      // regex query example
+      val lst = SessCollection.findAll(new BasicDBObject("name", Pattern.compile("^Mongo")))
+      lst.size must_== 2
+
+      // jobject query now also works
+      val lstjobj = SessCollection.findAll(("name" -> (("$regex" -> "^Mon") ~ ("$flags" -> 0))))
+      lstjobj.size must_== 2
+
+      // use regex and another clause
+      val lst2 = SessCollection.findAll(new BasicDBObject("name", Pattern.compile("^Mon")).append("count", 2))
+      lst2.size must_== 1
+
+      val lstjobj2 = SessCollection.findAll(("name" -> (("$regex" -> "^Mongo") ~ ("$flags" -> 0))) ~ ("count" -> 3))
+      lstjobj2.size must_== 1
+
+      if (!debug) {
+        // delete them
+        SessCollection.delete(qry)
+        SessCollection.findAll.size must_== 0
+
+        SessCollection.drop
+      }
+
+    })
+
+    success
+  }
+
+  "Primitives example" in {
+
+    checkMongoIsRunning
+
+    def date(s: String) = Primitive.formats.dateFormat.parse(s).get
+
+    val p = Primitive(ObjectId.get, 2147483647, 2147483648L, 1797693, 3.4028235F, 1000, 0, true, 512, date("2004-09-04T18:06:22.000Z"))
+
+    // save it
+    p.save
+
+    // retrieve it
+    def pFromDb = Primitive.find(p._id)
+
+    pFromDb.isDefined must_== true
+
+    p mustEqual pFromDb.get
+
+    if (!debug) {
+      // delete it
+      p.delete
+
+      pFromDb.isEmpty must_== true
+      Primitive.drop
+    }
+
+    success
+  }
+
+  "Ref example" in {
+
+    checkMongoIsRunning
+
+    val ref1 = RefJDoc(ObjectId.get)
+    val ref2 = RefJDoc(ObjectId.get)
+
+    ref1.save
+    ref2.save
+
+    val md1 = MainJDoc(ObjectId.get, "md1", ref1.getRef, Some(ref1._id))
+    val md2 = MainJDoc(ObjectId.get, "md2", ref1.getRef, None)
+    val md3 = MainJDoc(ObjectId.get, "md3", ref2.getRef, None)
+    val md4 = MainJDoc(ObjectId.get, "md4", ref2.getRef, None)
+
+    md1.save
+    md2.save
+    md3.save
+    md4.save
+
+    MainJDoc.count must_== 4
+    RefJDoc.count must_== 2
+
+    // query for a single doc with a JObject query
+    val md1a = MainJDoc.find(("name") -> "md1")
+    md1a.isDefined must_== true
+    md1a.foreach(o => o._id must_== md1._id)
+
+    // query for a single doc with a k, v query
+    val md1b = MainJDoc.find(md1._id)
+    md1b.isDefined must_== true
+    md1b.foreach(o => o._id must_== md1._id)
+
+    // find all documents
+    MainJDoc.findAll.size must_== 4
+    RefJDoc.findAll.size must_== 2
+
+    // find all documents with JObject query
+    val mdq1 = MainJDoc.findAll(("name" -> "md1"))
+    mdq1.size must_== 1
+
+    // find all documents with $in query, sorted
+    val qry = ("name" -> ("$in" -> List("md1", "md2")))
+    val mdq2 = MainJDoc.findAll(qry, ("name" -> -1))
+    mdq2.size must_== 2
+    mdq2.head._id must_== md2._id
+
+    // Find all documents using a k, v query
+    val mdq3 = MainJDoc.findAll("_id", md1._id)
+    mdq3.size must_== 1
+
+    MainJDoc.drop
+    RefJDoc.drop
+
+    success
+  }
+
+  "Pattern example" in {
+
+    checkMongoIsRunning
+
+    val pdoc1 = PatternDoc(ObjectId.get, Pattern.compile("^Mo", Pattern.CASE_INSENSITIVE))
+    pdoc1.save
+
+    PatternDoc.find(pdoc1._id) must beLike {
+      case Some(pdoc) =>
+        pdoc._id must_== pdoc1._id
+        pdoc.regx.pattern must_== pdoc1.regx.pattern
+        pdoc.regx.flags must_== pdoc1.regx.flags
+    }
+  }
+
+  "Issue 586 Date test" in {
+
+    checkMongoIsRunning
+
+    def date(s: String): Date = StringDateDoc.formats.dateFormat.parse(s).get
+
+    val newId = ObjectId.get
+    val dtStr = "2004-09-04T18:06Z"
+    val newDt = date(dtStr)
+
+    // create a document manually with a String for the Date field
+    MongoDB.useCollection("stringdatedocs") { coll =>
+      coll.save(new BasicDBObject("_id", newId).append("dt", dtStr))
+    }
+
+    val fromDb = StringDateDoc.find(newId)
+    fromDb must beLike {
+      case Some(sdd) =>
+        sdd._id must_== newId
+        sdd.dt must_== newDt
+        sdd.save
+
+        StringDateDoc.find(newId) must beLike {
+          case Some(sdd2) =>
+            sdd2.dt must_== sdd.dt
+        }
+    }
+  }
+}

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/LegacyMongoDocumentMongoClientSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/LegacyMongoDocumentMongoClientSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.specs2.mutable.Specification
 
 import json._
 
-package mongoclienttestdocs {
+package legacymongoclienttestdocs {
   case class SessCollection(_id: ObjectId, name: String, dbtype: String, count: Int)
     extends MongoDocument[SessCollection] {
 
@@ -46,10 +46,10 @@ package mongoclienttestdocs {
 /**
  * Systems under specification for MongoDocumentMongoClient.
  */
-class MongoDocumentMongoClientSpec extends Specification with MongoTestKit {
-  "MongoDocumentMongoClient Specification".title
+class LegacyMongoDocumentMongoClientSpec extends Specification with MongoTestKit {
+  "LegacyMongoDocumentMongoClient Specification".title
 
-  import mongoclienttestdocs._
+  import legacymongoclienttestdocs._
 
   "MongoClient example" in {
 

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoDirectSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,14 @@ package mongodb
 
 import net.liftweb.util.{Helpers, DefaultConnectionIdentifier}
 
+import scala.collection.JavaConverters._
 import java.util.UUID
 import java.util.regex.Pattern
 
+import org.bson.Document
 import com.mongodb.{WriteConcern, BasicDBObject, BasicDBObjectBuilder, MongoException}
+import com.mongodb.client.model.{IndexOptions, ReplaceOptions, UpdateOptions}
+import com.mongodb.client.model.Filters.{and, eq => eqs}
 
 import org.specs2.mutable.Specification
 
@@ -43,13 +47,13 @@ class MongoDirectSpec extends Specification with MongoTestKit {
     checkMongoIsRunning
 
     // build the DBObject
-    val doc = new BasicDBObject
+    val doc = new Document
 
     doc.put("name", "MongoDB")
     doc.put("type", "database")
     doc.put("count", 1: java.lang.Integer)
 
-    val info = new BasicDBObject
+    val info = new Document
 
     info.put("x", 203: java.lang.Integer)
     info.put("y", 102: java.lang.Integer)
@@ -57,49 +61,47 @@ class MongoDirectSpec extends Specification with MongoTestKit {
     doc.put("info", info)
 
     // use the Mongo instance directly
-    MongoDB.use(DefaultConnectionIdentifier) ( db => {
+    MongoDB.useDatabase(DefaultConnectionIdentifier) { db =>
       val coll = db.getCollection("testCollection")
 
       // save the doc to the db
-      coll.save(doc)
+      coll.insertOne(doc)
 
       // get the doc back from the db and compare them
-      coll.findOne must_== doc
+      coll.find().first() must_== doc
 
       // upsert
       doc.put("type", "document")
       doc.put("count", 2: java.lang.Integer)
-      val q = new BasicDBObject("name", "MongoDB") // the query to select the document(s) to update
+      val q = new Document("name", "MongoDB") // the query to select the document(s) to update
       val o = doc // the new object to update with, replaces the entire document, except possibly _id
-      val upsert = false // if the database should create the element if it does not exist
-      val apply = false // if an _id field should be added to the new object
-      coll.update(q, o, upsert, apply)
+      val ropts = new ReplaceOptions().upsert(false)
+      coll.replaceOne(q, o, ropts)
 
       // get the doc back from the db and compare
-      coll.findOne.get("type") must_== "document"
-      coll.findOne.get("count") must_== 2
+      coll.find.first.get("type") must_== "document"
+      coll.find.first.get("count") must_== 2
 
       // modifier operations $inc, $set, $push...
-      val o2 = new BasicDBObject
-      o2.put("$inc", new BasicDBObject("count", 1)) // increment count by 1
-      o2.put("$set", new BasicDBObject("type", "docdb")) // set type
-      coll.update(q, o2, false, false)
+      val o2 = new Document
+      o2.put("$inc", new Document("count", 1)) // increment count by 1
+      o2.put("$set", new Document("type", "docdb")) // set type
+      val uopts = new UpdateOptions().upsert(false)
+      coll.updateOne(q, o2, uopts)
 
       // get the doc back from the db and compare
-      coll.findOne.get("type") must_== "docdb"
-      coll.findOne.get("count") must_== 3
+      coll.find.first.get("type") must_== "docdb"
+      coll.find.first.get("count") must_== 3
 
       if (!debug) {
         // delete it
-        coll.remove(new BasicDBObject("_id", doc.get("_id")))
-        coll.find.count must_== 0
+        coll.deleteOne(new Document("_id", doc.get("_id")))
+        coll.countDocuments() must_== 0
         coll.drop
       }
 
-      // server-side eval
-      val six = db.eval(" function() { return 3+3; } ")
-      six must_== 6
-    })
+      success
+    }
   }
 
   "Mongo tutorial 2 example" in {
@@ -107,46 +109,46 @@ class MongoDirectSpec extends Specification with MongoTestKit {
     checkMongoIsRunning
 
     // use a DBCollection directly
-    MongoDB.useCollection("iDoc") ( coll => {
+    MongoDB.useMongoCollection("iDoc", classOf[Document]) { coll =>
       // insert multiple documents
       for (i <- List.range(1, 101)) {
-        coll.insert(new BasicDBObject().append("i", i))
+        coll.insertOne(new Document().append("i", i))
       }
 
       // create an index
-      coll.createIndex(new BasicDBObject("i", 1))  // create index on "i", ascending
+      coll.createIndex(new Document("i", 1))  // create index on "i", ascending
 
       // count the docs
-      coll.getCount must_== 100
+      coll.countDocuments() must_== 100
 
       // get the count using a query
-      coll.getCount(new BasicDBObject("i", new BasicDBObject("$gt", 50))) must_== 50
+      coll.countDocuments(new Document("i", new Document("$gt", 50))) must_== 50
 
       // use a cursor to get all docs
       val cur = coll.find
 
-      cur.count must_== 100
+      cur.iterator.asScala.toList.size must_== 100
 
       // get a single document with a query ( i = 71 )
-      val query = new BasicDBObject("i", 71)
+      val query = new Document("i", 71)
       val cur2 = coll.find(query)
 
-      cur2.count must_== 1
-      cur2.next.get("i") must_== 71
+      cur2.iterator.asScala.toList.size must_== 1
+      cur2.first.get("i") must_== 71
 
       // get a set of documents with a query
       // e.g. find all where i > 50
-      val cur3 = coll.find(new BasicDBObject("i", new BasicDBObject("$gt", 50)))
+      val cur3 = coll.find(new Document("i", new Document("$gt", 50)))
 
-      cur3.count must_== 50
+      cur3.iterator.asScala.toList.size must_== 50
 
       // range - 20 < i <= 30
-      val cur4 = coll.find(new BasicDBObject("i", new BasicDBObject("$gt", 20).append("$lte", 30)))
+      val cur4 = coll.find(new Document("i", new Document("$gt", 20).append("$lte", 30)))
 
-      cur4.count must_== 10
+      cur4.iterator.asScala.toList.size must_== 10
 
       // limiting result set
-      val cur5 = coll.find(new BasicDBObject("i", new BasicDBObject("$gt", 50))).limit(3)
+      val cur5 = coll.find(new Document("i", new Document("$gt", 50))).limit(3).iterator
 
       var cntr5 = 0
       while(cur5.hasNext) {
@@ -156,7 +158,7 @@ class MongoDirectSpec extends Specification with MongoTestKit {
       cntr5 must_== 3
 
       // skip
-      val cur6 = coll.find(new BasicDBObject("i", new BasicDBObject("$gt", 50))).skip(10)
+      val cur6 = coll.find(new Document("i", new Document("$gt", 50))).skip(10).iterator
 
       var cntr6 = 0
       while(cur6.hasNext) {
@@ -166,7 +168,7 @@ class MongoDirectSpec extends Specification with MongoTestKit {
       cntr6 must_== 40
 
       /* skip and limit */
-      val cur7 = coll.find.skip(10).limit(20)
+      val cur7 = coll.find.skip(10).limit(20).iterator
 
       var cntr7 = 0
       while(cur7.hasNext) {
@@ -176,7 +178,7 @@ class MongoDirectSpec extends Specification with MongoTestKit {
       cntr7 must_== 20
 
       // sorting
-      val cur8 = coll.find.sort(new BasicDBObject("i", -1)) // descending
+      val cur8 = coll.find.sort(new Document("i", -1)).iterator // descending
 
       var cntr8 = 100
       while(cur8.hasNext) {
@@ -185,17 +187,17 @@ class MongoDirectSpec extends Specification with MongoTestKit {
       }
 
       // remove some docs by a query
-      coll.remove(new BasicDBObject("i", new BasicDBObject("$gt", 50)))
+      coll.deleteMany(new Document("i", new Document("$gt", 50)))
 
-      coll.find.count must_== 50
+      coll.countDocuments() must_== 50
 
       if (!debug) {
         // delete the rest of the rows
-        coll.remove(new BasicDBObject("i", new BasicDBObject("$lte", 50)))
-        coll.find.count must_== 0
+        coll.deleteMany(new Document("i", new Document("$lte", 50)))
+        coll.countDocuments() must_== 0
         coll.drop
       }
-    })
+    }
     success
   }
 
@@ -204,16 +206,16 @@ class MongoDirectSpec extends Specification with MongoTestKit {
     checkMongoIsRunning
 
     // use a Mongo instance directly
-    MongoDB.use ( db => {
+    MongoDB.useDefaultDatabase { db =>
       val coll = db.getCollection("testCollection")
 
       // create a unique index on name
-      coll.createIndex(new BasicDBObject("name", 1), new BasicDBObject("unique", true))
+      coll.createIndex(new Document("name", 1), (new IndexOptions).unique(true))
 
       // build the DBObjects
-      val doc = new BasicDBObject
-      val doc2 = new BasicDBObject
-      val doc3 = new BasicDBObject
+      val doc = new Document
+      val doc2 = new Document
+      val doc3 = new Document
 
       doc.put("name", "MongoSession")
       doc.put("type", "db")
@@ -228,46 +230,42 @@ class MongoDirectSpec extends Specification with MongoTestKit {
       doc3.put("count", 1: java.lang.Integer)
 
       // save the docs to the db
-      Helpers.tryo(coll.save(doc, WriteConcern.SAFE)).toOption must beSome
-      coll.save(doc2, WriteConcern.SAFE) must throwA[MongoException]
-      Helpers.tryo(coll.save(doc2, WriteConcern.SAFE)) must beLike {
+      Helpers.tryo(coll.withWriteConcern(WriteConcern.ACKNOWLEDGED).insertOne(doc)).toOption must beSome
+      coll.withWriteConcern(WriteConcern.ACKNOWLEDGED).insertOne(doc2) must throwA[MongoException]
+      Helpers.tryo(coll.withWriteConcern(WriteConcern.ACKNOWLEDGED).insertOne(doc2)) must beLike {
         case Failure(msg, _, _) =>
           msg must contain("E11000")
       }
-      Helpers.tryo(coll.save(doc3, WriteConcern.SAFE)).toOption must beSome
+      Helpers.tryo(coll.withWriteConcern(WriteConcern.ACKNOWLEDGED).insertOne(doc3)).toOption must beSome
 
       // query for the docs by type
-      val qry = new BasicDBObject("type", "db")
-      coll.find(qry).count must_== 2
+      val qry = eqs("type", "db")
+      coll.countDocuments(qry) must_== 2
 
       // modifier operations $inc, $set, $push...
-      val o2 = new BasicDBObject
-      o2.put("$inc", new BasicDBObject("count", 1)) // increment count by 1
-      coll.update(qry, o2, false, false).getN must_== 1
-      coll.update(qry, o2, false, false).isUpdateOfExisting must_== true
+      val o2 = new Document
+      o2.put("$inc", new Document("count", 1)) // increment count by 1
+      coll.updateOne(qry, o2).getModifiedCount must_== 1
+      coll.updateOne(qry, o2).getMatchedCount must_== 1
 
       // this update query won't find any docs to update
-      coll.update(new BasicDBObject("name", "None"), o2, false, false).getN must_== 0
+      coll.updateOne(eqs("name", "None"), o2).getModifiedCount must_== 0
 
       // regex query example
       val key = "name"
       val regex = "^Mongo"
-      val cur = coll.find(
-          BasicDBObjectBuilder.start.add(key, Pattern.compile(regex)).get)
-      cur.count must_== 2
+      coll.countDocuments(eqs(key, Pattern.compile(regex))) must_== 2
 
       // use regex and another dbobject
-      val cur2 = coll.find(
-          BasicDBObjectBuilder.start.add(key, Pattern.compile(regex)).add("count", 1).get)
-      cur2.count must_== 1
+      coll.countDocuments(and(eqs(key, Pattern.compile(regex)), eqs("count", 1))) must_== 1
 
       if (!debug) {
         // delete them
-        coll.remove(new BasicDBObject("type", "db")).getN must_== 2
-        coll.find.count must_== 0
+        coll.deleteMany(eqs("type", "db")).getDeletedCount must_== 2
+        coll.countDocuments must_== 0
         coll.drop
       }
-    })
+    }
     success
   }
 
@@ -275,17 +273,16 @@ class MongoDirectSpec extends Specification with MongoTestKit {
 
     checkMongoIsRunning
 
-    MongoDB.useCollection("examples.uuid") { coll =>
+    MongoDB.useMongoCollection("examples.uuid", classOf[Document]) { coll =>
       val uuid = UUID.randomUUID
-      val dbo = new BasicDBObject("_id", uuid).append("name", "dbo")
-      coll.save(dbo)
+      val doc = new Document("_id", uuid).append("name", "doc")
+      coll.insertOne(doc)
 
-      val qry = new BasicDBObject("_id", uuid)
-      val dbo2 = coll.findOne(qry)
+      val qry = eqs("_id", uuid)
+      val fromDb = coll.find(qry).first
 
-      dbo2.get("_id") must_== dbo.get("_id")
-      dbo2.get("name") must_== dbo.get("name")
+      fromDb.get("_id") must_== doc.get("_id")
+      fromDb.get("name") must_== doc.get("name")
     }
   }
 }
-

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WorldWide Conferencing, LLC
+ * Copyright 2014-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,15 +38,15 @@ class MongoSpec extends Specification  {
     // make sure mongo is running
     try {
       // this will throw an exception if it can't connect to the db
-      mc.getConnectPoint
+      mc.listDatabaseNames()
     } catch {
       case _: MongoTimeoutException =>
         skipped("MongoDB is not running")
     }
 
     // using an undefined identifier throws an exception
-    MongoDB.use(DefaultConnectionIdentifier) { db =>
-      db.getCollectionNames
+    MongoDB.useDatabase(DefaultConnectionIdentifier) { db =>
+      db.listCollections
     } must throwA(new MongoException("Mongo not found: ConnectionIdentifier(lift)"))
 
     // remove defined db

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoTestKit.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/MongoTestKit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017 WorldWide Conferencing, LLC
+ * Copyright 2010-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ object TestMongo {
   lazy val isMongoRunning: Boolean =
     try {
       // this will throw an exception if it can't connect to the db
-      mongo.getConnectPoint
+      mongo.listDatabaseNames()
       true
     } catch {
       case _: MongoTimeoutException =>
@@ -73,7 +73,7 @@ trait MongoTestKit extends Specification with BeforeAfterEach {
     if (!debug && TestMongo.isMongoRunning) {
       // drop the databases
       dbs.foreach { case (id, _) =>
-        MongoDB.use(id) { db => db.dropDatabase }
+        MongoDB.useDatabase(id) { _.drop() }
       }
     }
 

--- a/persistence/mongodb/src/test/scala/net/liftweb/mongodb/QueryExamplesSpec.scala
+++ b/persistence/mongodb/src/test/scala/net/liftweb/mongodb/QueryExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2014 WorldWide Conferencing, LLC
+ * Copyright 2011-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,13 +27,17 @@ import org.bson.types.ObjectId
 import org.specs2.mutable.Specification
 
 package queryexamplesfixtures {
+  import com.mongodb.client.model.Indexes._
+
   case class Person(_id: ObjectId, name: String, birthDate: Date, childId: UUID, petId: Option[ObjectId]) extends MongoDocument[Person] {
     def meta = Person
   }
   object Person extends MongoDocumentMeta[Person] {
     override def formats = allFormats
-    // index name
-    createIndex(("name" -> 1))
+
+    def createIndexes(): Unit =  {
+      Person.createIndex(ascending("name"))
+    }
 
     // implicit formats already exists
     def findAllBornAfter(dt: Date) = findAll(("birthDate" -> ("$gt" -> dt)))
@@ -47,6 +51,8 @@ class QueryExamplesSpec extends Specification with MongoTestKit {
 
   "Query examples" in {
     checkMongoIsRunning
+
+    Person.createIndexes()
 
     val fredsBirthDate = Calendar.getInstance
     fredsBirthDate.set(1970, 1, 1, 19, 0)

--- a/persistence/record/src/main/scala/net/liftweb/record/Field.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/Field.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2019 WorldWide Conferencing, LLC
+ * Copyright 2007-20190 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/persistence/record/src/main/scala/net/liftweb/record/field/BinaryField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/BinaryField.scala
@@ -30,7 +30,7 @@ import JE._
 
 
 trait BinaryTypedField extends TypedField[Array[Byte]] {
-  
+
   def setFromAny(in: Any): Box[Array[Byte]] = genericSetFromAny(in)
 
   def setFromString(s: String): Box[Array[Byte]] = s match {
@@ -46,7 +46,7 @@ trait BinaryTypedField extends TypedField[Array[Byte]] {
   def asJValue: JValue = asJString(base64Encode _)
   def setFromJValue(jvalue: JValue) = setFromJString(jvalue)(s => tryo(base64Decode(s)))
 }
-  
+
 class BinaryField[OwnerType <: Record[OwnerType]](@deprecatedName('rec) val owner: OwnerType)
   extends Field[Array[Byte], OwnerType] with MandatoryTypedField[Array[Byte]] with BinaryTypedField {
 

--- a/persistence/record/src/main/scala/net/liftweb/record/field/EnumField.scala
+++ b/persistence/record/src/main/scala/net/liftweb/record/field/EnumField.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2011 WorldWide Conferencing, LLC
+ * Copyright 2007-2020 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,18 +41,18 @@ trait EnumTypedField[EnumType <: Enumeration] extends TypedField[EnumType#Value]
   def fromInt(in: Int): Box[EnumType#Value] = tryo(enum(in))
 
   def setFromAny(in: Any): Box[EnumType#Value] = in match {
-    case     (value: Int)    => setBox(fromInt(value))
-    case Some(value: Int)    => setBox(fromInt(value))
-    case Full(value: Int)    => setBox(fromInt(value))
-    case (value: Int)::_     => setBox(fromInt(value))
-    case     (value: Number) => setBox(fromInt(value.intValue))
-    case Some(value: Number) => setBox(fromInt(value.intValue))
-    case Full(value: Number) => setBox(fromInt(value.intValue))
-    case (value: Number)::_  => setBox(fromInt(value.intValue))
+    case     (value: Int)    => setFromInt(value)
+    case Some(value: Int)    => setFromInt(value)
+    case Full(value: Int)    => setFromInt(value)
+    case (value: Int)::_     => setFromInt(value)
+    case     (value: Number) => setFromInt(value.intValue)
+    case Some(value: Number) => setFromInt(value.intValue)
+    case Full(value: Number) => setFromInt(value.intValue)
+    case (value: Number)::_  => setFromInt(value.intValue)
     case _                   => genericSetFromAny(in)(valueManifest)
   }
 
-  def setFromString(s: String): Box[EnumType#Value] = 
+  def setFromString(s: String): Box[EnumType#Value] =
     if(s == null || s.isEmpty) {
       if(optional_?)
     	  setBox(Empty)
@@ -61,6 +61,8 @@ trait EnumTypedField[EnumType <: Enumeration] extends TypedField[EnumType#Value]
     } else {
       setBox(asInt(s).flatMap(fromInt))
     }
+
+  def setFromInt(in: Int): Box[EnumType#Value] = setBox(fromInt(in))
 
   /** Label for the selection item representing Empty, show when this field is optional. Defaults to the empty string. */
   def emptyOptionLabel: String = ""

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,8 +33,8 @@ object Dependencies {
   lazy val joda_time              = "joda-time"                  % "joda-time"          % "2.10"
   lazy val joda_convert           = "org.joda"                   % "joda-convert"       % "2.1"
   lazy val htmlparser             = "nu.validator"               % "htmlparser"         % "1.4.12"
-  lazy val mongo_java_driver      = "org.mongodb"                % "mongodb-driver"     % "3.7.1"
-  lazy val mongo_java_driver_async  = "org.mongodb"              % "mongodb-driver-async" % "3.7.1"
+  lazy val mongo_java_driver      = "org.mongodb"                % "mongodb-driver"     % "3.12.5"
+  lazy val mongo_java_driver_async  = "org.mongodb"              % "mongodb-driver-async" % "3.12.5"
   lazy val paranamer              = "com.thoughtworks.paranamer" % "paranamer"          % "2.8"
   lazy val scalajpa               = "org.scala-libs"             % "scalajpa"           % "1.5"
   lazy val scalap: ModuleMap      = "org.scala-lang"             % "scalap"             % _

--- a/project/LiftSbtHelpers.scala
+++ b/project/LiftSbtHelpers.scala
@@ -37,7 +37,7 @@ object LiftSbtHelpers {
 
   def liftProject(id: String, base: File): Project = {
     Project(id, base)
-      .settings(scalacOptions ++= List("-feature", "-language:implicitConversions"))
+      .settings(scalacOptions ++= List("-feature", "-language:implicitConversions", "-deprecation"))
       .settings(
         autoAPIMappings := true,
         apiMappings ++= {

--- a/travis.sh
+++ b/travis.sh
@@ -12,7 +12,7 @@ if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -z "$DISABLE_PUBLISH" ]; then
 
   if [[ "$TRAVIS_SCALA_VERSION" =~ ^2.13 ]]; then
     # we only have certain modules available for publishing in 2.13
-    sbt ++$TRAVIS_SCALA_VERSION lift-webkit/publish lift-json/publish lift-actor/publish lift-json-ext/publish lift-record/publish lift-proto/publish lift-mapper/publish lift-common/publish lift-db/publish lift-markdown/publish lift-util/publish lift-testkit/publish
+    sbt ++$TRAVIS_SCALA_VERSION lift-webkit/publish lift-json/publish lift-actor/publish lift-json-ext/publish lift-record/publish lift-proto/publish lift-mapper/publish lift-common/publish lift-db/publish lift-markdown/publish lift-util/publish lift-testkit/publish lift-mongodb/publish lift-mongodb-record/publish
   else
     sbt ++$TRAVIS_SCALA_VERSION publish
   fi


### PR DESCRIPTION
…ongo-java-driver. Enable Scala 2.13 for lift-mongodb and lift-mongodb-record.

Fixes #1830 
Supercedes #1977

Since there haven't been any replies to my [ml thread about the async parts](https://groups.google.com/d/msg/liftweb/GkY3BRab4GI/TnJmrMLuBQAJ) I've chosen to deprecate them. If someone comes along later and wants to use them we can update them at that point.

I'm running this locally with my app (rotozen.com) and all is working ok. I'll be testing it for a few more days since the app does different things depending on the day of the week.