### PR TITLE
Remove squeryl and JSON scala combinators parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val core: Seq[ProjectReference] =
 lazy val common =
   coreProject("common")
     .settings(
-      description := "Common Libraties and Utilities",
+      description := "Common Libraries and Utilities",
       libraryDependencies ++= Seq(slf4j_api, logback, slf4j_log4j12, scala_xml, scala_parser)
     )
 
@@ -201,7 +201,7 @@ lazy val webkit =
 // Persistence Projects
 // --------------------
 lazy val persistence: Seq[ProjectReference] =
-  Seq(db, proto, mapper, record, squeryl_record, mongodb, mongodb_record)
+  Seq(db, proto, mapper, record, mongodb, mongodb_record)
 
 lazy val db =
   persistenceProject("db")
@@ -231,11 +231,6 @@ lazy val record =
   persistenceProject("record")
     .dependsOn(proto)
     .settings(libraryDependencies ++= Seq(jbcrypt))
-
-lazy val squeryl_record =
-  persistenceProject("squeryl-record")
-    .dependsOn(record, db)
-    .settings(libraryDependencies ++= Seq(h2, squeryl))
 
 lazy val mongodb =
   persistenceProject("mongodb")

--- a/core/json/benchmark/Jsonbench.scala
+++ b/core/json/benchmark/Jsonbench.scala
@@ -5,13 +5,11 @@
  * - lift-json-???.jar
  */
 object Jsonbench extends Benchmark {
-  import scala.util.parsing.json.JSON
   import org.codehaus.jackson._
   import org.codehaus.jackson.map._
   import net.liftweb.json.JsonParser
 
   def main(args: Array[String]) = {
-    benchmark("Scala std") { JSON.parse(json) }
     val mapper = new ObjectMapper
     benchmark("Jackson") { mapper.readValue(json, classOf[JsonNode]) }
     benchmark("lift-json") { JsonParser.parse(json) }

--- a/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
+++ b/core/json/src/test/scala/net/liftweb/json/JsonPrintingSpec.scala
@@ -32,7 +32,7 @@ class JsonPrintingSpec extends Specification  with JValueGen with ScalaCheck {
   "JSON Printing Specification".title
 
   "rendering does not change semantics" in {
-    val rendering = (json: JValue) => parse(JsonAST.prettyRender(json)) == parse(JsonAST.compactRender(json))
+    val rendering = (json: JValue) => JsonParser.parse(JsonAST.prettyRender(json)) == JsonParser.parse(JsonAST.compactRender(json))
     forAll(rendering)
   }
 
@@ -106,8 +106,6 @@ class JsonPrintingSpec extends Specification  with JValueGen with ScalaCheck {
       render(JDouble(Double.NaN)) must throwAn[IllegalArgumentException]
     }
   }
-
-  private def parse(json: String) = scala.util.parsing.json.JSON.parseRaw(json)
 
   implicit def arbDoc: Arbitrary[JValue] = Arbitrary(genJValue)
 }

--- a/core/markdown/src/main/scala/net/liftweb/markdown/BaseParsers.scala
+++ b/core/markdown/src/main/scala/net/liftweb/markdown/BaseParsers.scala
@@ -21,7 +21,6 @@ package net.liftweb.markdown
 
 import scala.language.postfixOps
 
-import util.parsing.json.Parser
 import util.parsing.combinator.RegexParsers
 import collection.SortedMap
 
@@ -151,7 +150,7 @@ trait BaseParsers extends RegexParsers {
             val lower:SortedMap[Char,Char] = rs.rangeTo(c)
             val (begin:Char, end:Char) = if (lower.isEmpty) ('\u0001', '\u0000') //this invalid pair always causes failure
                                          else lower.last
-                               
+
             if (begin <= c && c <= end) Success(c, in.rest)
             else                        Failure(verboseString(c) + " not in range " +
                                             verboseString(begin) + " - " + verboseString(end),
@@ -161,7 +160,7 @@ trait BaseParsers extends RegexParsers {
 
     /**
      * Succeeds if the given parsers succeeds and the given function is defined at the parse result.
-     * Returns the result of the method applied to the given parsers result. 
+     * Returns the result of the method applied to the given parsers result.
      */
     def acceptMatch[S,T](f:PartialFunction[S,T])(p:Parser[S]):Parser[T] = Parser { in =>
         p(in) match {
@@ -242,7 +241,7 @@ trait BaseParsers extends RegexParsers {
      * everything between the quotes is run through the escape handling
      * That way you can omit xml escaping when writing inline XML in markdown.
      */
-    def xmlAttrVal:Parser[String] = 
+    def xmlAttrVal:Parser[String] =
       ('"'  ~> ((not('"')  ~> aChar)*) <~ '"'  ^^ {'"' +  _.mkString + '"' }) |
       ('\'' ~> ((not('\'') ~> aChar)*) <~ '\'' ^^ {'\'' + _.mkString + '\''})
     /** Parses an XML Attribute with simplified value handling like xmlAttrVal.

--- a/core/util/src/main/scala/net/liftweb/util/SourceInfo.scala
+++ b/core/util/src/main/scala/net/liftweb/util/SourceInfo.scala
@@ -2,7 +2,6 @@ package net.liftweb.util
 
 import net.liftweb.common.Box
 import scala.xml.NodeSeq
-import util.parsing.json.JSONArray
 import net.liftweb.json.JsonAST.JValue
 import scala.reflect.runtime.universe._
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,6 @@ object Dependencies {
   lazy val scalap: ModuleMap      = "org.scala-lang"             % "scalap"             % _
   lazy val scala_compiler: ModuleMap = "org.scala-lang"          % "scala-compiler"     % _
   lazy val scalaz7_core           = "org.scalaz"                %% "scalaz-core"        % "7.2.28"
-  lazy val squeryl                = "org.squeryl"               %% "squeryl"            % "0.9.5-7"
   lazy val slf4j_api              = "org.slf4j"                  % "slf4j-api"          % slf4jVersion
   lazy val scala_xml              = "org.scala-lang.modules"     %% "scala-xml"         % "1.3.0"
   lazy val scala_parallel_collections =  "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0"


### PR DESCRIPTION
Remove dependencies that are not used anymore but still referenced, causing problems for futur upgrades: 

 - squeryl is a dead project for years now, and it causes import problem in intellij. Since `persistance` module is deleted, there's no reason to keep it, 
 - `JSON` in scala-combinator was removed post-1.1 branch as a "sample, confused for a real parsed" and should not be used. It will make impossible update to newer version of the llib. See: https://github.com/scala/scala-parser-combinators/issues/99

The changes are minimal and all tests pass. 