### PR TITLE
Bump to Scala 2.12.12 for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 sudo: false
 scala:
   - 2.11.12
-  - 2.12.11
+  - 2.12.12
   - 2.13.2
 cache:
   directories:
@@ -15,10 +15,10 @@ jdk:
   - openjdk8
 matrix:
   include:
-  - scala: 2.12.11
+  - scala: 2.12.12
     jdk: openjdk11
     env: DISABLE_PUBLISH=true
-  - scala: 2.12.11
+  - scala: 2.12.12
     jdk: openjdk12
     env: DISABLE_PUBLISH=true
   - scala: 2.13.2

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ startYear in ThisBuild             := Some(2006)
 organizationName in ThisBuild      := "WorldWide Conferencing, LLC"
 
 val scala211Version = "2.11.12"
-val scala212Version = "2.12.11"
+val scala212Version = "2.12.12"
 val scala213Version = "2.13.2"
 
 val crossUpTo212 = Seq(scala212Version, scala211Version)


### PR DESCRIPTION
Bumps the version of Scala to 2.12.12. Hoping this gets things compatible for [this issue on the ML](https://groups.google.com/g/liftweb/c/pgTJc2C86Cg/m/UtOInrknAAAJ).
