### PR TITLE
Allow arbitrary tagging of comet elements.

### DIFF
--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Comet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Comet.scala
@@ -87,10 +87,10 @@ object Comet extends DispatchSnippet with LazyLoggable {
              
              (c.!?(c.cometRenderTimeout, AskRender)) match {
                case Full(AnswerRender(response, _, when, _)) if c.hasOuter =>
-                 buildSpan(Empty, c.buildSpan(when, response.inSpan) ++ response.outSpan, c, c.uniqueId+"_outer")
+                 LiftRules.cometElementTagger.vend(buildSpan(Empty, c.buildSpan(when, response.inSpan) ++ response.outSpan, c, c.uniqueId+"_outer"))
                
                case Full(AnswerRender(response, _, when, _)) =>
-                 c.buildSpan(when, response.inSpan)
+                 LiftRules.cometElementTagger.vend(c.buildSpan(when, response.inSpan))
                
                case e =>
                  if (c.cometRenderTimeoutHandler().isDefined) {

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftRules.scala
@@ -1561,6 +1561,21 @@ class LiftRules() extends Factory with FormVendor with LazyLoggable {
     )
 
   /**
+   * A transform used to tag spans generated to contain comets. By
+   * default, adds a data-lift-comet attribute set to "true". Note that
+   * if you change this behavior, comet rehydration will not work.
+   */
+  val cometElementTagger: FactoryMaker[(NodeSeq)=>NodeSeq] =
+    new FactoryMaker({
+      ns:NodeSeq => ns match {
+        case elem:Elem =>
+          elem % new UnprefixedAttribute("data-lift-comet", Text("true"), Null)
+        case other =>
+          other
+      }
+    }) {}
+
+  /**
    * Holds the last update time of the Ajax request. Based on this server mayreturn HTTP 304 status
    * indicating the client to used the cached information.
    */


### PR DESCRIPTION
By default, tags them with a data-lift-comet="true" attribute.

**[Mailing List](https://groups.google.com/forum/#!forum/liftweb) thread**:
REPLACE THIS WITH ML LINK

Provide a description of the changes this pull request makes including the
background motivation for this change.
