### PR TITLE
feat(lift-json)!: Prepare for scala 3 with type extractor

### DIFF
--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -448,9 +448,14 @@ object Extraction {
         else if (classOf[Seq[_]].isAssignableFrom(c)) newCollection(root, m, a => List(a.toSeq: _*))
         else if (c == classOf[Option[_]]) newOption(root, m)
         else fail("Expected collection but got " + m + " for class " + c)
+
       case Dict(m) => root match {
         case JObject(xs) => Map(xs.map(x => (x.name, build(x.value, m))): _*)
         case x => fail("Expected object but got " + x)
+      }
+
+      case _ => {
+        fail("Unexpected mapping type: " + mapping)
       }
     }
 

--- a/core/json/src/main/scala/net/liftweb/json/Extraction.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Extraction.scala
@@ -55,19 +55,6 @@ object Extraction {
       def typeArguments: List[TypeExtractor[_]] = mf.typeArguments.map(arg => fromManifest(arg))
     }
     
-    /** Lower priority fallback implementation using ClassTag when Manifest is not available.
-     *  This provides only basic runtime class information without generics.
-     */
-    object LowPriority {
-      implicit def fromClassTag[A](implicit ct: ClassTag[A]): TypeExtractor[A] = new TypeExtractor[A] {
-        def runtimeClass: Class[_] = ct.runtimeClass
-        def typeArguments: List[TypeExtractor[_]] = Nil // ClassTag limitation
-      }
-    }
-    
-    // Import the low priority implicits
-    import LowPriority._
-    
     /** Future Scala 3 macro-based implementation.
      *  This would replace the Manifest-based approach in Scala 3.
      *  

--- a/core/json/src/main/scala/net/liftweb/json/FieldSerializer.scala
+++ b/core/json/src/main/scala/net/liftweb/json/FieldSerializer.scala
@@ -17,8 +17,6 @@
 package net.liftweb
 package json
 
-import scala.reflect.ClassTag
-
 /**
  * Serializer which serializes all fields of a class too.
  *
@@ -32,7 +30,7 @@ import scala.reflect.ClassTag
  * )
  * </pre>
  */
-case class FieldSerializer[A: ClassTag](
+case class FieldSerializer[A: Extraction.TypeExtractor](
   serializer:   PartialFunction[(String, Any), Option[(String, Any)]] = Map(),
   deserializer: PartialFunction[JField, JField] = Map()
 )

--- a/core/json/src/main/scala/net/liftweb/json/FieldSerializer.scala
+++ b/core/json/src/main/scala/net/liftweb/json/FieldSerializer.scala
@@ -17,6 +17,8 @@
 package net.liftweb
 package json
 
+import scala.reflect.ClassTag
+
 /**
  * Serializer which serializes all fields of a class too.
  *
@@ -30,7 +32,7 @@ package json
  * )
  * </pre>
  */
-case class FieldSerializer[A: Manifest](
+case class FieldSerializer[A: ClassTag](
   serializer:   PartialFunction[(String, Any), Option[(String, Any)]] = Map(),
   deserializer: PartialFunction[JField, JField] = Map()
 )

--- a/core/json/src/main/scala/net/liftweb/json/Formats.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Formats.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.concurrent.{Map=>ConcurrentScalaMap}
 import scala.jdk.CollectionConverters._
+import scala.reflect.ClassTag
 
 /** Formats to use when converting JSON.
  * Formats are usually configured by using an implicit parameter:
@@ -86,7 +87,7 @@ trait Formats { self: Formats =>
   /**
    * Adds a field serializer for a given type to this formats.
    */
-  def + [A](newSerializer: FieldSerializer[A])(implicit mf: Manifest[A]): Formats = new Formats {
+  def + [A](newSerializer: FieldSerializer[A])(implicit ct: ClassTag[A]): Formats = new Formats {
     val dateFormat = Formats.this.dateFormat
     override val typeHintFieldName = self.typeHintFieldName
     override val parameterNameReader = self.parameterNameReader
@@ -95,7 +96,7 @@ trait Formats { self: Formats =>
     // The type inferencer infers an existential type below if we use
     // value :: list instead of list.::(value), and we get a feature
     // warning.
-    override val fieldSerializers: List[(Class[_], FieldSerializer[_])] = self.fieldSerializers.::((mf.runtimeClass: Class[_], newSerializer))
+    override val fieldSerializers: List[(Class[_], FieldSerializer[_])] = self.fieldSerializers.::((ct.runtimeClass: Class[_], newSerializer))
   }
 
   private[json] def fieldSerializer(clazz: Class[_]): Option[FieldSerializer[_]] = {
@@ -293,10 +294,10 @@ private[json] class ThreadLocal[A](init: => A) extends java.lang.ThreadLocal[A] 
   def apply() = get
 }
 
-class CustomSerializer[A: Manifest](
+class CustomSerializer[A: ClassTag](
   ser: Formats => (PartialFunction[JValue, A], PartialFunction[Any, JValue])) extends Serializer[A] {
 
-  val Class = implicitly[Manifest[A]].runtimeClass
+  val Class = implicitly[ClassTag[A]].runtimeClass
 
   def deserialize(implicit format: Formats) = {
     case (TypeInfo(Class, _), json) =>

--- a/core/json/src/main/scala/net/liftweb/json/Formats.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Formats.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.concurrent.{Map=>ConcurrentScalaMap}
 import scala.jdk.CollectionConverters._
-import scala.reflect.ClassTag
 
 /** Formats to use when converting JSON.
  * Formats are usually configured by using an implicit parameter:
@@ -87,7 +86,7 @@ trait Formats { self: Formats =>
   /**
    * Adds a field serializer for a given type to this formats.
    */
-  def + [A](newSerializer: FieldSerializer[A])(implicit ct: ClassTag[A]): Formats = new Formats {
+  def + [A](newSerializer: FieldSerializer[A])(implicit te: Extraction.TypeExtractor[A]): Formats = new Formats {
     val dateFormat = Formats.this.dateFormat
     override val typeHintFieldName = self.typeHintFieldName
     override val parameterNameReader = self.parameterNameReader
@@ -96,7 +95,7 @@ trait Formats { self: Formats =>
     // The type inferencer infers an existential type below if we use
     // value :: list instead of list.::(value), and we get a feature
     // warning.
-    override val fieldSerializers: List[(Class[_], FieldSerializer[_])] = self.fieldSerializers.::((ct.runtimeClass: Class[_], newSerializer))
+    override val fieldSerializers: List[(Class[_], FieldSerializer[_])] = self.fieldSerializers.::((te.runtimeClass: Class[_], newSerializer))
   }
 
   private[json] def fieldSerializer(clazz: Class[_]): Option[FieldSerializer[_]] = {
@@ -294,10 +293,10 @@ private[json] class ThreadLocal[A](init: => A) extends java.lang.ThreadLocal[A] 
   def apply() = get
 }
 
-class CustomSerializer[A: ClassTag](
+class CustomSerializer[A: Extraction.TypeExtractor](
   ser: Formats => (PartialFunction[JValue, A], PartialFunction[Any, JValue])) extends Serializer[A] {
 
-  val Class = implicitly[ClassTag[A]].runtimeClass
+  val Class = implicitly[Extraction.TypeExtractor[A]].runtimeClass
 
   def deserialize(implicit format: Formats) = {
     case (TypeInfo(Class, _), json) =>

--- a/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
+++ b/core/json/src/main/scala/net/liftweb/json/JsonAST.scala
@@ -702,8 +702,8 @@ object JsonAST {
      * res0: Person("joe")
      * }}}
      */
-    def extract[A](implicit formats: Formats, mf: scala.reflect.Manifest[A]): A =
-      Extraction.extract(this)(formats, mf)
+    def extract[A](implicit formats: Formats, te: Extraction.TypeExtractor[A]): A =
+      Extraction.extract(this)(formats, te)
 
     /**
      * Optionally extract a value into a concrete Scala instance from its `JValue` representation.
@@ -730,8 +730,8 @@ object JsonAST {
      * res1: Option[Person] = Some(Person(joe))
      * }}}
      */
-    def extractOpt[A](implicit formats: Formats, mf: scala.reflect.Manifest[A]): Option[A] =
-      Extraction.extractOpt(this)(formats, mf)
+    def extractOpt[A](implicit formats: Formats, te: Extraction.TypeExtractor[A]): Option[A] =
+      Extraction.extractOpt(this)(formats, te)
 
     /**
      * Attempt to extract a concrete Scala instance of type `A` from this `JValue` and, on failing to do so, return
@@ -751,8 +751,8 @@ object JsonAST {
      * res0: Person("joe")
      * }}}
      */
-    def extractOrElse[A](default: => A)(implicit formats: Formats, mf: scala.reflect.Manifest[A]): A =
-      Extraction.extractOpt(this)(formats, mf).getOrElse(default)
+    def extractOrElse[A](default: => A)(implicit formats: Formats, te: Extraction.TypeExtractor[A]): A =
+      Extraction.extractOpt(this)(formats, te).getOrElse(default)
 
     def toOpt: Option[JValue] = this match {
       case JNothing => None

--- a/core/json/src/main/scala/net/liftweb/json/Serialization.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Serialization.scala
@@ -17,7 +17,7 @@
 package net.liftweb
 package json
 
-import scala.reflect.Manifest
+import scala.reflect.ClassTag
 
 /** Functions to serialize and deserialize a case class.
  * Custom serializer can be inserted if a class is not a case class.
@@ -58,13 +58,13 @@ object Serialization {
 
   /** Deserialize from a String.
    */
-  def read[A](json: String)(implicit formats: Formats, mf: Manifest[A]): A =
-    parse(json).extract(formats, mf)
+  def read[A](json: String)(implicit formats: Formats, te: Extraction.TypeExtractor[A]): A =
+    parse(json).extract(formats, te)
 
   /** Deserialize from a Reader.
    */
-  def read[A](in: Reader)(implicit formats: Formats, mf: Manifest[A]): A =
-    JsonParser.parse(in).extract(formats, mf)
+  def read[A](in: Reader)(implicit formats: Formats, te: Extraction.TypeExtractor[A]): A =
+    JsonParser.parse(in).extract(formats, te)
 
   /** Create Serialization formats with given type hints.
    * <p>

--- a/core/json/src/main/scala/net/liftweb/json/Serialization.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Serialization.scala
@@ -17,7 +17,6 @@
 package net.liftweb
 package json
 
-import scala.reflect.ClassTag
 
 /** Functions to serialize and deserialize a case class.
  * Custom serializer can be inserted if a class is not a case class.

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -36,8 +36,8 @@ import json._
 import org.mozilla.javascript.Scriptable
 import org.mozilla.javascript.UniqueTag
 import json.JsonAST.{JString, JValue}
+import json.Extraction.TypeExtractor.fromManifest
 import scala.xml.Group
-
 
 object LiftSession {
 
@@ -2780,7 +2780,10 @@ class LiftSession(private[http] val _contextPath: String, val underlyingId: Stri
               func <- map.get(name)
               payload = in \ "payload"
               reified <- if (func.manifest == jvmanifest) Some(payload) else {
-                try {Some(payload.extract(defaultFormats, func.manifest))} catch {
+                // n.b. this should have applied the implicit conversion from the
+                // compiler, but it doesn't want to for some unknown reason.
+                // For now, I'm manually invoking fromManifest.
+                try {Some(payload.extract(defaultFormats, fromManifest(func.manifest)))} catch {
                   case e: Exception =>
                     logger.error("Failed to extract "+payload+" as "+func.manifest, e)
                     ca ! FailMsg(guid, "Failed to extract payload as "+func.manifest+" exception "+ e.getMessage)


### PR DESCRIPTION
Provide for a `TypeExtractor` interface to assist with the migration of lift-json to Scala 3. In particular:

* Wrap the existing `Manifest` driven implementation in the `TypeExtractor`
* Provide implicit conversions for `Manifest=>TypeExtractor` that work in most cases.
  * I observed one instance where the compiler didn't seem to derive this as I expected. This could be representative of a wider problem using the conversion that ultimately annoys folks.

I took this approach after evaluating how json4s has decided to support Scala 3. By my understanding this was done with the approach of augmenting reflection capabilities. I also realized there's an open bug json4s/json4s#431 (opened by me!) which doesn't seem to have been fixed yet so I'm not eager to try to dig into their reflection implementation to try and fix that and then migrate over.

Going to consider this a breaking change, even though we're going to make the attempt to smooth it over with an implicit conversion.